### PR TITLE
Feature zms 3418 ekiosk zwei standorte keine ou

### DIFF
--- a/zmsticketprinter/templates/block/header/pageheader.twig
+++ b/zmsticketprinter/templates/block/header/pageheader.twig
@@ -11,10 +11,24 @@
             {% endfor %}
         </div>
         {% endif %}
-    	<div class="adressangabe">
+
+        {# Check if there are multiple different scopes #}
+        {% set firstScopeId = ticketprinter.buttons[0].scope.id %}
+        {% set allSameScopeId = true %}
+
+        {% for button in ticketprinter.buttons %}
+            {% if button.scope.id != firstScopeId %}
+                {% set allSameScopeId = false %}
+            {% endif %}
+        {% endfor %}
+
+        {% if allSameScopeId %}
+        <div class="adressangabe">
             <div class="adressangabe_behoerde">{{ organisation.name }}</div>
-    		<div class="adressangabe_name">{{ department.name }}</div>
+            <div class="adressangabe_name">{{ department.name }}</div>
         </div>
+        {% endif %}
+
     </span>
     {% block timer %}
         {{ parent() }}

--- a/zmsticketprinter/templates/block/header/pageheader.twig
+++ b/zmsticketprinter/templates/block/header/pageheader.twig
@@ -12,22 +12,9 @@
         </div>
         {% endif %}
 
-        {# Check if there are multiple different scopes #}
-        {% set firstScopeId = ticketprinter.buttons[0].scope.id %}
-        {% set allSameScopeId = true %}
-
-        {% for button in ticketprinter.buttons %}
-            {% if button.scope.id != firstScopeId %}
-                {% set allSameScopeId = false %}
-            {% endif %}
-        {% endfor %}
-
-        {% if allSameScopeId %}
         <div class="adressangabe">
-            <div class="adressangabe_behoerde">{{ organisation.name }}</div>
             <div class="adressangabe_name">{{ department.name }}</div>
         </div>
-        {% endif %}
 
     </span>
     {% block timer %}

--- a/zmsticketprinter/tests/Zmsticketprinter/TicketprinterByScopeTest.php
+++ b/zmsticketprinter/tests/Zmsticketprinter/TicketprinterByScopeTest.php
@@ -59,7 +59,6 @@ class TicketprinterByScopeTest extends Base
             ]
         ], [ ]);
         $this->assertStringContainsString('Apparat-Id: 71abcdefghijklmnopqrstuvwxyz', (string) $response->getBody());
-        $this->assertStringContainsString('Köpenick', (string) $response->getBody());
         $this->assertStringNotContainsString('Handynummer nachträglich eintragen', (string) $response->getBody());
     }
 }

--- a/zmsticketprinter/tests/Zmsticketprinter/TicketprinterByScopeWithNotificationTest.php
+++ b/zmsticketprinter/tests/Zmsticketprinter/TicketprinterByScopeWithNotificationTest.php
@@ -58,7 +58,6 @@ class TicketprinterByScopeWithNotificationTest extends Base
                 'Ticketprinter' => '71abcdefghijklmnopqrstuvwxyz',
             ]
         ], [ ]);
-        $this->assertStringContainsString('Charlottenburg-Wilmersdorf', (string) $response->getBody());
         $this->assertStringContainsString('buttonTelefonnummernachtragen', (string) $response->getBody());
         $this->assertStringContainsString('Handynummer nachträglich eintragen', (string) $response->getBody());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed the organization name from the address section in the header for a cleaner display.
  
- **Bug Fixes**
	- Adjusted test validations by removing specific string assertions, streamlining the testing process. 

- **Tests**
	- Updated tests to reflect changes in rendering criteria, ensuring continued functionality without certain string checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->