### PR TITLE
fix(ZMSKVR-318): error message missing email template in zmscitizenapi

### DIFF
--- a/zmscitizenapi/config.example.php
+++ b/zmscitizenapi/config.example.php
@@ -1,6 +1,7 @@
 <?php
 define('ZMS_API_URL', getenv('ZMS_API_URL') ? getenv('ZMS_API_URL') : 'https://localhost/terminvereinbarung/api/2');
 define('MAINTENANCE_MODE_ENABLED', in_array(strtolower(getenv('MAINTENANCE_MODE_ENABLED')), ["1", "true", "yes"]));
+define('ZMS_IDENTIFIER', getenv('ZMS_IDENTIFIER') ? getenv('ZMS_IDENTIFIER') : 'Zmscitizenapi-ENV');
 
 class App extends \BO\Zmscitizenapi\Application
 {
@@ -13,4 +14,9 @@ class App extends \BO\Zmscitizenapi\Application
      * Flag for enabling maintenance mode
      */
     const MAINTENANCE_MODE_ENABLED = MAINTENANCE_MODE_ENABLED;
+
+    /**
+     * Name of the application
+     */
+    const IDENTIFIER = ZMS_IDENTIFIER;
 }

--- a/zmscitizenapi/src/Zmscitizenapi/Localization/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Localization/ErrorMessages.php
@@ -202,6 +202,11 @@ class ErrorMessages
             'errorMessage' => 'Scope not found.',
             'statusCode' => self::HTTP_NOT_FOUND
         ],
+        'templateRenderingError' => [
+            'errorCode' => 'templateError',
+            'errorMessage' => 'An error occurred while rendering the email template. Please contact support.',
+            'statusCode' => self::HTTP_INTERNAL_SERVER_ERROR
+        ],
         'processInvalid' => [
             'errorCode' => 'processInvalid',
             'errorMessage' => 'The process data is invalid.',
@@ -490,6 +495,11 @@ class ErrorMessages
             'errorMessage' => 'Bereich nicht gefunden.',
             'statusCode' => self::HTTP_NOT_FOUND
         ],
