### PR TITLE
fix(ZMS-3256 ZMS-3257): Use BuergerID Instead of Wartenummer for Walk-In Citizens Without Scheduled Appointments

### DIFF
--- a/zmsadmin/custom_templates/block/process/called.twig
+++ b/zmsadmin/custom_templates/block/process/called.twig
@@ -11,7 +11,7 @@
                     Name
                 </dt>
                 <dd>
-                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.queue.number }})
+                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.id }})
                 </dd>
                 {% if process.requests %}
                 <dt>
@@ -63,7 +63,7 @@
             <h4>{% trans %}Zeit seit Kundenaufruf{% endtrans %}:</h4>
             <span id="clock" role="timer" class="clock" title="verstrichene Zeit seit dem Kundenaufruf" data-callTime={{ workstation.process.queue.callTime }} data-now={{ getNow()|date('U') }}></span>
             <h4>
-            Ist der Kunde "{% if  workstation.process.clients|first.familyName|length > 0 %}{{ workstation.process.clients|first.familyName }} {% endif %}(Wartenr. {{ workstation.process.queue.number }})" gekommen?
+            Ist der Kunde "{% if  workstation.process.clients|first.familyName|length > 0 %}{{ workstation.process.clients|first.familyName }} {% endif %}(Wartenr. {{ workstation.process.id }})" gekommen?
             </h4>
             <button type="button" class="button button--default button--fullwidth client-called_button-success" style="margin: 0.5em 0;">Ja, Kunde erschienen</button>
             <button type="button" class="button button--diamond button--fullwidth client-called_button-skip right" data-exclude="{{ exclude }}" style="margin: 0.5em 0;">Nein, nächster Kunde bitte</button>

--- a/zmsadmin/custom_templates/block/process/info.twig
+++ b/zmsadmin/custom_templates/block/process/info.twig
@@ -11,7 +11,7 @@
                     Name
                 </dt>
                 <dd>
-                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.queue.number }})
+                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.id }})
                 </dd>
                 <dt>
                     Anliegen

--- a/zmsadmin/custom_templates/block/queue/table.twig
+++ b/zmsadmin/custom_templates/block/queue/table.twig
@@ -119,16 +119,16 @@
 								<td>
 									{% if item.queue.status != "reserved" and source != 'counter' and (workstation.scope.id == item.scope.id or allowClusterWideCall) and isToday %}
 										<a title="{% trans %}Diesen Bürger aufrufen{% endtrans %}" href="{{ urlGet('workstation', {}, {'calledprocess': item.id}) }}" data-process="{{ item.id }}">
-											{{ item.queue.number }}
+											{{ item.id }}
 										</a>
 									{% else %}
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>
 									{% if item.clients|first.familyName %}
 										{{ item.clients|first.familyName }}{% else %}Wartenummer
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>{{ item.clients|first.telephone }}</td>
@@ -249,10 +249,10 @@
 									<td>
 										{% if item.queue.status != "reserved" and source != 'counter' and (workstation.scope.id == item.scope.id or allowClusterWideCall) and isToday %}
 											<a title="{% trans %}Diesen Bürger aufrufen{% endtrans %}" href="{{ urlGet('workstation', {}, {'calledprocess': item.id}) }}" data-process="{{ item.id }}">
-												{{ item.queue.number }}
+												{{ item.id }}
 											</a>
 										{% else %}
-											{{ item.queue.number }}
+											{{ item.id }}
 										{% endif %}
 									</td>
 									<td class="callnextclient">
@@ -352,7 +352,7 @@
 									</td>
 									{% if item.queue.status != "reserved" and item.queue.status != "preconfirmed" %}
 										<td class="center">
-											<a data-id="{{ item.id }}" data-name="{{ item.queue.withAppointment ? item.clients|first.familyName|raw : ('Wartenummer ' ~ item.queue.number) }}" href="#" class="icon process-delete" title="Löschen">
+											<a data-id="{{ item.id }}" data-name="{{ item.queue.withAppointment ? item.clients|first.familyName|raw : ('Wartenummer ' ~ item.id) }}" href="#" class="icon process-delete" title="Löschen">
 												<i class="far fa-trash-alt" aria-hidden="true"></i>
 												<span class="aural">Löschen</span>
 											</a>
