### PR TITLE
chore(ZMS-3237): Switch php base image from Berlin to Munich

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -7,7 +7,7 @@ jobs:
   module-test:
     runs-on: ubuntu-latest
     container:
-      image: "registry.gitlab.com/eappointment/php-base:${{ matrix.php_version }}-dev"
+      image: "ghcr.io/it-at-m/eappointment-php-base:${{ matrix.php_version }}-dev"
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@main
@@ -44,7 +44,7 @@ jobs:
   zmsapi-test:
     runs-on: ubuntu-latest
     container:
-      image: "registry.gitlab.com/eappointment/php-base:8.0-dev"
+      image: "ghcr.io/it-at-m/eappointment-php-base:8.0-dev"
     services:
       mariadb:
         image: mariadb:10.6
@@ -96,7 +96,7 @@ jobs:
   zmsdb-test:
     runs-on: ubuntu-latest
     container:
-      image: "registry.gitlab.com/eappointment/php-base:8.0-dev"
+      image: "ghcr.io/it-at-m/eappointment-php-base:8.0-dev"
     services:
       mariadb:
         image: mariadb:10.6

--- a/.resources/Containerfile
+++ b/.resources/Containerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 RUN useradd --shell /bin/bash --create-home build
 COPY --chown=build:build . /build
 ARG MODULE
@@ -8,8 +8,7 @@ USER build:build
 RUN make live
 
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 RUN docker-apt-clean-install libfcgi-bin
 ARG MODULE
 COPY --from=build --chown=0:0 /build/${MODULE} /var/www/html
- 

--- a/zmsadmin/.gitlab-ci.yml
+++ b/zmsadmin/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
     remote: https://gitlab.com/eappointment/php-base/-/raw/main/template-php-ci.yml
 
-test-php-73:
+test-php-80:
     variables:
       PHP_VERSION: 8.0
     image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev

--- a/zmsadmin/.gitlab-ci.yml
+++ b/zmsadmin/.gitlab-ci.yml
@@ -4,7 +4,7 @@ include:
 test-php-73:
     variables:
       PHP_VERSION: 7.3
-    image: registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev
+    image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev
     script:
         - $CLI_COMPOSER
         - $CLI_PHPCS

--- a/zmsadmin/.gitlab-ci.yml
+++ b/zmsadmin/.gitlab-ci.yml
@@ -19,7 +19,7 @@ test-php-73:
         - npm install --legacy-peer-deps
         - make css
     variables:
-        PHP_VERSION: "7.3"
+        PHP_VERSION: "8.0"
     only:
         changes:
             - .gitlab-ci.yml

--- a/zmsadmin/.gitlab-ci.yml
+++ b/zmsadmin/.gitlab-ci.yml
@@ -3,7 +3,7 @@ include:
 
 test-php-73:
     variables:
-      PHP_VERSION: 7.3
+      PHP_VERSION: 8.0
     image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev
     script:
         - $CLI_COMPOSER

--- a/zmsadmin/Dockerfile
+++ b/zmsadmin/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 COPY --chown=1000:1000 . /build
 WORKDIR /build
 USER 1000:1000
 RUN make live
 
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 COPY --from=build --chown=0:0 /build /var/www/html

--- a/zmsapi/.gitlab-ci.yml
+++ b/zmsapi/.gitlab-ci.yml
@@ -25,7 +25,7 @@ include:
             junit: public/_tests/junit.xml
 
 
-test-php-73:
+test-php-80:
     extends: .test-php-custom
     allow_failure: true
     services:

--- a/zmsapi/.gitlab-ci.yml
+++ b/zmsapi/.gitlab-ci.yml
@@ -38,7 +38,7 @@ test-php-73:
         - ln -s vendor/eappointment/zmsdb/tests/Zmsdb/fixtures data
         - vendor/bin/importTestData --commit
     variables:
-      PHP_VERSION: "7.3"
+      PHP_VERSION: "8.0"
       MYSQL_PORT: "tcp://mysql:3306"
       MYSQL_DATABASE: zmsbo
       MYSQL_ROOT_PASSWORD: zmsapi
@@ -73,7 +73,7 @@ outdated:
 apidoc:
     stage: .pre
     variables:
-        PHP_VERSION: "7.3"
+        PHP_VERSION: "8.0"
     image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev
     before_script:
         - $CLI_COMPOSER --no-scripts

