### PR TITLE
fix(ZMSKVR-134): filter out non bookable days in getFreeDays

### DIFF
--- a/zmsadmin/package-lock.json
+++ b/zmsadmin/package-lock.json
@@ -42,6 +42,7 @@
         "react-to-print": "^2.14.10",
         "redux-json-schema": "^1.0.0",
         "stream-http": "^3.2.0",
+        "svgo": "^3.3.2",
         "url": "^0.11.0",
         "util": "^0.12.5"
       }
@@ -2172,6 +2173,16 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2495,6 +2506,13 @@
       "version": "1.0.0",
       "resolved": "git+ssh://git@gitlab.com/eappointment/zmsentities.git#34257f84656f5527d3e66005c9290ac6fd1a606e"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2805,6 +2823,86 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -5070,6 +5168,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5217,6 +5322,19 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
     },
     "node_modules/nullthrows": {
       "version": "1.1.1",
@@ -6199,21 +6317,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/srcset": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.1.tgz",
-      "integrity": "sha512-/P1UYbGfJVlxZag7aABNRrulEXAwCSDo7fklafOQrantuPTDmYgijJMks2zusPCVzgW9+4P69mq7w6pYuZpgxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ssr-window": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-3.0.0.tgz",
@@ -6394,6 +6497,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/swiper": {

--- a/zmsadmin/package.json
+++ b/zmsadmin/package.json
@@ -56,6 +56,7 @@
     "react-to-print": "^2.14.10",
     "redux-json-schema": "^1.0.0",
     "stream-http": "^3.2.0",
+    "svgo": "^3.3.2",
     "url": "^0.11.0",
     "util": "^0.12.5"
   },

--- a/zmscalldisplay/package-lock.json
+++ b/zmscalldisplay/package-lock.json
@@ -19,7 +19,8 @@
         "parcel": "^2.6.2",
         "postcss": "^8.4.16",
         "qrcode-generator": "1.4.4",
-        "sass": "^1.54.4"
+        "sass": "^1.54.4",
+        "svgo": "^3.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3316,8 +3317,6 @@
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -3335,8 +3334,6 @@
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -3352,8 +3349,6 @@
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -3370,8 +3365,6 @@
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -3387,8 +3380,6 @@
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
@@ -3504,8 +3495,6 @@
       "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "css-tree": "~2.2.0"
       },
@@ -3520,8 +3509,6 @@
       "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.0.28",
         "source-map-js": "^1.0.1"
@@ -3536,9 +3523,7 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true,
-      "license": "CC0-1.0",
-      "optional": true,
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -5439,9 +5424,7 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
-      "license": "CC0-1.0",
-      "optional": true,
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7006,8 +6989,6 @@
       "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",

--- a/zmscalldisplay/package.json
+++ b/zmscalldisplay/package.json
@@ -44,6 +44,7 @@
     "parcel": "^2.6.2",
     "postcss": "^8.4.16",
     "qrcode-generator": "1.4.4",
-    "sass": "^1.54.4"
+    "sass": "^1.54.4",
+    "svgo": "^3.3.2"
   }
 }

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
@@ -10,6 +10,7 @@ use BO\Zmscitizenapi\Services\Core\ExceptionService;
 use BO\Zmsentities\Calendar;
 use BO\Zmsentities\Process;
 use BO\Zmsentities\Source;
+use BO\Zmsentities\Collection\DayList;
 use BO\Zmsentities\Collection\ProcessList;
 use BO\Zmsentities\Collection\ProviderList;
 use BO\Zmsentities\Collection\RequestList;
@@ -115,7 +116,7 @@ class ZmsApiClientService
             if (!$entity instanceof Calendar) {
                 return new Calendar();
             }