+        'templateRenderingError' => [
+            'errorCode' => 'templateError',
+            'errorMessage' => 'Bei der Darstellung der E-Mail-Vorlage ist ein Fehler aufgetreten. Bitte kontaktieren Sie den Support.',
+            'statusCode' => self::HTTP_INTERNAL_SERVER_ERROR
+        ],
         'processInvalid' => [
             'errorCode' => 'processInvalid',
             'errorMessage' => 'Die Prozessdaten sind ungültig.',
@@ -774,6 +784,11 @@ class ErrorMessages
             'errorCode' => 'scopeNotFound',
             'errorMessage' => 'Область не знайдено.',
             'statusCode' => self::HTTP_NOT_FOUND
+        ],
+        'templateRenderingError' => [
+            'errorCode' => 'templateError',
+            'errorMessage' => 'Під час рендерингу шаблону електронної пошти сталася помилка. Будь ласка, зверніться до служби підтримки.',
+            'statusCode' => self::HTTP_INTERNAL_SERVER_ERROR
         ],
         'processInvalid' => [
             'errorCode' => 'processInvalid',

--- a/zmscitizenapi/src/Zmscitizenapi/Localization/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Localization/ErrorMessages.php
@@ -25,6 +25,11 @@ class ErrorMessages
     private const FALLBACK_LANGUAGE = 'EN';
 // English messages
     public const EN = [
+        'zmsClientCommunicationError' => [
+            'errorCode' => 'zmsClientCommunicationError',
+            'errorMessage' => 'The service is temporarily unavailable. Please try again later.',
+            'statusCode' => 503
+        ],
         'notImplemented' => [
             'errorCode' => 'notImplemented',
             'statusCode' => self::HTTP_NOT_IMPLEMENTED,
@@ -202,11 +207,6 @@ class ErrorMessages
             'errorMessage' => 'Scope not found.',
             'statusCode' => self::HTTP_NOT_FOUND
         ],
-        'templateRenderingError' => [
-            'errorCode' => 'templateError',
-            'errorMessage' => 'An error occurred while rendering the email template. Please contact support.',
-            'statusCode' => self::HTTP_INTERNAL_SERVER_ERROR
-        ],
         'processInvalid' => [
             'errorCode' => 'processInvalid',
             'errorMessage' => 'The process data is invalid.',
@@ -318,6 +318,11 @@ class ErrorMessages
     ];
 // German messages
     public const DE = [
+        'zmsClientCommunicationError' => [
+            'errorCode' => 'zmsClientCommunicationError',
+            'errorMessage' => 'Der Dienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.',
+            'statusCode' => 503
+        ],
         'notImplemented' => [
             'errorCode' => 'notImplemented',
             'statusCode' => self::HTTP_NOT_IMPLEMENTED,
@@ -495,11 +500,6 @@ class ErrorMessages
             'errorMessage' => 'Bereich nicht gefunden.',
             'statusCode' => self::HTTP_NOT_FOUND
         ],
-        'templateRenderingError' => [
-            'errorCode' => 'templateError',
-            'errorMessage' => 'Bei der Darstellung der E-Mail-Vorlage ist ein Fehler aufgetreten. Bitte kontaktieren Sie den Support.',
-            'statusCode' => self::HTTP_INTERNAL_SERVER_ERROR
-        ],
         'processInvalid' => [
             'errorCode' => 'processInvalid',
             'errorMessage' => 'Die Prozessdaten sind ungültig.',
@@ -610,6 +610,11 @@ class ErrorMessages
 
     ];
     public const UA = [
+        'zmsClientCommunicationError' => [
+            'errorCode' => 'zmsClientCommunicationError',
+            'errorMessage' => 'Сервіс тимчасово недоступний. Будь ласка, спробуйте пізніше.',
+            'statusCode' => 503
+        ],
         'notImplemented' => [
             'errorCode' => 'notImplemented',
             'statusCode' => self::HTTP_NOT_IMPLEMENTED,
@@ -784,11 +789,6 @@ class ErrorMessages
             'errorCode' => 'scopeNotFound',
             'errorMessage' => 'Область не знайдено.',
             'statusCode' => self::HTTP_NOT_FOUND
-        ],
-        'templateRenderingError' => [
-            'errorCode' => 'templateError',
-            'errorMessage' => 'Під час рендерингу шаблону електронної пошти сталася помилка. Будь ласка, зверніться до служби підтримки.',
-            'statusCode' => self::HTTP_INTERNAL_SERVER_ERROR
         ],
         'processInvalid' => [
             'errorCode' => 'processInvalid',

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentCancelService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentCancelService.php
@@ -33,6 +33,7 @@ class AppointmentCancelService
             ]];
         }
 
+        // Todo: check if the email template cancelled exists for the scope before submitting and sending
         $this->sendCancellationEmail($process);
         return $this->cancelProcess($process);
     }

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentConfirmService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentConfirmService.php
@@ -24,6 +24,7 @@ class AppointmentConfirmService
             return $reservedProcess;
         }
 
+        // Todo: check if the email template confirmed exists for the scope before submitting and sending
         $result = $this->confirmProcess($reservedProcess);
         if (is_array($result) && !empty($result['errors'])) {
             return $result;

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentPreconfirmService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentPreconfirmService.php
@@ -24,6 +24,7 @@ class AppointmentPreconfirmService
             return $reservedProcess;
         }
 
