### PR TITLE
Hotfix zmskvr 445 468 zmscitizenapi appointment duration and office service validation for available days appointments

### DIFF
--- a/zmscitizenapi/bootstrap.php
+++ b/zmscitizenapi/bootstrap.php
@@ -44,7 +44,7 @@ App::$slim->add(new \BO\Zmscitizenapi\Middleware\LanguageMiddleware($logger));
 App::$slim->add(new \BO\Zmscitizenapi\Middleware\RequestLoggingMiddleware($logger));
 App::$slim->add(new \BO\Zmscitizenapi\Middleware\SecurityHeadersMiddleware($logger));
 // Todo: Enable CORS when the old frontend is replaced with Zmscitizenview
-//App::$slim->add(new \BO\Zmscitizenapi\Middleware\CorsMiddleware($logger));
+App::$slim->add(new \BO\Zmscitizenapi\Middleware\CorsMiddleware($logger));
 // Todo: Implement CSRF with Zmscitizenview
 //App::$slim->add(new \BO\Zmscitizenapi\Middleware\CsrfMiddleware($logger));
 App::$slim->add(new \BO\Zmscitizenapi\Middleware\RateLimitingMiddleware($cache, $logger));

--- a/zmscitizenapi/bootstrap.php
+++ b/zmscitizenapi/bootstrap.php
@@ -44,7 +44,7 @@ App::$slim->add(new \BO\Zmscitizenapi\Middleware\LanguageMiddleware($logger));
 App::$slim->add(new \BO\Zmscitizenapi\Middleware\RequestLoggingMiddleware($logger));
 App::$slim->add(new \BO\Zmscitizenapi\Middleware\SecurityHeadersMiddleware($logger));
 // Todo: Enable CORS when the old frontend is replaced with Zmscitizenview
-App::$slim->add(new \BO\Zmscitizenapi\Middleware\CorsMiddleware($logger));
+//App::$slim->add(new \BO\Zmscitizenapi\Middleware\CorsMiddleware($logger));
 // Todo: Implement CSRF with Zmscitizenview
 //App::$slim->add(new \BO\Zmscitizenapi\Middleware\CsrfMiddleware($logger));
 App::$slim->add(new \BO\Zmscitizenapi\Middleware\RateLimitingMiddleware($cache, $logger));

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
@@ -23,6 +23,7 @@ class Office extends Entity implements JsonSerializable
     public ?array $geo = null;
     public ?array $disabledByServices = null;
     public ?ThinnedScope $scope = null;
+    public ?string $maxSlotsPerAppointment = null;
 
     public function __construct(
         int $id,
@@ -35,7 +36,8 @@ class Office extends Entity implements JsonSerializable
         ?int $slotTimeInMinutes = null,
         ?array $geo = null,
         ?array $disabledByServices = [],
-        ?ThinnedScope $scope = null
+        ?ThinnedScope $scope = null,
+        ?string $maxSlotsPerAppointment = null
     ) {
         $this->id = $id;
         $this->name = $name;
@@ -46,8 +48,9 @@ class Office extends Entity implements JsonSerializable
         $this->organizationUnit = $organizationUnit;
         $this->slotTimeInMinutes = $slotTimeInMinutes;
         $this->geo = $geo;
-        $this->scope = $scope;
         $this->disabledByServices = $disabledByServices;
+        $this->scope = $scope;
+        $this->maxSlotsPerAppointment = $maxSlotsPerAppointment;
         $this->ensureValid();
     }
 
@@ -77,6 +80,7 @@ class Office extends Entity implements JsonSerializable
             'geo' => $this->geo,
             'disabledByServices' => $this->disabledByServices,
             'scope' => $this->scope?->toArray(),
+            'maxSlotsPerAppointment' => $this->maxSlotsPerAppointment,
         ];
     }
 

--- a/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedScope.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedScope.php
@@ -36,7 +36,10 @@ class ThinnedScope extends Entity implements JsonSerializable
     public ?bool $captchaActivatedRequired;
     /** @var string|null */
     public ?string $displayInfo;
-    public function __construct(int $id = 0, ?ThinnedProvider $provider = null, ?string $shortName = null, ?string $emailFrom = null, ?bool $emailRequired = null, ?bool $telephoneActivated = null, ?bool $telephoneRequired = null, ?bool $customTextfieldActivated = null, ?bool $customTextfieldRequired = null, ?string $customTextfieldLabel = null, ?bool $captchaActivatedRequired = null, ?string $displayInfo = null)
+    /** @var int|null */
+    public ?int $slotsPerAppointment;
+
+    public function __construct(int $id = 0, ?ThinnedProvider $provider = null, ?string $shortName = null, ?string $emailFrom = null, ?bool $emailRequired = null, ?bool $telephoneActivated = null, ?bool $telephoneRequired = null, ?bool $customTextfieldActivated = null, ?bool $customTextfieldRequired = null, ?string $customTextfieldLabel = null, ?bool $captchaActivatedRequired = null, ?string $displayInfo = null, ?int $slotsPerAppointment = null)
     {
         $this->id = $id;
         $this->provider = $provider;
@@ -50,6 +53,7 @@ class ThinnedScope extends Entity implements JsonSerializable
         $this->customTextfieldLabel = $customTextfieldLabel;
         $this->captchaActivatedRequired = $captchaActivatedRequired;
         $this->displayInfo = $displayInfo;
+        $this->slotsPerAppointment = $slotsPerAppointment;
         $this->ensureValid();
     }
 
@@ -115,6 +119,11 @@ class ThinnedScope extends Entity implements JsonSerializable
         return $this->displayInfo;
     }
 
+    public function getSlotsPerAppointment(): ?int
+    {
+        return $this->slotsPerAppointment;
+    }
+
     public function toArray(): array
     {
         return [
@@ -130,6 +139,7 @@ class ThinnedScope extends Entity implements JsonSerializable
             'customTextfieldLabel' => $this->customTextfieldLabel,
             'captchaActivatedRequired' => $this->captchaActivatedRequired,
             'displayInfo' => $this->displayInfo,
+            'slotsPerAppointment' => $this->slotsPerAppointment,
         ];
     }
 