@@ -429,16 +429,16 @@
 								<td>
 									{% if item.queue.status != "reserved" and source != 'counter' and (workstation.scope.id == item.scope.id or allowClusterWideCall) and isToday %}
 										<a title="{% trans %}Diesen Bürger aufrufen{% endtrans %}" href="{{ urlGet('workstation', {}, {'calledprocess': item.id}) }}" data-process="{{ item.id }}">
-											{{ item.queue.number }}
+											{{ item.id }}
 										</a>
 									{% else %}
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>
 									{% if item.clients|first.familyName %}
 										{{ item.clients|first.familyName }}{% else %}Wartenummer
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>{{ item.clients|first.telephone }}</td>

--- a/zmsadmin/custom_templates/block/scope/appointmentsByDay.twig
+++ b/zmsadmin/custom_templates/block/scope/appointmentsByDay.twig
@@ -40,7 +40,7 @@
                     <tr>
                         <td>{{ clusterEnabled ? item.scope.shortName : loop.index }}</td>
                         <td>{{ item.queue.arrivalTime|date('H:i') }}</td>
-                        <td>{{ item.queue.number }}</td>
+                        <td>{{ item.id }}</td>
                         <td>{{ item.clients.0.familyName }}</td>
                         <td>{{ item.clients.0.telephone }}</td>
                         <td>{{ item.clients.0.email }}</td>

--- a/zmsadmin/templates/block/pickup/called.twig
+++ b/zmsadmin/templates/block/pickup/called.twig
@@ -8,10 +8,10 @@
             <p>
             {% if workstation.process.clients|first.familyName %}
                 Ist der Abholer<br />
-                <strong>"{{ workstation.process.clients|first.familyName }} (Wartenummer {{ workstation.process.queue.number }})"</strong><br/>
+                <strong>"{{ workstation.process.clients|first.familyName }} (Wartenummer {{ workstation.process.id }})"</strong><br/>
                 gekommen?
             {% else %}
-                Ist der Abholer mit der Wartenummer <strong>{{ workstation.process.queue.number }}</strong> gekommen?
+                Ist der Abholer mit der Wartenummer <strong>{{ workstation.process.id }}</strong> gekommen?
             {% endif %}
             </p>
             <div class="form-actions left">

--- a/zmsadmin/templates/block/pickup/table-handheld.twig
+++ b/zmsadmin/templates/block/pickup/table-handheld.twig
@@ -26,7 +26,7 @@
                         <td>
                             <a href="#" data-id="{{ item.id }}" data-name="{{ item.clients|first.familyName }}" class="button button-submit process-pickup" title="aufrufen">aufrufen</a>
                         </td>
-                        <td>{% if item.queue.withAppointment %}{{ item.id }}{% else %}{{ item.queue.number }}{% endif %}</td>
+                        <td>{% if item.queue.withAppointment %}{{ item.id }}{% else %}{{ item.id }}{% endif %}</td>
                         <td>{{ item.clients|first.familyName }}</td>
                     </tr>
                     {% endfor %}

--- a/zmsadmin/templates/block/pickup/table.twig
+++ b/zmsadmin/templates/block/pickup/table.twig
@@ -50,7 +50,7 @@
                     </td>
                     {% endif %}
                     <td>{{ item.appointments|first.date|date("d.m.Y") }}</td>
-                    <td>{% if item.queue.withAppointment %}{{ item.id }}{% else %}{{ item.queue.number }}{% endif %}</td>
+                    <td>{% if item.queue.withAppointment %}{{ item.id }}{% else %}{{ item.id }}{% endif %}</td>
                     <td>
                         {{ item.clients|first.familyName }}
                         {% if item.queue.callCount > 0 %}

--- a/zmsadmin/templates/block/process/called.twig
+++ b/zmsadmin/templates/block/process/called.twig
@@ -11,7 +11,7 @@
                     Name
                 </dt>
                 <dd>
-                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.queue.number }})
+                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.id }})
                 </dd>
                 {% if process.requests %}
                 <dt>
@@ -63,7 +63,7 @@
             <h4>{% trans %}Zeit seit Kundenaufruf{% endtrans %}:</h4>
             <span id="clock" role="timer" class="clock" title="verstrichene Zeit seit dem Kundenaufruf" data-callTime={{ workstation.process.queue.callTime }} data-now={{ getNow()|date('U') }}></span>
             <h4>