-            $bookableDays = new \BO\Zmsentities\Collection\DayList();
+            $bookableDays = new DayList();
             foreach ($entity->days as $day) {
                 if (isset($day['status']) && $day['status'] === 'bookable') {
                     $bookableDays->addEntity($day);

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
@@ -111,9 +111,18 @@ class ZmsApiClientService
             $calendar->requests = $requests;
             $result = \App::$http->readPostResult('/calendar/', $calendar);
             $entity = $result?->getEntity();
+
             if (!$entity instanceof Calendar) {
                 return new Calendar();
             }
+            $bookableDays = new \BO\Zmsentities\Collection\DayList();
+            foreach ($entity->days as $day) {
+                if (isset($day['status']) && $day['status'] === 'bookable') {
+                    $bookableDays->addEntity($day);
+                }
+            }
+            $entity->days = $bookableDays;
+
             return $entity;
         } catch (\Exception $e) {
             ExceptionService::handleException($e);

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableDaysListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableDaysListControllerTest.php
@@ -12,7 +12,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
     public function setUp(): void
     {
         parent::setUp();
-        
+
         \App::$source_name = 'unittest';
 
         if (\App::$cache) {
@@ -39,12 +39,31 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceCount' => '1',
         ];
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'availableDays' => [
-                "2024-08-21", "2024-08-22", "2024-08-23", "2024-08-26", "2024-08-27", "2024-08-28", "2024-08-29", "2024-08-30", 
-                "2024-09-02", "2024-09-03", "2024-09-04", "2024-09-05", "2024-09-06", "2024-09-09", "2024-09-10", "2024-09-11", 
-                "2024-09-12", "2024-09-13", "2024-09-16", "2024-09-17", "2024-09-18", "2024-09-19", "2024-09-20"
+                "2024-08-22",
+                "2024-08-23",
+                "2024-08-26",
+                "2024-08-27",
+                "2024-08-28",
+                "2024-08-29",
+                "2024-08-30",
+                "2024-09-02",
+                "2024-09-03",
+                "2024-09-04",
+                "2024-09-05",
+                "2024-09-06",
+                "2024-09-09",
+                "2024-09-10",
+                "2024-09-11",
+                "2024-09-12",
+                "2024-09-13",
+                "2024-09-16",
+                "2024-09-17",
+                "2024-09-18",
+                "2024-09-19",
+                "2024-09-20"
             ]
         ];
         $this->assertEquals(200, $response->getStatusCode());
@@ -72,7 +91,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'endDate' => '2024-08-23',
         ];
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('noAppointmentForThisDay')
@@ -92,7 +111,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'endDate' => 'invalid-date',
         ];
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -113,9 +132,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate')
@@ -124,7 +143,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidStartDate')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
-   
+
     public function testMissingEndDate()
     {
         $parameters = [
@@ -133,18 +152,18 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidEndDate')
             ],
         ];