--- a/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedScope.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedScope.php
@@ -36,10 +36,10 @@ class ThinnedScope extends Entity implements JsonSerializable
     public ?bool $captchaActivatedRequired;
     /** @var string|null */
     public ?string $displayInfo;
-    /** @var int|null */
-    public ?int $slotsPerAppointment;
+    /** @var string|null */
+    public ?string $slotsPerAppointment;
 
-    public function __construct(int $id = 0, ?ThinnedProvider $provider = null, ?string $shortName = null, ?string $emailFrom = null, ?bool $emailRequired = null, ?bool $telephoneActivated = null, ?bool $telephoneRequired = null, ?bool $customTextfieldActivated = null, ?bool $customTextfieldRequired = null, ?string $customTextfieldLabel = null, ?bool $captchaActivatedRequired = null, ?string $displayInfo = null, ?int $slotsPerAppointment = null)
+    public function __construct(int $id = 0, ?ThinnedProvider $provider = null, ?string $shortName = null, ?string $emailFrom = null, ?bool $emailRequired = null, ?bool $telephoneActivated = null, ?bool $telephoneRequired = null, ?bool $customTextfieldActivated = null, ?bool $customTextfieldRequired = null, ?string $customTextfieldLabel = null, ?bool $captchaActivatedRequired = null, ?string $displayInfo = null, ?string $slotsPerAppointment = null)
     {
         $this->id = $id;
         $this->provider = $provider;
@@ -119,7 +119,7 @@ class ThinnedScope extends Entity implements JsonSerializable
         return $this->displayInfo;
     }
 
-    public function getSlotsPerAppointment(): ?int
+    public function getSlotsPerAppointment(): ?string
     {
         return $this->slotsPerAppointment;
     }

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableAppointmentsListService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableAppointmentsListService.php
@@ -41,6 +41,16 @@ class AvailableAppointmentsListService
             return $errors;
         }
 
+        foreach ($clientData->officeIds as $officeId) {
+            $errors = ValidationService::validateServiceLocationCombination(
+                (int) $officeId,
+                array_map('intval', $clientData->serviceIds)
+            );
+            if (!empty($errors['errors'])) {
+                return $errors;
+            }
+        }
+
         return $this->getAvailableAppointments($clientData);
     }
 
@@ -88,6 +98,17 @@ class AvailableAppointmentsListService
         $errors = $this->validateClientData($clientData);
         if (!empty($errors['errors'])) {
             return $errors;
+        }
+
+        // Validate service-location combinations for each office
+        foreach ($clientData->officeIds as $officeId) {
+            $errors = ValidationService::validateServiceLocationCombination(
+                (int) $officeId,
+                array_map('intval', $clientData->serviceIds)
+            );
+            if (!empty($errors['errors'])) {
+                return $errors;
+            }
         }
 
         return $this->getAvailableAppointments($clientData, true);

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableAppointmentsListService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableAppointmentsListService.php
@@ -12,6 +12,8 @@ use BO\Zmscitizenapi\Services\Core\ZmsApiFacadeService;
 
 class AvailableAppointmentsListService
 {
+    use ServiceLocationValidationTrait;
+
     private TokenValidationService $tokenValidator;
     private ZmsApiFacadeService $zmsApiFacadeService;
 
@@ -41,14 +43,9 @@ class AvailableAppointmentsListService
             return $errors;
         }
 
-        foreach ($clientData->officeIds as $officeId) {
-            $errors = ValidationService::validateServiceLocationCombination(
-                (int) $officeId,
-                array_map('intval', $clientData->serviceIds)
-            );
-            if (!empty($errors['errors'])) {
-                return $errors;
-            }
+        $errors = $this->validateServiceLocations($clientData->officeIds, $clientData->serviceIds);
+        if ($errors !== null) {
+            return $errors;
         }
 
         return $this->getAvailableAppointments($clientData);
@@ -100,15 +97,9 @@ class AvailableAppointmentsListService
             return $errors;
         }
 
-        // Validate service-location combinations for each office
-        foreach ($clientData->officeIds as $officeId) {
-            $errors = ValidationService::validateServiceLocationCombination(
-                (int) $officeId,
-                array_map('intval', $clientData->serviceIds)
-            );
-            if (!empty($errors['errors'])) {
-                return $errors;
-            }
+        $errors = $this->validateServiceLocations($clientData->officeIds, $clientData->serviceIds);
+        if ($errors !== null) {
+            return $errors;
         }
 
         return $this->getAvailableAppointments($clientData, true);

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableDaysListService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableDaysListService.php
@@ -11,6 +11,8 @@ use BO\Zmscitizenapi\Services\Core\ZmsApiFacadeService;
 
 class AvailableDaysListService
 {
+    use ServiceLocationValidationTrait;
+
     private TokenValidationService $tokenValidator;
     private ZmsApiFacadeService $zmsApiFacadeService;
 
@@ -41,14 +43,9 @@ class AvailableDaysListService
             return $errors;
         }
 
-        foreach ($clientData->officeIds as $officeId) {
-            $errors = ValidationService::validateServiceLocationCombination(
-                (int) $officeId,
-                array_map('intval', $clientData->serviceIds)
-            );
-            if (!empty($errors['errors'])) {
-                return $errors;
-            }
+        $errors = $this->validateServiceLocations($clientData->officeIds, $clientData->serviceIds);
+        if ($errors !== null) {
+            return $errors;
         }
 
         return $this->getAvailableDays($clientData);

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableDaysListService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Availability/AvailableDaysListService.php
@@ -41,6 +41,16 @@ class AvailableDaysListService
             return $errors;
         }
 
+        foreach ($clientData->officeIds as $officeId) {
+            $errors = ValidationService::validateServiceLocationCombination(
+                (int) $officeId,
+                array_map('intval', $clientData->serviceIds)
+            );
+            if (!empty($errors['errors'])) {
+                return $errors;
+            }
+        }
+
         return $this->getAvailableDays($clientData);
     }
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Availability/ServiceLocationValidationTrait.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Availability/ServiceLocationValidationTrait.php
@@ -19,7 +19,7 @@ trait ServiceLocationValidationTrait
                 return $errors;
             }
         }
-        
+
         return null;
     }