-            Ist der Kunde "{% if  workstation.process.clients|first.familyName|length > 0 %}{{ workstation.process.clients|first.familyName }} {% endif %}(Wartenr. {{ workstation.process.queue.number }})" gekommen?
+            Ist der Kunde "{% if  workstation.process.clients|first.familyName|length > 0 %}{{ workstation.process.clients|first.familyName }} {% endif %}(Wartenr. {{ workstation.process.id }})" gekommen?
             </h4>
             <button type="button" class="button button--default button--fullwidth client-called_button-success" style="margin: 0.5em 0;">Ja, Kunde erschienen</button>
             <button type="button" class="button button--diamond button--fullwidth client-called_button-skip right" data-exclude="{{ exclude }}" style="margin: 0.5em 0;">Nein, nächster Kunde bitte</button>

--- a/zmsadmin/templates/block/process/info.twig
+++ b/zmsadmin/templates/block/process/info.twig
@@ -11,7 +11,7 @@
                     Name
                 </dt>
                 <dd>
-                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.queue.number }})
+                    {{ workstation.process.clients|first.familyName }} <br>(Wartenr. {{ workstation.process.id }})
                 </dd>
                 <dt>
                     Anliegen

--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -119,16 +119,16 @@
 								<td>
 									{% if item.queue.status != "reserved" and source != 'counter' and (workstation.scope.id == item.scope.id or allowClusterWideCall) and isToday %}
 										<a title="{% trans %}Diesen Bürger aufrufen{% endtrans %}" href="{{ urlGet('workstation', {}, {'calledprocess': item.id}) }}" data-process="{{ item.id }}">
-											{{ item.queue.number }}
+											{{ item.id }}
 										</a>
 									{% else %}
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>
 									{% if item.clients|first.familyName %}
 										{{ item.clients|first.familyName }}{% else %}Wartenummer
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>{{ item.clients|first.telephone }}</td>
@@ -249,10 +249,10 @@
 									<td>
 										{% if item.queue.status != "reserved" and source != 'counter' and (workstation.scope.id == item.scope.id or allowClusterWideCall) and isToday %}
 											<a title="{% trans %}Diesen Bürger aufrufen{% endtrans %}" href="{{ urlGet('workstation', {}, {'calledprocess': item.id}) }}" data-process="{{ item.id }}">
-												{{ item.queue.number }}
+												{{ item.id }}
 											</a>
 										{% else %}
-											{{ item.queue.number }}
+											{{ item.id }}
 										{% endif %}
 									</td>
 									<td class="callnextclient">
@@ -352,7 +352,7 @@
 									</td>
 									{% if item.queue.status != "reserved" and item.queue.status != "preconfirmed" %}
 										<td class="center">
-											<a data-id="{{ item.id }}" data-name="{{ item.queue.withAppointment ? item.clients|first.familyName|raw : ('Wartenummer ' ~ item.queue.number) }}" href="#" class="icon process-delete" title="Löschen">
+											<a data-id="{{ item.id }}" data-name="{{ item.queue.withAppointment ? item.clients|first.familyName|raw : ('Wartenummer ' ~ item.id) }}" href="#" class="icon process-delete" title="Löschen">
 												<i class="far fa-trash-alt" aria-hidden="true"></i>
 												<span class="aural">Löschen</span>
 											</a>
@@ -429,16 +429,16 @@
 								<td>
 									{% if item.queue.status != "reserved" and source != 'counter' and (workstation.scope.id == item.scope.id or allowClusterWideCall) and isToday %}
 										<a title="{% trans %}Diesen Bürger aufrufen{% endtrans %}" href="{{ urlGet('workstation', {}, {'calledprocess': item.id}) }}" data-process="{{ item.id }}">
-											{{ item.queue.number }}
+											{{ item.id }}
 										</a>
 									{% else %}
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>
 									{% if item.clients|first.familyName %}
 										{{ item.clients|first.familyName }}{% else %}Wartenummer
-										{{ item.queue.number }}
+										{{ item.id }}
 									{% endif %}
 								</td>
 								<td>{{ item.clients|first.telephone }}</td>

--- a/zmsadmin/templates/block/scope/appointmentsByDay.twig
+++ b/zmsadmin/templates/block/scope/appointmentsByDay.twig
@@ -40,7 +40,7 @@
                     <tr>
                         <td>{{ clusterEnabled ? item.scope.shortName : loop.index }}</td>
                         <td>{{ item.queue.arrivalTime|date('H:i') }}</td>
