### PR TITLE
ZMS-1794 adjust form to display minutes instead of slotcount

### DIFF
--- a/zmsadmin/src/Zmsadmin/AppointmentForm.php
+++ b/zmsadmin/src/Zmsadmin/AppointmentForm.php
@@ -50,6 +50,8 @@ class AppointmentForm extends BaseController
             ? Helper\AppointmentFormHelper::readFreeProcessList($request, $workstation)
             : null;
 
+        $provider = $selectedScope->getProvider();
+
         return \BO\Slim\Render::withHtml(
             $response,
             'block/appointment/form.twig',
@@ -65,7 +67,8 @@ class AppointmentForm extends BaseController
                 'selectedDate' => ($selectedDate) ? $selectedDate : \App::$now->format('Y-m-d'),
                 'selectedTime' => $selectedTime,
                 'freeProcessList' => $freeProcessList,
-                'requestList' => $requestList
+                'requestList' => $requestList,
+                'slotTimeInMinutes' => $provider->getSlotTimeInMinutes(),
             )
         );
     }

--- a/zmsadmin/src/Zmsadmin/Helper/AppointmentFormHelper.php
+++ b/zmsadmin/src/Zmsadmin/Helper/AppointmentFormHelper.php
@@ -76,7 +76,7 @@ class AppointmentFormHelper
         if ($selectedScopeId) {
             $selectedScope = \App::$http
               ->readGetResult('/scope/'. $selectedScopeId .'/', [
-                  'resolveReferences' => 1,
+                  'resolveReferences' => 2,
                   'gql' => GraphDefaults::getScope()
                 ])
               ->getEntity();

--- a/zmsadmin/src/Zmsadmin/Helper/GraphDefaults.php
+++ b/zmsadmin/src/Zmsadmin/Helper/GraphDefaults.php
@@ -127,6 +127,7 @@ EOS;
         name 
         data { 
             payment 
+            slotTimeInMinutes
         }
     }
     queue

--- a/zmsadmin/templates/block/appointment/form.twig
+++ b/zmsadmin/templates/block/appointment/form.twig
@@ -54,10 +54,11 @@
                                 {% else %}
                                     {% set selected = "" %}
                                 {% endif %}
-                                {% set slotCountOptions = slotCountOptions|merge([{ "value": slotCount, "name": slotCount, "selected":selected}]) %}
+                                {% set duration = slotTimeInMinutes * slotCount %}
+                                {% set slotCountOptions = slotCountOptions|merge([{ "value": slotCount, "name": duration, "selected":selected}]) %}
                             {% endfor %}
                             {{ formgroup(
-                                {"label": "Slots"},
+                                {"label": "Termindauer in Minuten"},
                                 [{
                                     "type":"select",
                                     "parameter": {
@@ -297,8 +298,9 @@
                                     {% endif %}
 
                                     {% set requestName = request.name %}
+                                    {% set duration = slotTimeInMinutes * request.timeSlotCount %}
                                     {% if scope.preferences.appointment.multipleSlotsEnabled or selectedProcess.scope.preferences.appointment.multipleSlotsEnabled %}
-                                        {% set requestName = request.name ~ " (" ~ request.timeSlotCount ~ ")" %}
+                                        {% set requestName = request.name ~ " (" ~ duration ~ " min)" %}
                                     {% endif %}
                                     {% set requestsOptions = requestsOptions|merge([{ "value": request.id, "name": requestName, "class": "service-checkbox", "data": {'slots': request.timeSlotCount}, "selected": checked }]) %}
                                 {% endfor %}

--- a/zmsentities/src/Zmsentities/Provider.php
+++ b/zmsentities/src/Zmsentities/Provider.php
@@ -77,4 +77,9 @@ class Provider extends Schema\Entity
     {
         return $this->toProperty()->data->get();
     }
+
+    public function getSlotTimeInMinutes()
+    {
+        return $this->getAdditionalData()['slotTimeInMinutes'];
+    }
 }


### PR DESCRIPTION
This PR changes the display of the form "Terminvereinbarung Neu" in such a way that it displays the duration of an appointment, not the number of slots required.