-} 
+}

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Availability/ServiceLocationValidationTrait.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Availability/ServiceLocationValidationTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenapi\Services\Availability;
+
+use BO\Zmscitizenapi\Services\Core\ValidationService;
+
+trait ServiceLocationValidationTrait
+{
+    private function validateServiceLocations(array $officeIds, array $serviceIds): ?array
+    {
+        foreach ($officeIds as $officeId) {
+            $errors = ValidationService::validateServiceLocationCombination(
+                (int) $officeId,
+                array_map('intval', $serviceIds)
+            );
+            if (!empty($errors['errors'])) {
+                return $errors;
+            }
+        }
+        
+        return null;
+    }
+} 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -85,16 +85,17 @@ class MapperService
                 scope: isset($providerScope) && !isset($providerScope['errors']) ? new ThinnedScope(
                     id: isset($providerScope->id) ? (int) $providerScope->id : 0,
                     provider: isset($providerScope->provider) ? $providerScope->provider : null,
-                    shortName: isset($providerScope->shortName) ? $providerScope->shortName : null,
-                    emailFrom: isset($providerScope->emailFrom) ? $providerScope->emailFrom : null,
+                    shortName: isset($providerScope->shortName) ? (string) $providerScope->shortName : null,
+                    emailFrom: isset($providerScope->emailFrom) ? (string) $providerScope->emailFrom : null,
                     emailRequired: isset($providerScope->emailRequired) ? (bool) $providerScope->emailRequired : null,
                     telephoneActivated: isset($providerScope->telephoneActivated) ? (bool) $providerScope->telephoneActivated : null,
                     telephoneRequired: isset($providerScope->telephoneRequired) ? (bool) $providerScope->telephoneRequired : null,
                     customTextfieldActivated: isset($providerScope->customTextfieldActivated) ? (bool) $providerScope->customTextfieldActivated : null,
                     customTextfieldRequired: isset($providerScope->customTextfieldRequired) ? (bool) $providerScope->customTextfieldRequired : null,
-                    customTextfieldLabel: isset($providerScope->customTextfieldLabel) ? $providerScope->customTextfieldLabel : null,
+                    customTextfieldLabel: isset($providerScope->customTextfieldLabel) ? (string) $providerScope->customTextfieldLabel : null,
                     captchaActivatedRequired: isset($providerScope->captchaActivatedRequired) ? (bool) $providerScope->captchaActivatedRequired : null,
-                    displayInfo: isset($providerScope->displayInfo) ? $providerScope->displayInfo : null
+                    displayInfo: isset($providerScope->displayInfo) ? (string) $providerScope->displayInfo : null,
+                    slotsPerAppointment: isset($providerScope->slotsPerAppointment) ? (int) $providerScope->slotsPerAppointment : null
                 ) : null
             );
         }
@@ -206,16 +207,17 @@ class MapperService
         return new ThinnedScope(
             id: (int) ($scope->id ?? 0),
             provider: $thinnedProvider,
-            shortName: $scope->shortName ?? null,
+            shortName: isset($scope->shortName) ? (string) $scope->shortName : null,
             emailFrom: (string) $scope->getEmailFrom() ?? null,
             emailRequired: isset($scope->data['emailRequired']) ? (bool) $scope->data['emailRequired'] : null,
             telephoneActivated: isset($scope->data['telephoneActivated']) ? (bool) $scope->data['telephoneActivated'] : null,
             telephoneRequired: isset($scope->data['telephoneRequired']) ? (bool) $scope->data['telephoneRequired'] : null,
             customTextfieldActivated: isset($scope->data['customTextfieldActivated']) ? (bool) $scope->data['customTextfieldActivated'] : null,
             customTextfieldRequired: isset($scope->data['customTextfieldRequired']) ? (bool) $scope->data['customTextfieldRequired'] : null,
-            customTextfieldLabel: $scope->data['customTextfieldLabel'] ?? null,
+            customTextfieldLabel: isset($scope->data['customTextfieldLabel']) ? (string) $scope->data['customTextfieldLabel'] : null,
             captchaActivatedRequired: isset($scope->data['captchaActivatedRequired']) ? (bool) $scope->data['captchaActivatedRequired'] : null,
-            displayInfo: $scope->data['displayInfo'] ?? null
+            displayInfo: isset($scope->data['displayInfo']) ? (string) $scope->data['displayInfo'] : null,
+            slotsPerAppointment: isset($scope->data['slotsPerAppointment']) ? (int) $scope->data['slotsPerAppointment'] : null
         );
     }
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -95,8 +95,9 @@ class MapperService
                     customTextfieldLabel: isset($providerScope->customTextfieldLabel) ? (string) $providerScope->customTextfieldLabel : null,
                     captchaActivatedRequired: isset($providerScope->captchaActivatedRequired) ? (bool) $providerScope->captchaActivatedRequired : null,
                     displayInfo: isset($providerScope->displayInfo) ? (string) $providerScope->displayInfo : null,
-                    slotsPerAppointment: isset($providerScope->slotsPerAppointment) ? (int) $providerScope->slotsPerAppointment : null
-                ) : null
+                    slotsPerAppointment: isset($providerScope->slotsPerAppointment) ? ((string) $providerScope->slotsPerAppointment === '' ? null : (string) $providerScope->slotsPerAppointment) : null
+                ) : null,
+                maxSlotsPerAppointment: isset($providerScope) && !isset($providerScope['errors']) && isset($providerScope->slotsPerAppointment) ? ((string) $providerScope->slotsPerAppointment === '' ? null : (string) $providerScope->slotsPerAppointment) : null
             );
         }
 
@@ -217,7 +218,7 @@ class MapperService
             customTextfieldLabel: isset($scope->data['customTextfieldLabel']) ? (string) $scope->data['customTextfieldLabel'] : null,
             captchaActivatedRequired: isset($scope->data['captchaActivatedRequired']) ? (bool) $scope->data['captchaActivatedRequired'] : null,
             displayInfo: isset($scope->data['displayInfo']) ? (string) $scope->data['displayInfo'] : null,