--- a/zmsapi/.gitlab-ci.yml
+++ b/zmsapi/.gitlab-ci.yml
@@ -4,7 +4,7 @@ include:
 .test-php-custom:
     stage: test
     variables:
-      PHP_VERSION: 7.3
+      PHP_VERSION: 8.0
     image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev
     cache:
         key: "zmsbase"

--- a/zmsapi/.gitlab-ci.yml
+++ b/zmsapi/.gitlab-ci.yml
@@ -5,7 +5,7 @@ include:
     stage: test
     variables:
       PHP_VERSION: 7.3
-    image: registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev
+    image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev
     cache:
         key: "zmsbase"
         paths:
@@ -74,7 +74,7 @@ apidoc:
     stage: .pre
     variables:
         PHP_VERSION: "7.3"
-    image: registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev
+    image: ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev
     before_script:
         - $CLI_COMPOSER --no-scripts
         - bin/configure

--- a/zmsapi/Dockerfile
+++ b/zmsapi/Dockerfile
@@ -1,10 +1,10 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 COPY --from=build --chown=0:0 /var/www/html /var/www/html
 RUN chmod -R 1777 /var/www/html/data

--- a/zmscalldisplay/.gitlab-ci.yml
+++ b/zmscalldisplay/.gitlab-ci.yml
@@ -5,7 +5,7 @@ test-php-73:
     extends: .test-php
     allow_failure: false
     variables:
-      PHP_VERSION: "7.3"
+      PHP_VERSION: "8.0"
     only:
         changes:
             - .gitlab-ci.yml
@@ -53,7 +53,7 @@ pages:
 build-docker:
     extends: .build-docker
     variables:
-        PHP_VERSION: "7.3"
+        PHP_VERSION: "8.0"
     only:
         - tags
         - main

--- a/zmscalldisplay/.gitlab-ci.yml
+++ b/zmscalldisplay/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
     remote: https://gitlab.com/eappointment/php-base/-/raw/main/template-php-ci.yml
 
-test-php-73:
+test-php-80:
     extends: .test-php
     allow_failure: false
     variables:

--- a/zmscalldisplay/Dockerfile
+++ b/zmscalldisplay/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 COPY --from=build --chown=0:0 /var/www/html /var/www/html

--- a/zmsclient/.gitlab-ci.yml
+++ b/zmsclient/.gitlab-ci.yml
@@ -16,7 +16,7 @@ build-mockup:
     - docker build --pull -t "${MOCKUP_IMAGE}" tests/mockup/
     - docker push "${MOCKUP_IMAGE}"
 
-test-php-73:
+test-php-80:
     extends: .test-php
     allow_failure: false
     variables:

--- a/zmsclient/.gitlab-ci.yml
+++ b/zmsclient/.gitlab-ci.yml
@@ -20,7 +20,7 @@ test-php-73:
     extends: .test-php
     allow_failure: false
     variables:
-        PHP_VERSION: "7.3"
+        PHP_VERSION: "8.0"
         ZMS_API_URL: http://mockupserver:8083
     services:
         - name: $MOCKUP_IMAGE

--- a/zmsclient/docker-compose.yml
+++ b/zmsclient/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   test:
     depends_on:
       - mockup
-    image: ghcr.io/it-at-m/eappointment-php-base:7.4-base
+    image: ghcr.io/it-at-m/eappointment-php-base:8.0-base
     volumes:
       - type: bind
         source: "."

--- a/zmsclient/docker-compose.yml
+++ b/zmsclient/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   test:
     depends_on:
       - mockup
-    image: registry.gitlab.com/eappointment/php-base:7.3-base
+    image: ghcr.io/it-at-m/eappointment-php-base:7.3-base
     volumes:
       - type: bind
         source: "."

--- a/zmsclient/docker-compose.yml
+++ b/zmsclient/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   test:
     depends_on:
       - mockup
-    image: ghcr.io/it-at-m/eappointment-php-base:7.3-base
+    image: ghcr.io/it-at-m/eappointment-php-base:7.4-base
     volumes:
       - type: bind
         source: "."

--- a/zmsclient/phpunit.xml
+++ b/zmsclient/phpunit.xml
@@ -10,7 +10,7 @@
   convertNoticesToExceptions="true" 
   convertWarningsToExceptions="true" 
   forceCoversAnnotation="false" 
