### PR TITLE
fix(ZMSKVR-345): fix closure schemas and defaults

### DIFF
--- a/zmsentities/schema/closure.json
+++ b/zmsentities/schema/closure.json
@@ -2,7 +2,7 @@
     "type": "object",
     "description": "A closure is a free day where a department and its scopes are closed.",
     "example": {
-        "id" : 1234,
+        "id": 1234,
         "Datum": 1447924981
     },
     "required": [
@@ -11,7 +11,15 @@
     "additionalProperties": false,
     "properties": {
         "id": {
-            "type": "number"
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
         },
         "Datum": {
             "type": "number",
@@ -20,6 +28,39 @@
         "lastChange": {
             "type": "number",
             "description": "unix timestamp of the last change on this closure"
+        },
+        "year": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
+        },
+        "month": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
+        },
+        "day": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
         }
     }
 }

--- a/zmsentities/schema/dereferenced/closure.json
+++ b/zmsentities/schema/dereferenced/closure.json
@@ -11,7 +11,15 @@
     "additionalProperties": false,
     "properties": {
         "id": {
-            "type": "number"
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
         },
         "Datum": {
             "type": "number",
@@ -20,6 +28,39 @@
         "lastChange": {
             "type": "number",
             "description": "unix timestamp of the last change on this closure"
+        },
+        "year": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
+        },
+        "month": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
+        },
+        "day": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            ]
         }
     }
 }

--- a/zmsentities/schema/dereferenced/scope.json
+++ b/zmsentities/schema/dereferenced/scope.json
@@ -232,26 +232,68 @@
             }
         },
         "closure": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "description": "A closure is a free day where scopes are closed.",
-                "example": {
-                    "id": 1234,
-                    "Datum": 1447924981
+            "type": "object",
+            "description": "A closure is a free day where a department and its scopes are closed.",
+            "example": {
+                "id" : 1234,
+                "Datum": 1447924981
+            },
+            "required": [
+                "Datum"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^[0-9]+$"
+                        }
+                    ]
                 },
-                "required": [
-                    "Datum"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                    "id": {
-                        "type": "number"
-                    },
-                    "Datum": {
-                        "type": "number",
-                        "description": "unix timestamp"
-                    }
+                "Datum": {
+                    "type": "number",
+                    "description": "unix timestamp"
+                },
+                "lastChange": {
+                    "type": "number",
+                    "description": "unix timestamp of the last change on this closure"
+                },
+                "year": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^[0-9]+$"
+                        }
+                    ]
+                },
+                "month": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^[0-9]+$"
+                        }
+                    ]
+                },
+                "day": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^[0-9]+$"
+                        }
+                    ]
                 }
             }
         },

--- a/zmsentities/schema/scope.json
+++ b/zmsentities/schema/scope.json
@@ -134,7 +134,7 @@
             }
         },
         "closure": {
-            "type": "object",
+            "type": "array",
             "items": {
                 "$ref": "closure.json"
             }

--- a/zmsentities/schema/scope.json
+++ b/zmsentities/schema/scope.json
@@ -134,7 +134,7 @@
             }
         },
         "closure": {
-            "type": "array",
+            "type": "object",
             "items": {
                 "$ref": "closure.json"
             }

--- a/zmsentities/src/Zmsentities/Closure.php
+++ b/zmsentities/src/Zmsentities/Closure.php
@@ -8,6 +8,15 @@ class Closure extends Schema\Entity
 
     public static $schema = "closure.json";
 
+    public function getDefaults()
+    {
+        return [
+            'id' => 0,
+            'Datum' => 1447924981,
+            'lastChange' => 1447924981
+        ];
+    }
+
     public function setTimestampFromDateformat($fromFormat = 'd.m.Y')
     {
         $dateTime = \DateTimeImmutable::createFromFormat($fromFormat, $this->date, new \DateTimeZone('UTC'));


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for new optional fields "year," "month," and "day" in closure data, allowing more detailed date information.
	- Introduced a method to provide default values for closure properties.

- **Improvements**
	- Enhanced flexibility by allowing numeric fields such as "id," "year," "month," and "day" to accept both numbers and numeric strings.
	- Updated closure data structure to use a single closure object with expanded property options instead of an array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->