-            slotsPerAppointment: isset($scope->data['slotsPerAppointment']) ? (int) $scope->data['slotsPerAppointment'] : null
+            slotsPerAppointment: isset($scope->data['slotsPerAppointment']) ? ((string) $scope->data['slotsPerAppointment'] === '' ? null : (string) $scope->data['slotsPerAppointment']) : null
         );
     }
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -110,8 +110,9 @@ class ZmsApiFacadeService
                     customTextfieldLabel: $matchingScope->getCustomTextfieldLabel(),
                     captchaActivatedRequired: (bool) $matchingScope->getCaptchaActivatedRequired(),
                     displayInfo: $matchingScope->getDisplayInfo(),
-                    slotsPerAppointment: (int) $matchingScope->getSlotsPerAppointment()
-                ) : null
+                    slotsPerAppointment: ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment())
+                ) : null,
+                maxSlotsPerAppointment: $matchingScope ? ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment()) : null
             );
         }
 
@@ -159,7 +160,7 @@ class ZmsApiFacadeService
                     customTextfieldLabel: $matchingScope->getCustomTextfieldLabel(),
                     captchaActivatedRequired: (bool) $matchingScope->getCaptchaActivatedRequired(),
                     displayInfo: $matchingScope->getDisplayInfo(),
-                    slotsPerAppointment: (int) $matchingScope->getSlotsPerAppointment()
+                    slotsPerAppointment: ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment())
                 );
             }
         }
@@ -267,7 +268,7 @@ class ZmsApiFacadeService
             'customTextfieldLabel' => $matchingScope->getCustomTextfieldLabel() ?? null,
             'captchaActivatedRequired' => (bool) $matchingScope->getCaptchaActivatedRequired() ?? null,
             'displayInfo' => $matchingScope->getDisplayInfo() ?? null,
-            'slotsPerAppointment' => (int) $matchingScope->getSlotsPerAppointment() ?? null
+            'slotsPerAppointment' => ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment()) ?? null
         ];
         return new ThinnedScope(
             id: (int) $result['id'],
@@ -331,7 +332,19 @@ class ZmsApiFacadeService
                     $scope = $scopeData;
                 }
 
-                $offices[] = new Office(id: (int) $provider->id, name: $provider->name, showAlternativeLocations: $provider->data['showAlternativeLocations'] ?? null, displayNameAlternatives: $provider->data['displayNameAlternatives'] ?? [], organization: $provider->data['organization'] ?? null, organizationUnit: $provider->data['organizationUnit'] ?? null, slotTimeInMinutes: $provider->data['slotTimeInMinutes'] ?? null, address: $provider->address ?? null, geo: $provider->geo ?? null, scope: $scope);
+                $offices[] = new Office(
+                    id: (int) $provider->id,
+                    name: $provider->name,
+                    showAlternativeLocations: $provider->data['showAlternativeLocations'] ?? null,
+                    displayNameAlternatives: $provider->data['displayNameAlternatives'] ?? [],
+                    organization: $provider->data['organization'] ?? null,
+                    organizationUnit: $provider->data['organizationUnit'] ?? null,
+                    slotTimeInMinutes: $provider->data['slotTimeInMinutes'] ?? null,
+                    address: $provider->address ?? null,
+                    geo: $provider->geo ?? null,
+                    scope: $scope,
+                    maxSlotsPerAppointment: $scope ? ((string) $scope->getSlotsPerAppointment() === '' ? null : (string) $scope->getSlotsPerAppointment()) : null
+                );
             }
         }
 
@@ -392,7 +405,7 @@ class ZmsApiFacadeService
             customTextfieldLabel: $matchingScope->getCustomTextfieldLabel() ?? null,
             captchaActivatedRequired: (bool) $matchingScope->getCaptchaActivatedRequired() ?? null,
             displayInfo: $matchingScope->getDisplayInfo() ?? null,
-            slotsPerAppointment: (int) $matchingScope->getSlotsPerAppointment() ?? null
+            slotsPerAppointment: ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment()) ?? null
         );
     }
 
@@ -648,7 +661,7 @@ class ZmsApiFacadeService
                 customTextfieldLabel: $process->scope->getCustomTextfieldLabel() ?? null,
                 captchaActivatedRequired: (bool) $process->scope->getCaptchaActivatedRequired() ?? false,
                 displayInfo: $process->scope->getDisplayInfo() ?? null,
-                slotsPerAppointment: (int) $process->scope->getSlotsPerAppointment() ?? null
+                slotsPerAppointment: ((string) $process->scope->getSlotsPerAppointment() === '' ? null : (string) $process->scope->getSlotsPerAppointment()) ?? null
             );
         }
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -63,6 +63,9 @@ class ZmsApiFacadeService
         }
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
     public static function getOffices(bool $showUnpublished = false): OfficeList
     {
         $cacheKey = self::CACHE_KEY_OFFICES . ($showUnpublished ? '_unpublished' : '');
@@ -360,6 +363,9 @@ class ZmsApiFacadeService
         return $result;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
     public static function getScopeById(?int $scopeId): ThinnedScope|array
     {
         $scopeList = ZmsApiClientService::getScopes() ?? new ScopeList();

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -109,7 +109,8 @@ class ZmsApiFacadeService
                     customTextfieldRequired: (bool) $matchingScope->getCustomTextfieldRequired(),
                     customTextfieldLabel: $matchingScope->getCustomTextfieldLabel(),
                     captchaActivatedRequired: (bool) $matchingScope->getCaptchaActivatedRequired(),
-                    displayInfo: $matchingScope->getDisplayInfo()
+                    displayInfo: $matchingScope->getDisplayInfo(),
+                    slotsPerAppointment: (int) $matchingScope->getSlotsPerAppointment()
                 ) : null
             );
         }
@@ -157,7 +158,8 @@ class ZmsApiFacadeService
                     customTextfieldRequired: (bool) $matchingScope->getCustomTextfieldRequired(),
                     customTextfieldLabel: $matchingScope->getCustomTextfieldLabel(),
                     captchaActivatedRequired: (bool) $matchingScope->getCaptchaActivatedRequired(),
-                    displayInfo: $matchingScope->getDisplayInfo()
+                    displayInfo: $matchingScope->getDisplayInfo(),
+                    slotsPerAppointment: (int) $matchingScope->getSlotsPerAppointment()
                 );
             }
         }
