### PR TITLE
feat(ZMS-3212) Notfall für Tresen deaktiveren

### DIFF
--- a/zmsadmin/templates/block/emergency/emergency.twig
+++ b/zmsadmin/templates/block/emergency/emergency.twig
@@ -7,10 +7,11 @@
         data-state="clear"
         data-source="">
         <h2 class="aural">Notruf</h2>
+        {% if workstation.name %}
         <button class="button button--emergency emergency__button-trigger" >
             <i class="fas fa-bell" aria-hidden="true"></i> NOTRUF
         </button>
-
+        {% endif %}
         <div class="emergency__overlay">
             <div class="block emergency__overlay-layout" role="dialog" aria-labelledby="emergency__overlay_title">
             {% embed "block/scaffholding/board.twig" with {'class': "emergency__display-box"} %} {# do NOT use class exception here! #}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved emergency button rendering by adding a condition to only display the button when a workstation name is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->