### PR TITLE
Ticketprinterhash-id wird nicht angeziegt

### DIFF
--- a/zmsticketprinter/templates/block/ticketprinterhash.twig
+++ b/zmsticketprinter/templates/block/ticketprinterhash.twig
@@ -1,6 +1,6 @@
 {% block ticketprinterhash %}
 
-            <div class="ticketprinterhash noprint">
+            <div class="ticketprinterhash noprint" style="display: none">
                 Apparat-Id: {{ticketprinter.hash}}
             </div>
 


### PR DESCRIPTION

E-Kiosk "Apparat ID" entfernen