### PR TITLE
fix(ZMSKVR-389): fix typing subRequestCounts ids as int, fix trailing slash, add 404 catch all to zmscitizenapi and add an exception to or ExceptionService

### DIFF
--- a/zmscitizenapi/routing.php
+++ b/zmscitizenapi/routing.php
@@ -53,6 +53,13 @@ createLanguageRoutes(
     "ServicesListController",
     "get"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/services',
+    '\BO\Zmscitizenapi\Controllers\Service\ServicesListController',
+    "ServicesListController",
+    "get"
+);
 
 /**
  * @swagger
@@ -75,6 +82,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/scopes/',
+    '\BO\Zmscitizenapi\Controllers\Scope\ScopesListController',
+    "ScopesListController",
+    "get"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/scopes',
     '\BO\Zmscitizenapi\Controllers\Scope\ScopesListController',
     "ScopesListController",
     "get"
@@ -105,6 +119,13 @@ createLanguageRoutes(
     "OfficesListController",
     "get"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/offices',
+    '\BO\Zmscitizenapi\Controllers\Office\OfficesListController',
+    "OfficesListController",
+    "get"
+);
 
 /**
  * @swagger
@@ -127,6 +148,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/offices-and-services/',
+    '\BO\Zmscitizenapi\Controllers\Office\OfficesServicesRelationsController',
+    "OfficesServicesRelationsController",
+    "get"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/offices-and-services',
     '\BO\Zmscitizenapi\Controllers\Office\OfficesServicesRelationsController',
     "OfficesServicesRelationsController",
     "get"
@@ -165,6 +193,13 @@ createLanguageRoutes(
     "ScopeByIdController",
     "get"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/scope-by-id',
+    '\BO\Zmscitizenapi\Controllers\Scope\ScopeByIdController',
+    "ScopeByIdController",
+    "get"
+);
 
 /**
  * @swagger
@@ -197,6 +232,13 @@ createLanguageRoutes(
     "ServiceListByOfficeController",
     "get"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/services-by-office',
+    '\BO\Zmscitizenapi\Controllers\Service\ServiceListByOfficeController',
+    "ServiceListByOfficeController",
+    "get"
+);
 
 /**
  * @swagger
@@ -225,6 +267,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/offices-by-service/',
+    '\BO\Zmscitizenapi\Controllers\Office\OfficeListByServiceController',
+    "OfficeListByServiceController",
+    "get"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/offices-by-service',
     '\BO\Zmscitizenapi\Controllers\Office\OfficeListByServiceController',
     "OfficeListByServiceController",
     "get"
@@ -262,6 +311,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/available-days/',
+    '\BO\Zmscitizenapi\Controllers\Availability\AvailableDaysListController',
+    "AvailableDaysListController",
+    "get"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/available-days',
     '\BO\Zmscitizenapi\Controllers\Availability\AvailableDaysListController',
     "AvailableDaysListController",
     "get"
@@ -308,6 +364,13 @@ createLanguageRoutes(
     "AvailableAppointmentsListController",
     "get"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/available-appointments',
+    '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListController',
+    "AvailableAppointmentsListController",
+    "get"
+);
 
 /**
  * @swagger
@@ -346,6 +409,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/available-appointments-by-office/',
+    '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListByOfficeController',
+    "AvailableAppointmentsListByOfficeController",
+    "get"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/available-appointments-by-office',
     '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListByOfficeController',
     "AvailableAppointmentsListByOfficeController",
     "get"
@@ -407,6 +477,13 @@ createLanguageRoutes(
     "AppointmentByIdController",
     "get"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/appointment',
+    '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentByIdController',
+    "AppointmentByIdController",
+    "get"
+);
 
 /**
  * @swagger
@@ -429,6 +506,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/captcha-details/',
+    '\BO\Zmscitizenapi\Controllers\Security\CaptchaController',
+    "CaptchaController",
+    "get"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/captcha-details',
     '\BO\Zmscitizenapi\Controllers\Security\CaptchaController',
     "CaptchaController",
     "get"
@@ -486,6 +570,13 @@ createLanguageRoutes(
     "AppointmentReserveController",
     "post"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/reserve-appointment',
+    '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentReserveController',
+    "AppointmentReserveController",
+    "post"
+);
 
 /**
  * @swagger
@@ -535,6 +626,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/update-appointment/',
+    '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentUpdateController',
+    "AppointmentUpdateController",
+    "post"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/update-appointment',
     '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentUpdateController',
     "AppointmentUpdateController",
     "post"
@@ -592,6 +690,13 @@ createLanguageRoutes(
     "AppointmentConfirmController",
     "post"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/confirm-appointment',
+    '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentConfirmController',
+    "AppointmentConfirmController",
+    "post"
+);
 
 /**
  * @swagger
@@ -645,6 +750,13 @@ createLanguageRoutes(
     "AppointmentPreconfirmController",
     "post"
 );
+createLanguageRoutes(
+    \App::$slim,
+    '/preconfirm-appointment',
+    '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentPreconfirmController',
+    "AppointmentPreconfirmController",
+    "post"
+);
 
 /**
  * @swagger
@@ -694,6 +806,13 @@ createLanguageRoutes(
 createLanguageRoutes(
     \App::$slim,
     '/cancel-appointment/',
+    '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentCancelController',
+    "AppointmentCancelController",
+    "post"
+);
+createLanguageRoutes(
+    \App::$slim,
+    '/cancel-appointment',
     '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentCancelController',
     "AppointmentCancelController",
     "post"

--- a/zmscitizenapi/routing.php
+++ b/zmscitizenapi/routing.php
@@ -817,3 +817,15 @@ createLanguageRoutes(
     "AppointmentCancelController",
     "post"
 );
+
+// Catch-all route for 404 errors
+\App::$slim->map(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'], '/{routes:.+}', function ($request, $response) {
+    $error = \BO\Zmscitizenapi\Localization\ErrorMessages::get('notFound');
+    $response = $response->withStatus($error['statusCode']);
+    $response->getBody()->write(json_encode([
+        'errors' => [
+            $error
+        ]
+    ]));
+    return $response->withHeader('Content-Type', 'application/json');
+})->setName('notFound');

--- a/zmscitizenapi/src/Zmscitizenapi/Controllers/Appointment/AppointmentByIdController.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Controllers/Appointment/AppointmentByIdController.php
@@ -19,7 +19,6 @@ class AppointmentByIdController extends BaseController
         $this->service = new AppointmentByIdService();
     }
 
-    // AppointmentByIdController.php
     public function readResponse(RequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
     {
 

--- a/zmscitizenapi/src/Zmscitizenapi/Controllers/Appointment/AppointmentCancelController.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Controllers/Appointment/AppointmentCancelController.php
@@ -27,7 +27,7 @@ class AppointmentCancelController extends BaseController
         }
 
         $result = $this->service->processCancel($request->getParsedBody());
-// Handle array errors from validation
+
         if (is_array($result) && isset($result['errors'])) {
             foreach ($result['errors'] as &$error) {
                 if (isset($error['errorCode'])) {
@@ -37,7 +37,6 @@ class AppointmentCancelController extends BaseController
             return $this->createJsonResponse($response, $result, ErrorMessages::getHighestStatusCode($result['errors']));
         }
 
-        // Handle successful response
         return $this->createJsonResponse($response, $result->toArray(), 200);
     }
 }

--- a/zmscitizenapi/src/Zmscitizenapi/Controllers/Appointment/AppointmentReserveController.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Controllers/Appointment/AppointmentReserveController.php
@@ -27,9 +27,7 @@ class AppointmentReserveController extends BaseController
         }
 
         $result = $this->service->processReservation($request->getParsedBody());
-// Handle array errors from validation
         if (is_array($result) && isset($result['errors'])) {
-// Translate each error message
             foreach ($result['errors'] as &$error) {
                 if (isset($error['errorCode'])) {
                     $error = ErrorMessages::get($error['errorCode'], $this->language);
@@ -38,7 +36,6 @@ class AppointmentReserveController extends BaseController
             return $this->createJsonResponse($response, $result, ErrorMessages::getHighestStatusCode($result['errors']));
         }
 
-        // Handle successful response
         return $this->createJsonResponse($response, $result->toArray(), 200);
     }
 }

--- a/zmscitizenapi/src/Zmscitizenapi/Localization/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Localization/ErrorMessages.php
@@ -35,6 +35,11 @@ class ErrorMessages
             'statusCode' => self::HTTP_NOT_IMPLEMENTED,
             'errorMessage' => 'Feature not implemented yet.',
         ],
+        'notFound' => [
+            'errorCode' => 'notFound',
+            'statusCode' => self::HTTP_NOT_FOUND,
+            'errorMessage' => 'Endpoint not found.',
+        ],
         'invalidRequest' => [
             'errorCode' => 'invalidRequest',
             'statusCode' => self::HTTP_BAD_REQUEST,
@@ -333,6 +338,11 @@ class ErrorMessages
             'statusCode' => self::HTTP_NOT_IMPLEMENTED,
             'errorMessage' => 'Funktion ist noch nicht implementiert.',
         ],
+        'notFound' => [
+            'errorCode' => 'notFound',
+            'statusCode' => self::HTTP_NOT_FOUND,
+            'errorMessage' => 'Endpunkt nicht gefunden.',
+        ],
         'invalidRequest' => [
             'errorCode' => 'invalidRequest',
             'statusCode' => self::HTTP_BAD_REQUEST,
@@ -629,6 +639,11 @@ class ErrorMessages
             'errorCode' => 'notImplemented',
             'statusCode' => self::HTTP_NOT_IMPLEMENTED,
             'errorMessage' => 'Функцію ще не реалізовано.',
+        ],
+        'notFound' => [
+            'errorCode' => 'notFound',
+            'statusCode' => self::HTTP_NOT_FOUND,
+            'errorMessage' => 'Кінцеву точку не знайдено.',
         ],
         'invalidRequest' => [
             'errorCode' => 'invalidRequest',

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -33,7 +33,18 @@ class ExceptionService
         $exceptionName = json_decode(json_encode($e), true)['template'] ?? null;
         $error = null;
 
+        error_log("******");
+        error_log(json_encode($exceptionName));
+        error_log("******");
+        exit();
+
         switch ($exceptionName) {
+            // Zmsslim exception
+            case 'Slim\\Exception\\HttpNotFoundException':
+                $error = self::getError('notFound');
+
+                break;
+
             // ZmsClient exception
             case 'BO\\Zmsclient\\Exception':
                 $error = self::getError('zmsClientCommunicationError');

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -131,7 +131,7 @@ class ExceptionService
                 break;
             case 'BO\\Zmsapi\\Exception\\Request\\RequestNotFound':
                 $error = self::getError('requestNotFound');
-
+                // Fall-through intentional - same error handling for both RequestNotFound exceptions
             case 'BO\\Zmsdb\\Exception\\Request\\RequestNotFound':
                 $error = self::getError('requestNotFound');
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -132,6 +132,9 @@ class ExceptionService
             case 'BO\\Zmsapi\\Exception\\Request\\RequestNotFound':
                 $error = self::getError('requestNotFound');
 
+            case 'BO\\Zmsdb\\Exception\\Request\\RequestNotFound':
+                $error = self::getError('requestNotFound');
+
                 break;
             case 'BO\\Zmsapi\\Exception\\Scope\\ScopeNotFound':
                 $error = self::getError('scopeNotFound');

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -243,7 +243,7 @@ class MapperService
                     } else {
                         if (!isset($subRequestCounts[$request->id])) {
                             $subRequestCounts[$request->id] = [
-                                'id' => $request->id,
+                                'id' => (int) $request->id,
                                 'count' => 0,
                             ];
                         }

--- a/zmsslim/src/Slim/Middleware/TrailingSlash.php
+++ b/zmsslim/src/Slim/Middleware/TrailingSlash.php
@@ -16,11 +16,11 @@ class TrailingSlash
     {
         $uri = $request->getUri();
         $path = $uri->getPath();
-        
+
         if (strpos($path, '/api/') !== false) {
             return $next->handle($request);
         }
-        
+
         if (substr($path, -1) !== '/' && !pathinfo($path, PATHINFO_EXTENSION)) {
             // permanently redirect paths without a trailing slash
             // to their trailing counterpart

--- a/zmsslim/src/Slim/Middleware/TrailingSlash.php
+++ b/zmsslim/src/Slim/Middleware/TrailingSlash.php
@@ -16,6 +16,11 @@ class TrailingSlash
     {
         $uri = $request->getUri();
         $path = $uri->getPath();
+        
+        if (strpos($path, '/api/') !== false) {
+            return $next->handle($request);
+        }
+        
         if (substr($path, -1) !== '/' && !pathinfo($path, PATHINFO_EXTENSION)) {
             // permanently redirect paths without a trailing slash
             // to their trailing counterpart


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API endpoints now support both trailing and non-trailing slash versions, improving flexibility when accessing services.
  - Added a catch-all route returning a localized 404 JSON error for unmatched API requests.

- **Bug Fixes**
  - Middleware updated to prevent automatic trailing slash redirects for API routes, ensuring consistent API behavior.
  - Improved error handling by unifying responses for similar request-not-found exceptions.
  - Ensured consistent data types by explicitly casting request IDs to integers in specific responses.

- **Style**
  - Removed several non-essential comment lines for cleaner code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->