-  stopOnFailure="true" 
+  stopOnFailure="false" 
   verbose="true"
   processIsolation="false"
 >

--- a/zmsdb/.gitlab-ci.yml
+++ b/zmsdb/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
     remote: https://gitlab.com/eappointment/php-base/-/raw/main/template-php-ci.yml
 
-test-php-73:
+test-php-80:
     extends: .test-php
     cache: []
     allow_failure: false

--- a/zmsdb/.gitlab-ci.yml
+++ b/zmsdb/.gitlab-ci.yml
@@ -13,7 +13,7 @@ test-php-73:
         - $CLI_COMPOSER
         - bin/importTestData --commit
     variables:
-      PHP_VERSION: "7.3"
+      PHP_VERSION: "8.0"
       MYSQL_DATABASE: zmsbo
       MYSQL_ROOT_PASSWORD: mysql
     only:

--- a/zmsdldb/.gitlab-ci.yml
+++ b/zmsdldb/.gitlab-ci.yml
@@ -5,7 +5,7 @@ test-php-73:
     extends: .test-php
     allow_failure: false
     variables:
-      PHP_VERSION: "7.3"
+      PHP_VERSION: "8.0"
     only:
         changes:
             - composer.lock

--- a/zmsdldb/.gitlab-ci.yml
+++ b/zmsdldb/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
     remote: https://gitlab.com/eappointment/php-base/-/raw/main/template-php-ci.yml
 
-test-php-73:
+test-php-80:
     extends: .test-php
     allow_failure: false
     variables:

--- a/zmsentities/.gitlab-ci.yml
+++ b/zmsentities/.gitlab-ci.yml
@@ -5,7 +5,7 @@ test-php-73:
     extends: .test-php
     allow_failure: false
     variables:
-      PHP_VERSION: "7.3"
+      PHP_VERSION: "8.0"
     only:
         changes:
             - composer.lock

--- a/zmsentities/.gitlab-ci.yml
+++ b/zmsentities/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
     remote: https://gitlab.com/eappointment/php-base/-/raw/main/template-php-ci.yml
 
-test-php-73:
+test-php-80:
     extends: .test-php
     allow_failure: false
     variables:

--- a/zmsmessaging/Dockerfile
+++ b/zmsmessaging/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 COPY --from=build --chown=0:0 /var/www/html /var/www/html

--- a/zmsstatistic/.gitlab-ci.yml
+++ b/zmsstatistic/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
     remote: https://gitlab.com/eappointment/php-base/-/raw/main/template-php-ci.yml
 
-test-php-73:
+test-php-80:
     extends: .test-php
     allow_failure: false
     variables:

--- a/zmsstatistic/.gitlab-ci.yml
+++ b/zmsstatistic/.gitlab-ci.yml
@@ -5,7 +5,7 @@ test-php-73:
     extends: .test-php
     allow_failure: false
     variables:
-        PHP_VERSION: "7.3"
+        PHP_VERSION: "8.0"
     only:
         changes:
             - .gitlab-ci.yml

--- a/zmsstatistic/Dockerfile
+++ b/zmsstatistic/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 COPY --chown=1000:1000 . /build
 WORKDIR /build
 USER 1000:1000
 RUN make live
 
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 COPY --from=build --chown=0:0 /build /var/www/html

--- a/zmsticketprinter/Dockerfile
+++ b/zmsticketprinter/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-dev as build
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-dev as build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM registry.gitlab.com/eappointment/php-base:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment-php-base:${PHP_VERSION}-base
 COPY --from=build --chown=0:0 /var/www/html /var/www/html


### PR DESCRIPTION
**Description**

Switches the PHP Base image from Berlin to Munich for more control
Upgrades zmsclient from PHP 7.3 to PHP 8.0

https://github.com/it-at-m/eappointment-php-base

**Reference**

Issues #ZMS-3237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Upgraded PHP version to 8.0 across various services and configurations.
	- Enhanced test execution process with updated Docker images for unit tests.

- **Bug Fixes**
	- Improved error handling and data processing in the Result class.

- **Chores**
	- Updated Dockerfile base images to use GitHub Container Registry.
	- Commented out deprecated test jobs in CI configurations.

- **Tests**
	- Modified PHPUnit configuration to allow continued test execution despite failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->