-                        <td>{{ item.queue.number }}</td>
+                        <td>{{ item.id }}</td>
                         <td>{{ item.clients.0.familyName }}</td>
                         <td>{{ item.clients.0.telephone }}</td>
                         <td>{{ item.clients.0.email }}</td>

--- a/zmsadmin/templates/exception/bo/zmsapi/exception/workstation/workstationhasassignedprocess.twig
+++ b/zmsadmin/templates/exception/bo/zmsapi/exception/workstation/workstationhasassignedprocess.twig
@@ -17,7 +17,7 @@
         </div>
         {% else %}
         <p>
-            Ist der Kunde{% if workstation.process.clients|first.familyName %} <strong>"{{ workstation.process.clients|first.familyName }}{% endif %} (Wartenr. {{ workstation.process.queue.number }})"</strong> gekommen?
+            Ist der Kunde{% if workstation.process.clients|first.familyName %} <strong>"{{ workstation.process.clients|first.familyName }}{% endif %} (Wartenr. {{ workstation.process.id }})"</strong> gekommen?
         </p>
         <div class="form-actions left">
             <a class="btn" data-callback="onFinishProcess" data-name="{{ workstation.process.clients|first.familyName }}" data-id="{{ workstation.process.id }}">Ja, bitte aus der Liste entfernen ✓</a>

--- a/zmsadmin/tests/Zmsadmin/PickupCallTest.php
+++ b/zmsadmin/tests/Zmsadmin/PickupCallTest.php
@@ -64,7 +64,7 @@ class PickupCallTest extends Base
         );
         $response = $this->render(['id' => 6], $this->parameters, []);
         $this->assertStringContainsString('Aufruf eines Abholers', (string)$response->getBody());
-        $this->assertStringContainsString('(Wartenummer 6)', (string)$response->getBody());
+        $this->assertStringContainsString('(Wartenummer 100632)', (string)$response->getBody());
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -93,7 +93,7 @@ class PickupCallTest extends Base
         $response = $this->render(['id' => 6], $this->parameters, []);
         $this->assertStringContainsString('Aufruf eines Abholers', (string)$response->getBody());
         $this->assertStringContainsString(
-            'Ist der Abholer mit der Wartenummer <strong>1</strong> gekommen?',
+            'Ist der Abholer mit der Wartenummer <strong>100632</strong> gekommen?',
             (string)$response->getBody()
         );
         $this->assertEquals(200, $response->getStatusCode());

--- a/zmsdb/src/Zmsdb/Query/Process.php
+++ b/zmsdb/src/Zmsdb/Query/Process.php
@@ -222,12 +222,7 @@ class Process extends Base implements MappingInterface
             'queue__callCount' => 'process.AnzahlAufrufe',
             'queue__callTime' => 'process.aufrufzeit',
             'queue__lastCallTime' => 'process.Timestamp',
-            'queue__number' => self::expression(
-                'IF(`process`.`wartenummer`,
-                    `process`.`wartenummer`,
-                    `process`.`BuergerID`
-                )'
-            ),
+            'queue__number' => "process.BuergerID",
             'queue__destination' => self::expression(
                 'IF(`process`.`AbholortID`,
                     `processscope`.`ausgabeschaltername`,

--- a/zmsdb/src/Zmsdb/Query/Queue.php
+++ b/zmsdb/src/Zmsdb/Query/Queue.php
@@ -41,7 +41,7 @@ class Queue extends Process implements MappingInterface
             END'
         );
         return [
-            //'id' => 'process.BuergerID',
+            'id' => 'process.BuergerID',
             'status' => $status_expression,
             'arrivalTime' => self::expression(
                 'CONCAT(
@@ -65,12 +65,7 @@ class Queue extends Process implements MappingInterface
                     `process`.`Timestamp`
                 )'
             ),
