### PR TITLE
fix(ZMS): closure schema error

### DIFF
--- a/zmsentities/schema/closure.json
+++ b/zmsentities/schema/closure.json
@@ -2,12 +2,8 @@
     "type": "object",
     "description": "A closure is a free day where a department and its scopes are closed.",
     "example": {
-        "id": 1234,
-        "Datum": 1447924981
+        "id": 1234
     },
-    "required": [
-        "Datum"
-    ],
     "additionalProperties": false,
     "properties": {
         "id": {
@@ -20,10 +16,6 @@
                     "pattern": "^[0-9]+$"
                 }
             ]
-        },
-        "Datum": {
-            "type": "number",
-            "description": "unix timestamp"
         },
         "lastChange": {
             "type": "number",

--- a/zmsentities/schema/closure.json
+++ b/zmsentities/schema/closure.json
@@ -4,7 +4,7 @@
     "example": {
         "id": 1234
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
         "id": {
             "oneOf": [

--- a/zmsentities/schema/dereferenced/closure.json
+++ b/zmsentities/schema/dereferenced/closure.json
@@ -2,12 +2,8 @@
     "type": "object",
     "description": "A closure is a free day where a department and its scopes are closed.",
     "example": {
-        "id": 1234,
-        "Datum": 1447924981
+        "id": 1234
     },
-    "required": [
-        "Datum"
-    ],
     "additionalProperties": false,
     "properties": {
         "id": {
@@ -20,10 +16,6 @@
                     "pattern": "^[0-9]+$"
                 }
             ]
-        },
-        "Datum": {
-            "type": "number",
-            "description": "unix timestamp"
         },
         "lastChange": {
             "type": "number",

--- a/zmsentities/schema/dereferenced/closure.json
+++ b/zmsentities/schema/dereferenced/closure.json
@@ -4,7 +4,7 @@
     "example": {
         "id": 1234
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
         "id": {
             "oneOf": [

--- a/zmsentities/schema/dereferenced/scope.json
+++ b/zmsentities/schema/dereferenced/scope.json
@@ -235,13 +235,9 @@
             "type": "object",
             "description": "A closure is a free day where a department and its scopes are closed.",
             "example": {
-                "id" : 1234,
-                "Datum": 1447924981
+                "id" : 1234
             },
-            "required": [
-                "Datum"
-            ],
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "id": {
                     "oneOf": [
@@ -253,10 +249,6 @@
                             "pattern": "^[0-9]+$"
                         }
                     ]
-                },
-                "Datum": {
-                    "type": "number",
-                    "description": "unix timestamp"
                 },
                 "lastChange": {
                     "type": "number",

--- a/zmsentities/src/Zmsentities/Closure.php
+++ b/zmsentities/src/Zmsentities/Closure.php
@@ -12,7 +12,6 @@ class Closure extends Schema\Entity
     {
         return [
             'id' => 0,
-            'Datum' => 1447924981,
             'lastChange' => 1447924981
         ];
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The closure object now allows additional, unspecified properties beyond those explicitly defined.

- **Refactor**
  - Removed the "Datum" (timestamp) field from closure objects; it is no longer required or included by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->