+        // Todo: check if the email template preconfirmed exists for the scope before submitting and sending
         $result = $this->preconfirmProcess($reservedProcess);
         if (is_array($result) && !empty($result['errors'])) {
             return $result;

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -30,7 +30,7 @@ class ExceptionService
      */
     public static function handleException(\Exception $e): never
     {
-        $exceptionName = get_class($e);
+        $exceptionName = json_decode(json_encode($e), true)['template'] ?? null;
         $error = null;
 
         switch ($exceptionName) {

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -93,11 +93,9 @@ class ExceptionService
                 break;
             case 'BO\\Zmsapi\\Exception\\Calendar\\AppointmentsMissed':
                 $error = self::getError('noAppointmentForThisScope');
-
                 break;
             case 'BO\\Zmsdb\\Exception\\CalendarWithoutScopes':
                 $error = self::getError('noAppointmentForThisScope');
-
                 break;
             // Other entity exceptions
             case 'BO\\Zmsapi\\Exception\\Department\\DepartmentNotFound':
@@ -127,6 +125,10 @@ class ExceptionService
             case 'BO\\Zmsapi\\Exception\\Source\\SourceNotFound':
                 $error = self::getError('sourceNotFound');
 
+                break;
+
+            case $e instanceof \Twig\Error\RuntimeError:
+                $error = self::getError('templateRenderingError');
                 break;
             // Use original message for unmapped exceptions
             default:

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -30,9 +30,28 @@ class ExceptionService
      */
     public static function handleException(\Exception $e): never
     {
-        $exceptionName = json_decode(json_encode($e), true)['template'] ?? null;
+        $exceptionName = get_class($e);
         $error = null;
+
         switch ($exceptionName) {
+            // ZmsClient exception
+            case 'BO\\Zmsclient\\Exception':
+                $error = self::getError('zmsClientCommunicationError');
+
+                break;
+            // Missing mail template exceptions
+            case 'Twig\\Error\\RuntimeError':
+                $error = self::getError('mailNotFound');
+
+                break;
+            case 'Twig\\Error\\LoaderError':
+                $error = self::getError('mailNotFound');
+
+                break;
+            case 'BO\\Zmsapi\\Exception\\Mail\\MailNotFound':
+                $error = self::getError('mailNotFound');
+
+                break;
             // Process exceptions
             case 'BO\\Zmsapi\\Exception\\Process\\ProcessNotFound':
                 $error = self::getError('appointmentNotFound');
@@ -102,10 +121,6 @@ class ExceptionService
                 $error = self::getError('departmentNotFound');
 
                 break;
-            case 'BO\\Zmsapi\\Exception\\Mail\\MailNotFound':
-                $error = self::getError('mailNotFound');
-
-                break;
             case 'BO\\Zmsapi\\Exception\\Organisation\\OrganisationNotFound':
                 $error = self::getError('organisationNotFound');
 
@@ -127,9 +142,6 @@ class ExceptionService
 
                 break;
 
-            case $e instanceof \Twig\Error\RuntimeError:
-                $error = self::getError('templateRenderingError');
-                break;
             // Use original message for unmapped exceptions
             default:
                 $error = [

--- a/zmsslim/src/Slim/Bootstrap.php
+++ b/zmsslim/src/Slim/Bootstrap.php
@@ -88,7 +88,7 @@ class Bootstrap
                 'client_ip' => $_SERVER['REMOTE_ADDR'] ?? '',
                 'remote_addr' => $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '',
                 'remote_user' => '',
-                'application' => 'zmsslim',
+                'application' => defined('\App::IDENTIFIER') ? \App::IDENTIFIER : 'zmsslim',
                 'message' => $record['message'],
                 'level' => $record['level_name'],
                 'context' => $record['context'],


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added multilingual error notifications to inform users when a service is temporarily unavailable.
	- Enhanced error messaging to provide more precise and helpful feedback for issues related to mail handling and calendar operations.
	- Introduced a new application identifier that can be set via an environment variable for improved configuration flexibility.

- **Chores**
	- Added comments in the appointment services (preconfirmation, cancellation, and confirmation) to indicate future tasks regarding email template checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->