@@ -265,6 +267,7 @@ class ZmsApiFacadeService
             'customTextfieldLabel' => $matchingScope->getCustomTextfieldLabel() ?? null,
             'captchaActivatedRequired' => (bool) $matchingScope->getCaptchaActivatedRequired() ?? null,
             'displayInfo' => $matchingScope->getDisplayInfo() ?? null,
+            'slotsPerAppointment' => (int) $matchingScope->getSlotsPerAppointment() ?? null
         ];
         return new ThinnedScope(
             id: (int) $result['id'],
@@ -278,7 +281,8 @@ class ZmsApiFacadeService
             customTextfieldRequired: $result['customTextfieldRequired'],
             customTextfieldLabel: $result['customTextfieldLabel'],
             captchaActivatedRequired: $result['captchaActivatedRequired'],
-            displayInfo: $result['displayInfo']
+            displayInfo: $result['displayInfo'],
+            slotsPerAppointment: $result['slotsPerAppointment']
         );
     }
 
@@ -387,7 +391,8 @@ class ZmsApiFacadeService
             customTextfieldRequired: (bool) $matchingScope->getCustomTextfieldRequired() ?? null,
             customTextfieldLabel: $matchingScope->getCustomTextfieldLabel() ?? null,
             captchaActivatedRequired: (bool) $matchingScope->getCaptchaActivatedRequired() ?? null,
-            displayInfo: $matchingScope->getDisplayInfo() ?? null
+            displayInfo: $matchingScope->getDisplayInfo() ?? null,
+            slotsPerAppointment: (int) $matchingScope->getSlotsPerAppointment() ?? null
         );
     }
 
@@ -642,7 +647,8 @@ class ZmsApiFacadeService
                 customTextfieldRequired: (bool) $process->scope->getCustomTextfieldRequired() ?? false,
                 customTextfieldLabel: $process->scope->getCustomTextfieldLabel() ?? null,
                 captchaActivatedRequired: (bool) $process->scope->getCaptchaActivatedRequired() ?? false,
-                displayInfo: $process->scope->getDisplayInfo() ?? null
+                displayInfo: $process->scope->getDisplayInfo() ?? null,
+                slotsPerAppointment: (int) $process->scope->getSlotsPerAppointment() ?? null
             );
         }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentByIdControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentByIdControllerTest.php
@@ -94,7 +94,8 @@ class AppointmentByIdControllerTest extends ControllerTestCase
                 "customTextfieldRequired" => true,
                 "customTextfieldLabel" => "Nachname des Kindes",
                 "captchaActivatedRequired" => false,
-                "displayInfo" => null
+                "displayInfo" => null,
+                "slotsPerAppointment" => null
             ],
             "subRequestCounts" => [],
             "serviceId" => 1063424,

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentCancelControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentCancelControllerTest.php
@@ -98,7 +98,8 @@ class AppointmentCancelControllerTest extends ControllerTestCase
                 'customTextfieldRequired' => null,
                 'customTextfieldLabel' => null,
                 'captchaActivatedRequired' => null,
-                'displayInfo' => null
+                'displayInfo' => null,
+                'slotsPerAppointment' => null
             ],
             'subRequestCounts' => [],
             'serviceId' => 10242339,

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentConfirmControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentConfirmControllerTest.php
@@ -95,7 +95,8 @@ class AppointmentConfirmControllerTest extends ControllerTestCase
                 'customTextfieldRequired' => null,
                 'customTextfieldLabel' => null,
                 'captchaActivatedRequired' => null,
-                'displayInfo' => null
+                'displayInfo' => null,
+                'slotsPerAppointment' => null
             ],
             'subRequestCounts' => [],
             'serviceId' => 10242339,

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentPreconfirmControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentPreconfirmControllerTest.php
@@ -93,7 +93,8 @@ class AppointmentPreconfirmControllerTest extends ControllerTestCase
                 'customTextfieldRequired' => null,
                 'customTextfieldLabel' => null,
                 'captchaActivatedRequired' => null,
-                'displayInfo' => null
+                'displayInfo' => null,
+                'slotsPerAppointment' => null
             ],
             'subRequestCounts' => [],
             'serviceId' => 10242339,

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentReserveControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentReserveControllerTest.php
@@ -97,7 +97,8 @@ class AppointmentReserveControllerTest extends ControllerTestCase
                 "customTextfieldRequired" => true,
                 "customTextfieldLabel" => "",
                 "captchaActivatedRequired" => false,
-                "displayInfo" => null
+                "displayInfo" => null,
+                "slotsPerAppointment" => null
             ],
             "subRequestCounts" => [],
             "serviceId" => 0,

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentUpdateControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentUpdateControllerTest.php
@@ -93,7 +93,8 @@ class AppointmentUpdateControllerTest extends ControllerTestCase
                 "customTextfieldRequired" => null,
                 "customTextfieldLabel" => null,
                 "captchaActivatedRequired" => null,
