### PR TITLE
feat(ZMS-3459): return slotTimeInMinutes

### DIFF
--- a/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
@@ -30,6 +30,9 @@ class Office extends Entity implements JsonSerializable
     /** @var string|null */
     public ?string $organizationUnit = null;
 
+    /** @var int|null */
+    public ?int $slotTimeInMinutes = null;
+
     /** @var array|null */
     public ?array $geo = null;
 
@@ -43,6 +46,7 @@ class Office extends Entity implements JsonSerializable
         ?array $displayNameAlternatives = null,
         ?string $organization = null,
         ?string $organizationUnit = null,
+        ?int $slotTimeInMinutes = null,
         ?array $geo = null,
         ?ThinnedScope $scope = null
     ) {
@@ -52,6 +56,7 @@ class Office extends Entity implements JsonSerializable
         $this->displayNameAlternatives = $displayNameAlternatives;
         $this->organization = $organization;
         $this->organizationUnit = $organizationUnit;
+        $this->slotTimeInMinutes = $slotTimeInMinutes;
         $this->geo = $geo;
         $this->scope = $scope;
 
@@ -79,6 +84,7 @@ class Office extends Entity implements JsonSerializable
             'displayNameAlternatives' => $this->displayNameAlternatives,
             'organization' => $this->organization,
             'organizationUnit' => $this->organizationUnit,
+            'slotTimeInMinutes' => $this->slotTimeInMinutes,
             'geo' => $this->geo,
             'scope' => $this->scope?->toArray(),
         ];

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -66,6 +66,7 @@ class MapperService
                 displayNameAlternatives: $provider->data['displayNameAlternatives'] ?? [],
                 organization: $provider->data['organization'] ?? null,
                 organizationUnit: $provider->data['organizationUnit'] ?? null,
+                slotTimeInMinutes: $provider->data['slotTimeInMinutes'] ?? null,
                 geo: isset($provider->data['geo']) ? $provider->data['geo'] : null,
                 scope: isset($providerScope) && !isset($providerScope['errors']) ? new ThinnedScope(
                     id: isset($providerScope->id) ? (int) $providerScope->id : 0,

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -64,6 +64,7 @@ class ZmsApiFacadeService
                 displayNameAlternatives: $provider->data['displayNameAlternatives'] ?? [],
                 organization: $provider->data['organization'] ?? null,
                 organizationUnit: $provider->data['organizationUnit'] ?? null,
+                slotTimeInMinutes: $provider->data['slotTimeInMinutes'] ?? null,
                 geo: $provider->data['geo'] ?? null,
                 scope: $matchingScope ? new ThinnedScope(
                     id: (int) $matchingScope->id,
@@ -373,6 +374,7 @@ class ZmsApiFacadeService
                         displayNameAlternatives: $provider->data['displayNameAlternatives'] ?? [],
                         organization: $provider->data['organization'] ?? null,
                         organizationUnit: $provider->data['organizationUnit'] ?? null,
+                        slotTimeInMinutes: $provider->data['slotTimeInMinutes'] ?? null,
                         geo: $provider->data['geo'] ?? null,
                         scope: $scope instanceof ThinnedScope ? $scope : null
                     );

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
@@ -45,6 +45,7 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => null,
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => null,
                     "scope" => [
                         "id" => 2,
@@ -104,6 +105,7 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => null,
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => null,
                     "scope" => [
                         "id" => 1,
@@ -140,6 +142,7 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => null,
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => null,
                     "scope" => [
                         "id" => 2,

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
@@ -44,6 +44,7 @@ class OfficesListControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => [],
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => [
                         "lat" => "48.12750898398659",
                         "lon" => "11.604317899956524"
@@ -83,6 +84,7 @@ class OfficesListControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => [],
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => [
                         "lat" => "48.12750898398659",
                         "lon" => "11.604317899956524"

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
@@ -44,6 +44,7 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => [],
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => [
                         "lat" => "48.12750898398659",
                         "lon" => "11.604317899956524"
@@ -83,6 +84,7 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                     "displayNameAlternatives" => [],
                     "organization" => null,
                     "organizationUnit" => null,
+                    "slotTimeInMinutes" => null,
                     "geo" => [
                         "lat" => "48.12750898398659",
                         "lon" => "11.604317899956524"

--- a/zmsentities/schema/citizenapi/collections/officeList.json
+++ b/zmsentities/schema/citizenapi/collections/officeList.json
@@ -70,6 +70,10 @@
             "type": ["string", "null"],
             "description": "The name of the organization"
           },
+          "slotTimeInMinutes": {
+            "type": ["integer", "null"],
+            "description": "Slot time in minutes"
+          },
           "geo": {
             "type": [
               "array",

--- a/zmsentities/schema/citizenapi/collections/officeServiceAndRelationList.json
+++ b/zmsentities/schema/citizenapi/collections/officeServiceAndRelationList.json
@@ -75,6 +75,10 @@
             "type": ["string", "null"],
             "description": "The name of the organization"
           },
+          "slotTimeInMinutes": {
+            "type": ["integer", "null"],
+            "description": "Slot time in minutes"
+          },
           "geo": {
             "type": [
               "array",

--- a/zmsentities/schema/citizenapi/office.json
+++ b/zmsentities/schema/citizenapi/office.json
@@ -51,6 +51,10 @@
             "type": ["string", "null"],
             "description": "The name of the organization"
         },
+        "slotTimeInMinutes": {
+            "type": ["integer", "null"],
+            "description": "Slot time in minutes"
+        },
         "geo": {
             "type": ["array", "object", "null"],
             "description": "Geographical coordinates of the office",


### PR DESCRIPTION
**Description**

Short description or comments

**Reference**

Issues #XXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `slotTimeInMinutes` property to Office entities, representing the slot time in minutes
	- Updated API responses and schemas to include the new slot time information

- **Documentation**
	- Updated JSON schemas to reflect the new `slotTimeInMinutes` property across multiple collections and entity definitions

- **Tests**
	- Updated test cases to validate the new `slotTimeInMinutes` property in office-related responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->