### PR TITLE
fix (zms-3272): time of CanceledSlots shortened to 5 minutes

### DIFF
--- a/zmsdb/src/Zmsdb/Helper/CalculateSlots.php
+++ b/zmsdb/src/Zmsdb/Helper/CalculateSlots.php
@@ -166,7 +166,7 @@ class CalculateSlots
         }
     }
 
-    public function writeCanceledSlots(\DateTimeInterface $now, $modify = '+10 minutes')
+    public function writeCanceledSlots(\DateTimeInterface $now, $modify = '+5 minutes')
     {
         \BO\Zmsdb\Connection\Select::getWriteConnection();
         $slotQuery = new \BO\Zmsdb\Slot();


### PR DESCRIPTION
**Description**

Short description or comments

**Reference**

Issues #XXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted slot cancellation time window from 10 minutes to 5 minutes to improve scheduling precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->