-                "displayInfo" => null
+                "displayInfo" => null,
+                "slotsPerAppointment" => null
             ],
             "status" => "reserved",
             "subRequestCounts" => [],

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableAppointmentsListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableAppointmentsListControllerTest.php
@@ -42,8 +42,8 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
 
         $parameters = [
             'date' => '3000-09-21',
-            'officeId' => 10546,
-            'serviceId' => '1063423',
+            'officeId' => '9999998',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
 
@@ -79,12 +79,13 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
 
         $parameters = [
             'date' => '3000-09-21',
-            'officeId' => 10546,
-            'serviceId' => '1063423',
+            'officeId' => '9999998',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
 
         $response = $this->render([], $parameters, []);
+        $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'errors' => [
                 ErrorMessages::get('appointmentNotAvailable')
@@ -97,8 +98,8 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     public function testDateMissing()
     {
         $parameters = [
-            'officeId' => 10546,
-            'serviceId' => '1063423',
+            'officeId' => '9999998',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
 
@@ -117,7 +118,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '3000-09-21',
-            'serviceId' => '1063423',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
 
@@ -136,7 +137,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '3000-09-21',
-            'officeId' => 10546,
+            'officeId' => '9999998',
             'serviceCount' => '1',
         ];
 
@@ -155,8 +156,8 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '3000-09-21',
-            'officeId' => 10546,
-            'serviceId' => '1063423',
+            'officeId' => '9999998',
+            'serviceId' => '1',
         ];
 
         $response = $this->render([], $parameters, []);
@@ -173,7 +174,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     public function testDateAndOfficeIdMissing()
     {
         $parameters = [
-            'serviceId' => '1063423',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
 
@@ -193,7 +194,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     public function testDateAndServiceIdMissing()
     {
         $parameters = [
-            'officeId' => 10546,
+            'officeId' => '9999998',
             'serviceCount' => '1',
         ];
 
@@ -213,8 +214,8 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     public function testDateAndServiceCountMissing()
     {
         $parameters = [
-            'officeId' => 10546,
-            'serviceId' => '1063423',
+            'officeId' => '9999998',
+            'serviceId' => '1',
         ];
 
         $response = $this->render([], $parameters, []);
@@ -254,7 +255,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '3000-09-21',
-            'serviceId' => '1063423',
+            'serviceId' => '1',
         ];
 
         $response = $this->render([], $parameters, []);
@@ -274,7 +275,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '3000-09-21',
-            'officeId' => 10546,
+            'officeId' => '9999998',
         ];
 
         $response = $this->render([], $parameters, []);
@@ -294,8 +295,8 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '21-09-3000',
-            'officeId' => 10546,
-            'serviceId' => '1063423',
+            'officeId' => '9999998',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
     
@@ -314,7 +315,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
     {
         $parameters = [
             'date' => '3000-09-21',
-            'officeId' => 10546,
+            'officeId' => '9999998',
             'serviceId' => 'invalid',
             'serviceCount' => '1',
         ];
@@ -335,7 +336,7 @@ class AvailableAppointmentsListControllerTest extends ControllerTestCase
         $parameters = [
             'date' => '3000-09-21',
             'officeId' => 'invalid',
-            'serviceId' => '1063423',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
     

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableDaysListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableDaysListControllerTest.php
@@ -629,8 +629,8 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $parameters = [
             'startDate' => '2024-08-29',
             'endDate' => '2024-09-04',
-            'officeId' => '102522',
-            'serviceId' => '1063424',
+            'officeId' => '9999998',
+            'serviceId' => '1',
             'serviceCount' => '1',
         ];
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
@@ -76,7 +76,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => true,
                         "customTextfieldLabel" => "",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ]
             ]
@@ -140,7 +141,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => false,
                         "customTextfieldLabel" => "Custom Label",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ],
                 [
@@ -181,7 +183,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => true,
                         "customTextfieldLabel" => "",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ]
             ]

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
@@ -36,6 +36,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
         $response = $this->render([], [
             'serviceId' => '2'
         ], []);
+        $reponseBody = json_decode((string)$response->getBody(), true);
+        error_log(json_encode($reponseBody));
         $expectedResponse = [
             "offices" => [
                 [
@@ -78,7 +80,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ]
             ]
         ];            
@@ -101,6 +104,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
         $response = $this->render([], [
             'serviceId' => '1'
         ], []);
+        $reponseBody = json_decode((string)$response->getBody(), true);
+        error_log(json_encode($reponseBody));
         $expectedResponse = [
             "offices" => [
                 [
@@ -143,7 +148,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ],
                 [
                     "id" => 9999999,
@@ -185,7 +191,8 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ]
             ]
         ];

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
@@ -36,8 +36,6 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
         $response = $this->render([], [
             'serviceId' => '2'
         ], []);
-        $reponseBody = json_decode((string)$response->getBody(), true);
-        error_log(json_encode($reponseBody));
         $expectedResponse = [
             "offices" => [
                 [
@@ -104,8 +102,6 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
         $response = $this->render([], [
             'serviceId' => '1'
         ], []);
-        $reponseBody = json_decode((string)$response->getBody(), true);
-        error_log(json_encode($reponseBody));
         $expectedResponse = [
             "offices" => [
                 [

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
@@ -80,7 +80,8 @@ class OfficesListControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ],
                 [
                     "id" => 9999999,
@@ -125,7 +126,8 @@ class OfficesListControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ]
             ]
         ];

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
@@ -78,7 +78,8 @@ class OfficesListControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => false,
                         "customTextfieldLabel" => "Custom Label",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ],
                 [
@@ -122,7 +123,8 @@ class OfficesListControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => true,
                         "customTextfieldLabel" => "",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ]
             ]

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
@@ -80,7 +80,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ],
                 [
                     "id" => 9999999,
@@ -125,7 +126,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ]
             ],
             "services" => [
@@ -226,7 +228,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ],
                 [
                     "id" => 9999999,
@@ -271,7 +274,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "captchaActivatedRequired" => false,
                         "displayInfo" => null,
                         "slotsPerAppointment" => null
-                    ]
+                    ],
+                    "maxSlotsPerAppointment" => null
                 ]
             ],
             "services" => [

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
@@ -78,7 +78,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => false,
                         "customTextfieldLabel" => "Custom Label",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ],
                 [
@@ -122,7 +123,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => true,
                         "customTextfieldLabel" => "",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ]
             ],
@@ -222,7 +224,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => false,
                         "customTextfieldLabel" => "Custom Label",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ],
                 [
@@ -266,7 +269,8 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "customTextfieldRequired" => true,
                         "customTextfieldLabel" => "",
                         "captchaActivatedRequired" => false,
-                        "displayInfo" => null
+                        "displayInfo" => null,
+                        "slotsPerAppointment" => null
                     ]
                 ]
             ],

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Scope/ScopeByIdControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Scope/ScopeByIdControllerTest.php
@@ -63,7 +63,8 @@ class ScopeByIdControllerTest extends ControllerTestCase
             "customTextfieldRequired" => false,
             "customTextfieldLabel" => "Custom Label",
             "captchaActivatedRequired" => false,