-            'number' => self::expression(
-                'IF(`process`.`wartenummer`,
-                    `process`.`wartenummer`,
-                    `process`.`BuergerID`
-)'
-            ),
+            'number' =>  'process.BuergerID',
             'destination' => self::expression(
                 'IF(`process`.`AbholortID`,
                     `processscope`.`ausgabeschaltername`,

--- a/zmsdb/src/Zmsdb/Query/Queue.php
+++ b/zmsdb/src/Zmsdb/Query/Queue.php
@@ -41,7 +41,7 @@ class Queue extends Process implements MappingInterface
             END'
         );
         return [
-            'id' => 'process.BuergerID',
+            //'id' => 'process.BuergerID',
             'status' => $status_expression,
             'arrivalTime' => self::expression(
                 'CONCAT(

--- a/zmsdb/tests/Zmsdb/ProcessTest.php
+++ b/zmsdb/tests/Zmsdb/ProcessTest.php
@@ -31,9 +31,8 @@ class ProcessTest extends Base
         $scope = (new \BO\Zmsdb\Scope())->readEntity(141, 0, true);
         $process = $query->writeNewFromTicketprinter($scope, $now);
         $process = $query->readByQueueNumberAndScope($process->queue['number'], $scope->id);
-        $this->assertEquals(101353, $process->queue['number']);
+        $this->assertEquals($process->getId(), $process->queue['number']);
         $process = $query->readByQueueNumberAndScope($process->getId(), $scope->id);
-        $this->assertTrue(100000 < $process->getId());
     }
 
     public function testReadByWorkstation()
@@ -357,7 +356,7 @@ class ProcessTest extends Base
         $input = $this->getTestProcessEntity();
         $process = $query->writeNewFromAdmin($input, $now);
         $this->assertEntity("\\BO\\Zmsentities\\Process", $process);
-        $this->assertEquals(100693, $process->queue->number);
+        $this->assertEquals($process->getId(), $process->queue->number);
     }
 
     public function testProcessListByScopeAndStatus()

--- a/zmsdb/tests/Zmsdb/ProcessTest.php
+++ b/zmsdb/tests/Zmsdb/ProcessTest.php
@@ -31,7 +31,7 @@ class ProcessTest extends Base
         $scope = (new \BO\Zmsdb\Scope())->readEntity(141, 0, true);
         $process = $query->writeNewFromTicketprinter($scope, $now);
         $process = $query->readByQueueNumberAndScope($process->queue['number'], $scope->id);
-        $this->assertEquals(1, $process->queue['number']);
+        $this->assertEquals(101353, $process->queue['number']);
         $process = $query->readByQueueNumberAndScope($process->getId(), $scope->id);
         $this->assertTrue(100000 < $process->getId());
     }
@@ -357,7 +357,7 @@ class ProcessTest extends Base
         $input = $this->getTestProcessEntity();
         $process = $query->writeNewFromAdmin($input, $now);
         $this->assertEntity("\\BO\\Zmsentities\\Process", $process);
-        $this->assertEquals(1000, $process->queue->number);
+        $this->assertEquals(100693, $process->queue->number);
     }
 
     public function testProcessListByScopeAndStatus()

--- a/zmsticketprinter/templates/block/content/print.twig
+++ b/zmsticketprinter/templates/block/content/print.twig
@@ -1,7 +1,7 @@
 {% block print %}
 <div class="print" media="print">
 	<span class="printausgabe msg_ihre_wartenummer">Ihre Wartenummer:</span>
-    <div class="printausgabe msg_ihre_nummernanzeige nummernanzeige">{{ process.queue.number }}</div>
+    <div class="printausgabe msg_ihre_nummernanzeige nummernanzeige">{{ process.id }}</div>
     <span class="printausgabe msg_stdname">
     	<span class="printausgabe msg_ihre_wartenummer">
     		{{ process.scope.contact.name }}<br>

--- a/zmsticketprinter/templates/page/process.twig
+++ b/zmsticketprinter/templates/page/process.twig
@@ -19,7 +19,7 @@
 		    {% trans %}Ihre Wartenummer lautet{% endtrans %}: <br>
 		</span>
 			<div class="nummernanzeige">
-				{{ process.queue.number }}
+				{{ process.id }}
 			</div>
 			<span>
         	{% if waitingClients >= 1 %}
@@ -61,7 +61,7 @@
         </span>
 
 				<form action="{{ urlGet('Notification', {}, {}) }}" method="post" id="postNotification">
-					{{ hiddenfield({ "name": "waitingNumber", "value": process.queue.number }) }}
+					{{ hiddenfield({ "name": "waitingNumber", "value": process.id }) }}
 					{{ hiddenfield({ "name": "scopeId", "value": process.scope.id }) }}
 					{{ hiddenfield({ "name": "organisationId", "value": organisation.id }) }}
 				</form>


### PR DESCRIPTION
**Description**

Use BuergerID Instead of Wartenummer for Walk-In Citizens Without Scheduled Appointments.

**Reference**

Issues #ZMS-3256 ZMS-3257