-        $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode()); 
+        $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-    
+    }
+
     public function testMissingOfficeId()
     {
         $parameters = [
@@ -153,9 +172,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidOfficeId')
@@ -163,8 +182,8 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         ];
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-    
+    }
+
     public function testMissingServiceId()
     {
         $parameters = [
@@ -173,9 +192,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'officeId' => '102522',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceId')
@@ -183,7 +202,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         ];
         $this->assertEquals(ErrorMessages::get('invalidServiceId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testMissingServiceCount()
     {
@@ -193,9 +212,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'officeId' => '102522',
             'serviceId' => '1063424',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceCount')
@@ -203,8 +222,8 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         ];
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-    
+    }
+
     public function testEmptyServiceCount()
     {
         $parameters = [
@@ -214,9 +233,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceCount')
@@ -224,8 +243,8 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         ];
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-        
+    }
+
     public function testInvalidServiceCountFormat()
     {
         $parameters = [
@@ -235,9 +254,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => 'one,two',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceCount')
@@ -245,14 +264,14 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         ];
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testAllParametersMissing()
     {
         $parameters = [];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -277,9 +296,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -289,8 +308,8 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidStartDate')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-    
+    }
+
     public function testMissingOfficeIdAndServiceId()
     {
         $parameters = [
@@ -298,9 +317,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'endDate' => '2024-09-04',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidOfficeId'),
@@ -310,7 +329,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testMissingServiceIdAndServiceCount()
     {
@@ -319,9 +338,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'endDate' => '2024-09-04',
             'officeId' => '102522',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceId'),
@@ -331,8 +350,8 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidServiceId')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-    
+    }
+
     public function testMissingStartDateAndOfficeId()
     {
         $parameters = [
@@ -340,9 +359,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -353,7 +372,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
-     
+
     public function testMissingEndDateAndServiceCount()
     {
         $parameters = [
@@ -361,9 +380,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'officeId' => '102522',
             'serviceId' => '1063424',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidEndDate'),
@@ -373,7 +392,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testMissingOfficeIdAndServiceCount()
     {
@@ -382,9 +401,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'endDate' => '2024-09-04',
             'serviceId' => '1063424',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidOfficeId'),
@@ -394,17 +413,17 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-    
+    }
+
     public function testMissingStartDateEndDateAndOfficeId()
     {
         $parameters = [
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -416,17 +435,17 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
- 
+    }
+
     public function testMissingStartDateEndDateAndServiceId()
     {
         $parameters = [
             'officeId' => '102522',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -438,7 +457,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testMissingStartDateOfficeIdAndServiceCount()
     {
@@ -446,9 +465,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'endDate' => '2024-09-04',
             'serviceId' => '1063424',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -460,17 +479,17 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
-   
+    }
+
     public function testMissingEndDateOfficeIdAndServiceCount()
     {
         $parameters = [
             'startDate' => '2024-08-29',
             'serviceId' => '1063424',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidEndDate'),
@@ -482,7 +501,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testEmptyStartDateAndEndDate()
     {
@@ -493,9 +512,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidStartDate'),
@@ -505,7 +524,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidStartDate')['statusCode'], $response->getStatusCode());
         $this->assertEquals(ErrorMessages::get('invalidEndDate')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
-    }    
+    }
 
     public function testNonNumericServiceCount()
     {
@@ -516,9 +535,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => 'abc,123',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceCount')
@@ -527,7 +546,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidServiceCount')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
-    
+
     public function testInvalidOfficeIdFormat()
     {
         $parameters = [
@@ -537,9 +556,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidOfficeId')
@@ -548,7 +567,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidOfficeId')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
-    
+
     public function testInvalidServiceIdFormat()
     {
         $parameters = [
@@ -558,9 +577,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => 'invalid',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidServiceId')
@@ -574,7 +593,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
     {
         $exception = new \BO\Zmsclient\Exception();
         $exception->template = 'BO\\Zmsapi\\Exception\\Calendar\\InvalidFirstDay';
-        
+
         $this->setApiCalls([
             [
                 'function' => 'readPostResult',
@@ -582,7 +601,7 @@ class AvailableDaysListControllerTest extends ControllerTestCase
                 'exception' => $exception
             ]
         ]);
-    
+
         $parameters = [
             'startDate' => '2024-08-29',
             'endDate' => '2024-09-04',
@@ -590,9 +609,9 @@ class AvailableDaysListControllerTest extends ControllerTestCase
             'serviceId' => '1063424',
             'serviceCount' => '1',
         ];
-    
+
         $response = $this->render([], $parameters, []);
-        $responseBody = json_decode((string)$response->getBody(), true);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('invalidDateRange')
@@ -601,5 +620,5 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $this->assertEquals(ErrorMessages::get('invalidDateRange')['statusCode'], $response->getStatusCode());
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
-         
+
 }

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Core/ZmsApiClientServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Core/ZmsApiClientServiceTest.php
@@ -8,10 +8,12 @@ use BO\Zmscitizenapi\Services\Core\ZmsApiClientService;
 use BO\Zmsclient\Http;
 use BO\Zmsclient\Result;
 use BO\Zmsentities\Calendar;
+use BO\Zmsentities\Day;
 use BO\Zmsentities\Process;
 use BO\Zmsentities\Provider;
 use BO\Zmsentities\Scope;
 use BO\Zmsentities\Source;
+use BO\Zmsentities\Collection\DayList;
 use BO\Zmsentities\Collection\ProcessList;
 use BO\Zmsentities\Collection\ProviderList;
 use BO\Zmsentities\Collection\RequestList;
@@ -394,8 +396,8 @@ class ZmsApiClientServiceTest extends TestCase
         $lastDay = ['year' => 2025, 'month' => 1, 'day' => 31];
     
         $calendar = new Calendar();
-        $dayList = new \BO\Zmsentities\Collection\DayList();
-        $day = new \BO\Zmsentities\Day([
+        $dayList = new DayList();
+        $day = new Day([
             'year' => 2025,
             'month' => 1,
             'day' => 15,

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Core/ZmsApiClientServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Core/ZmsApiClientServiceTest.php
@@ -386,27 +386,32 @@ class ZmsApiClientServiceTest extends TestCase
         ZmsApiClientService::getScopesByProviderId('unittest', 100);
     }
 
-    // Methods making direct API calls
     public function testGetFreeDaysSuccess(): void
     {
         $providers = new ProviderList([['id' => 1]]);
         $requests = new RequestList([['id' => 1]]);
         $firstDay = ['year' => 2025, 'month' => 1, 'day' => 1];
         $lastDay = ['year' => 2025, 'month' => 1, 'day' => 31];
-
+    
         $calendar = new Calendar();
-        $calendar->days = [
-            (object) ['year' => 2025, 'month' => 1, 'day' => 15]
-        ];
-
+        $dayList = new \BO\Zmsentities\Collection\DayList();
+        $day = new \BO\Zmsentities\Day([
+            'year' => 2025,
+            'month' => 1,
+            'day' => 15,
+            'status' => 'bookable'
+        ]);
+        $dayList->addEntity($day);
+        $calendar->days = $dayList;
+    
         $result = $this->createMock(Result::class);
         $result->method('getEntity')->willReturn($calendar);
-
+    
         $this->httpMock->expects($this->once())
             ->method('readPostResult')
             ->with('/calendar/', $this->isInstanceOf(Calendar::class))
             ->willReturn($result);
-
+    
         $result = ZmsApiClientService::getFreeDays($providers, $requests, $firstDay, $lastDay);
         $this->assertInstanceOf(Calendar::class, $result);
         $this->assertCount(1, $result->days);

--- a/zmsstatistic/package-lock.json
+++ b/zmsstatistic/package-lock.json
@@ -20,7 +20,8 @@
         "eslint-plugin-import": "^2.20.1",
         "jquery": "^3.4.1",
         "parcel": "^2.7.0",
-        "react-datepicker": "^4.2.1"
+        "react-datepicker": "^4.2.1",
+        "svgo": "^3.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2014,6 +2015,16 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2292,6 +2303,13 @@
       "name": "eappointment-zmsentities",
       "version": "1.0.0",
       "resolved": "git+ssh://git@gitlab.com/eappointment/zmsentities.git#34257f84656f5527d3e66005c9290ac6fd1a606e"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2627,6 +2645,86 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -4637,6 +4735,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4817,6 +4922,19 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
     },
     "node_modules/nullthrows": {
       "version": "1.1.1",
@@ -5767,21 +5885,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/srcset": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.1.tgz",
-      "integrity": "sha512-/P1UYbGfJVlxZag7aABNRrulEXAwCSDo7fklafOQrantuPTDmYgijJMks2zusPCVzgW9+4P69mq7w6pYuZpgxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ssr-window": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-3.0.0.tgz",
@@ -5926,6 +6029,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/swiper": {

--- a/zmsstatistic/package.json
+++ b/zmsstatistic/package.json
@@ -30,16 +30,17 @@
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.7.0",
-    "react-datepicker": "^4.2.1",
     "chart.js": "^2.7.2",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",
     "jquery": "^3.4.1",
-    "parcel": "^2.7.0"
+    "parcel": "^2.7.0",
+    "react-datepicker": "^4.2.1",
+    "svgo": "^3.3.2"
   },
   "dependencies": {
-    "bo-layout-admin-scss": "https://gitlab.com/eappointment/includes/layout-admin-scss.git#2.24.14",
     "bo-layout-admin-js": "https://gitlab.com/eappointment/includes/layout-admin-js.git#2.24.14",
+    "bo-layout-admin-scss": "https://gitlab.com/eappointment/includes/layout-admin-scss.git#2.24.14",
     "bo-zmsentities": "https://gitlab.com/eappointment/zmsentities.git#2.24.14"
   }
 }


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced booking availability now displays only bookable days, ensuring a clearer and more reliable scheduling experience.

- **Chores**
  - Improved internal asset optimization and dependency management for greater system stability.
  - Added new dependencies for development, including `svgo`.

- **Style**
  - Refined code formatting in tests to boost readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Some fixes in the frontend too: https://github.com/it-at-m/eappointment-buergeransicht/pull/156