-            "displayInfo" => null
+            "displayInfo" => null,
+            "slotsPerAppointment" => null
         ];               
         $responseBody = json_decode((string)$response->getBody(), true);
         $this->assertEquals(200, $response->getStatusCode());

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Scope/ScopesListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Scope/ScopesListControllerTest.php
@@ -64,7 +64,8 @@ class ScopesListControllerTest extends ControllerTestCase
                     "customTextfieldRequired" => false,
                     "customTextfieldLabel" => "Custom Label",
                     "captchaActivatedRequired" => false,
-                    "displayInfo" => null
+                    "displayInfo" => null,
+                    "slotsPerAppointment" => null
                 ],
                 [
                     "id" => 2,
@@ -93,7 +94,8 @@ class ScopesListControllerTest extends ControllerTestCase
                     "customTextfieldRequired" => true,
                     "customTextfieldLabel" => "",
                     "captchaActivatedRequired" => false,
-                    "displayInfo" => null
+                    "displayInfo" => null,
+                    "slotsPerAppointment" => null
                 ]
             ]
         ];

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Availability/AvailableAppointmentsListServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Availability/AvailableAppointmentsListServiceTest.php
@@ -153,6 +153,50 @@ class AvailableAppointmentsListServiceTest extends TestCase
         $this->assertEquals($expectedError, $result);
     }
 
+    public function testGetAvailableAppointmentsListWithInvalidServiceLocationCombinationReturnsError(): void
+    {
+        // Arrange
+        $queryParams = [
+            'date' => '2025-01-15',
+            'officeId' => '999',  // This office ID will trigger the validation error
+            'serviceId' => '456',
+            'serviceCount' => '1'
+        ];
+        $expectedError = ['errors' => [['errorCode' => 'invalidLocationAndServiceCombination']]];
+
+        $this->createMockValidationService([]);  // Initial validation passes
+        $this->service = new AvailableAppointmentsListService();
+
+        // Act
+        $result = $this->service->getAvailableAppointmentsList($queryParams);
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertEquals($expectedError, $result);
+    }
+
+    public function testGetAvailableAppointmentsListByOfficeWithInvalidServiceLocationCombinationReturnsError(): void
+    {
+        // Arrange
+        $queryParams = [
+            'date' => '2025-01-15',
+            'officeId' => '999',  // This office ID will trigger the validation error
+            'serviceId' => '456',
+            'serviceCount' => '1'
+        ];
+        $expectedError = ['errors' => [['errorCode' => 'invalidLocationAndServiceCombination']]];
+
+        $this->createMockValidationService([]);  // Initial validation passes
+        $this->service = new AvailableAppointmentsListService();
+
+        // Act
+        $result = $this->service->getAvailableAppointmentsListByOffice($queryParams);
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertEquals($expectedError, $result);
+    }
+
     private function createMockValidationService(array $returnValue): void
     {
         $class = 'BO\\Zmscitizenapi\\Services\\Core\\ValidationService';
@@ -169,6 +213,16 @@ class AvailableAppointmentsListServiceTest extends TestCase
                         $tokenValidator = null
                     ): array {
                             return unserialize(\'' . serialize($returnValue) . '\');
+                    }
+
+                    public static function validateServiceLocationCombination(
+                        int $officeId,
+                        array $serviceIds
+                    ): array {
+                        if ($officeId === 999) {
+                            return ["errors" => [["errorCode" => "invalidLocationAndServiceCombination"]]];
+                        }
+                        return [];
                     }
                 }'
             );

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Availability/AvailableDaysListServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Availability/AvailableDaysListServiceTest.php
@@ -158,6 +158,29 @@ class AvailableDaysListServiceTest extends TestCase
         $this->assertEquals($expectedError, $result);
     }
 
+    public function testGetAvailableDaysListWithInvalidServiceLocationCombinationReturnsError(): void
+    {
+        // Arrange
+        $queryParams = [
+            'officeId' => '999',  // This office ID will trigger the validation error
+            'serviceId' => '456',
+            'serviceCount' => '1',
+            'startDate' => '2025-01-01',
+            'endDate' => '2025-01-31'
+        ];
+        $expectedError = ['errors' => [['errorCode' => 'invalidLocationAndServiceCombination']]];
+
+        $this->createMockValidationService([]);  // Initial validation passes
+        $this->service = new AvailableDaysListService();
+
+        // Act
+        $result = $this->service->getAvailableDaysList($queryParams);
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertEquals($expectedError, $result);
+    }
+
     private function createMockValidationService(array $returnValue): void
     {
         $class = 'BO\\Zmscitizenapi\\Services\\Core\\ValidationService';
@@ -172,6 +195,16 @@ class AvailableDaysListServiceTest extends TestCase
                         array $serviceCounts
                     ): array {
                         return unserialize(\'' . serialize($returnValue) . '\');
+                    }
+
+                    public static function validateServiceLocationCombination(
+                        int $officeId,
+                        array $serviceIds
+                    ): array {
+                        if ($officeId === 999) {
+                            return ["errors" => [["errorCode" => "invalidLocationAndServiceCombination"]]];
+                        }
+                        return [];
                     }
                 }'
             );

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Core/MapperServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Core/MapperServiceTest.php
@@ -211,7 +211,8 @@ class MapperServiceTest extends TestCase
                 'customTextfieldRequired' => null,
                 'customTextfieldLabel' => null,
                 'captchaActivatedRequired' => null,
-                'displayInfo' => null
+                'displayInfo' => null,
+                'slotsPerAppointment' => null
             ],
             'subRequestCounts' => [],
             'serviceId' => 0,
@@ -245,6 +246,7 @@ class MapperServiceTest extends TestCase
         $this->assertEquals($scope['customTextfieldLabel'], $result->scope->customTextfieldLabel);
         $this->assertEquals($scope['captchaActivatedRequired'], $result->scope->captchaActivatedRequired);
         $this->assertEquals($scope['displayInfo'], $result->scope->displayInfo);
+        $this->assertEquals($scope['slotsPerAppointment'], $result->scope->slotsPerAppointment);
         $this->assertEquals($expectedResponse['subRequestCounts'], $result->subRequestCounts);
         $this->assertEquals($expectedResponse['serviceId'], $result->serviceId);
         $this->assertEquals($expectedResponse['serviceCount'], $result->serviceCount);
