### PR TITLE
fix(ZMS): closure schema error

### DIFF
--- a/zmsentities/schema/closure.json
+++ b/zmsentities/schema/closure.json
@@ -2,12 +2,8 @@
     "type": "object",
     "description": "A closure is a free day where a department and its scopes are closed.",
     "example": {
-        "id": 1234,
-        "Datum": 1447924981
+        "id": 1234
     },
-    "required": [
-        "Datum"
-    ],
     "additionalProperties": false,
     "properties": {
         "id": {
@@ -20,10 +16,6 @@
                     "pattern": "^[0-9]+$"
                 }
             ]
-        },
-        "Datum": {
-            "type": "number",
-            "description": "unix timestamp"
         },
         "lastChange": {
             "type": "number",

--- a/zmsentities/schema/dereferenced/closure.json
+++ b/zmsentities/schema/dereferenced/closure.json
@@ -2,12 +2,8 @@
     "type": "object",
     "description": "A closure is a free day where a department and its scopes are closed.",
     "example": {
-        "id": 1234,
-        "Datum": 1447924981
+        "id": 1234
     },
-    "required": [
-        "Datum"
-    ],
     "additionalProperties": false,
     "properties": {
         "id": {
@@ -20,10 +16,6 @@
                     "pattern": "^[0-9]+$"
                 }
             ]
-        },
-        "Datum": {
-            "type": "number",
-            "description": "unix timestamp"
         },
         "lastChange": {
             "type": "number",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "Datum" field from closure objects, including from required properties and examples. Only "id" is now required; "lastChange," "year," "month," and "day" remain optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->