@@ -640,6 +642,7 @@ class MapperServiceTest extends TestCase
         $this->assertNull($result->customTextfieldLabel);
         $this->assertNull($result->captchaActivatedRequired);
         $this->assertNull($result->displayInfo);
+        $this->assertNull($result->slotsPerAppointment);
     }
 
 }

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Scope/ScopeByIdServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Scope/ScopeByIdServiceTest.php
@@ -102,7 +102,8 @@ class ScopeByIdServiceTest extends TestCase
             customTextfieldRequired: false,
             customTextfieldLabel: null,
             captchaActivatedRequired: false,
-            displayInfo: null
+            displayInfo: null,
+            slotsPerAppointment: null
         );
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/fixtures/GET_appointments_empty.json
+++ b/zmscitizenapi/tests/Zmscitizenapi/fixtures/GET_appointments_empty.json
@@ -21,18 +21,18 @@
             "reminderTimestamp": 0,
             "requests": [{
                 "$schema": "https://schema.berlin.de/queuemanagement/request.json",
-                "id": "1063424",
-                "link": "https://service.berlin.de/dienstleistung/1063424/",
-                "name": "Service Name",
-                "source": "dldb"
+                "id": "1",
+                "link": "https://www.berlinonline.de",
+                "name": "Unittest Source Dienstleistung",
+                "source": "unittest"
             }],
             "scope": {
                 "$schema": "https://schema.berlin.de/queuemanagement/scope.json",
-                "hint": "Bürgeramt | Nr. wird zum Termin aufgerufen",
-                "id": "141",
+                "hint": "Unittest | Nr. wird zum Termin aufgerufen",
+                "id": "1",
                 "contact": {
-                    "name": "Bürgeramt Heerstraße",
-                    "street": "Heerstr. 12, 14052 Berlin",
+                    "name": "Unittest Source Dienstleister",
+                    "street": "Alte Jakobstraße 105, 10178 Berlin",
                     "email": "",
                     "country": "Germany"
                 },
@@ -53,8 +53,13 @@
                         "emailRequired": "0",
                         "adminMailOnAppointment": "0",
                         "adminMailOnDeleted": "0",
-                        "telephoneActivated": "0",
-                        "telephoneRequired": "0"
+                        "telephoneActivated": "1",
+                        "telephoneRequired": "0",
+                        "customTextfieldActivated": "1",
+                        "customTextfieldRequired": "0",
+                        "customTextfieldLabel": "Custom Label",
+                        "captchaActivatedRequired": "0",
+                        "displayInfo": "Infos zum Standort."
                     },
                     "notifications": {
                         "confirmationContent": "",
@@ -90,7 +95,7 @@
                         "emergencyEnabled": "1"
                     }
                 },
-                "shortName": "",
+                "shortName": "Scope 1",
                 "status": {
                     "emergency": {
                         "acceptedByWorkstation": "-1",
@@ -108,20 +113,20 @@
                     }
                 },
                 "provider": {
-                    "id": "122217",
+                    "id": "9999998",
                     "contact": {
                         "email": "test@example.com",
                         "city": "Berlin",
                         "country": "Germany",
-                        "name": "Bürgeramt Heerstraße",
-                        "postalCode": "14052",
+                        "name": "Unittest Source Dienstleister",
+                        "postalCode": "10178",
                         "region": "Berlin",
-                        "street": "Heerstr.",
-                        "streetNumber": "12"
+                        "street": "Alte Jakobstraße",
+                        "streetNumber": "105"
                     },
-                    "source": "dldb",
-                    "link": "https://service.berlin.de/standort/122217/",
-                    "name": "Bürgeramt Heerstraße"
+                    "source": "unittest",
+                    "link": "https://www.berlinonline.de",
+                    "name": "Unittest Source Dienstleister"
                 },
                 "department": {
                     "id": "74",

--- a/zmsentities/schema/citizenapi/office.json
+++ b/zmsentities/schema/citizenapi/office.json
@@ -112,6 +112,13 @@
         },
         "scope": {
             "$ref": "./thinnedScope.json"
+        },
+        "maxSlotsPerAppointment": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Maximum number of slots that can be booked per appointment"
         }
     },
     "required": [

--- a/zmsentities/schema/citizenapi/thinnedScope.json
+++ b/zmsentities/schema/citizenapi/thinnedScope.json
@@ -78,10 +78,10 @@
         },
         "slotsPerAppointment": {
             "type": [
-                "integer",
+                "string",
                 "null"
             ],
-            "description": "Maximum number of slots that can be booked per appointment"
+            "description": "Number of slots that can be booked per appointment"
         }
     }
 }

--- a/zmsentities/schema/citizenapi/thinnedScope.json
+++ b/zmsentities/schema/citizenapi/thinnedScope.json
@@ -75,6 +75,13 @@
                 "null"
             ],
             "description": "Additional display information"
+        },
+        "slotsPerAppointment": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "Maximum number of slots that can be booked per appointment"
         }
     }
 }

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -81,6 +81,11 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->getPreference('appointment', 'infoForAppointment', null);
     }
 
+    public function getSlotsPerAppointment()
+    {
+        return $this->getPreference('client', 'slotsPerAppointment', null);
+    }
+
     public function getProvider()
     {
         if (!isset($this->provider)) {
@@ -193,13 +198,6 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         $appointmentsPerMail = $this->toProperty()->preferences->client->appointmentsPerMail->get();
 
         return ($appointmentsPerMail) ? $appointmentsPerMail : null;
-    }
-
-    public function getSlotsPerAppointment()
-    {
-        $slotsPerAppointment = $this->toProperty()->preferences->client->slotsPerAppointment->get();
-
-        return ($slotsPerAppointment) ? $slotsPerAppointment : null;
     }
 
     public function getWhitelistedMails()


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new fields to office and scope data: "maxSlotsPerAppointment" and "slotsPerAppointment" to indicate the maximum and per-appointment slot limits.
  - These new fields are now included in API responses and documented in the API schema.

- **Bug Fixes**
  - Improved validation for service location and service combinations when checking available appointments and days.

- **Tests**
  - Extended and updated test coverage to verify the new fields and enhanced validation logic.
  - Updated test data to use generic unittest values and reflect new response structures.

- **Documentation**
  - API schema updated to describe the new fields for office and scope objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->