### PR TITLE
feat(ZMSKVR-321): add tests from old test suite for zmscitizenview ServiceFinder

### DIFF
--- a/zmscitizenview/tests/unit/ServiceFinder.spec.ts
+++ b/zmscitizenview/tests/unit/ServiceFinder.spec.ts
@@ -53,10 +53,77 @@ describe("ServiceFinder", () => {
           SubserviceListItem: {
             template: '<li class="subservice-stub"></li>',
           },
+          MucSelect: {
+            template: '<div class="muc-select-stub"></div>',
+            props: ['id', 'items', 'label', 'hint', 'multiple', 'noItemFoundMessage', 'itemTitle', 'modelValue'],
+            emits: ['update:modelValue'],
+          },
         },
       },
     });
   };
+
+  describe("Service Selection", () => {
+    it("should show service name when service is selected", async () => {
+      const service = makeService(0);
+      service.name = "Test Service Name";
+      const wrapper = createWrapper(service);
+      await nextTick();
+      expect(wrapper.text()).toContain("Test Service Name");
+    });
+
+    it("should not show service dropdown when service is preselected", async () => {
+      const wrapper = createWrapper(makeService(0));
+      await nextTick();
+      expect(wrapper.find("#service-search").exists()).toBe(false);
+    });
+
+    it("should show service dropdown when no service is selected", async () => {
+      const wrapper = createWrapper(null);
+      await nextTick();
+      expect(wrapper.find(".muc-select-stub").exists()).toBe(true);
+    });
+  });
+
+  describe("Service Count", () => {
+    it("should increase service count when plus button is clicked", async () => {
+      const service = makeService(0);
+      const wrapper = createWrapper(service);
+      await nextTick();
+      const counter = wrapper.findComponent({ name: "muc-counter" });
+      await counter.vm.$emit("update:modelValue", 2);
+      expect(service.count).toBe(2);
+    });
+
+    // TODO(ZMSKVR-486): Fix maxQuantity enforcement in ServiceFinder.vue
+    // it("should not allow increasing count beyond maxQuantity", async () => {
+    //   const service = makeService(0);
+    //   service.maxQuantity = 2;
+    //   const wrapper = createWrapper(service);
+    //   await nextTick();
+    //   const counter = wrapper.findComponent({ name: "muc-counter" });
+    //   await counter.vm.$emit("update:modelValue", 3);
+    //   await nextTick();
+    //   expect(service.count).toBe(2);
+    // });
+  });
+
+  describe("Next Step", () => {
+    it("should emit next event when next button is clicked", async () => {
+      const wrapper = createWrapper(makeService(0));
+      await nextTick();
+      const nextButton = wrapper.find(".m-button-group button");
+      await nextButton.trigger("click");
+      expect(wrapper.emitted("next")).toBeTruthy();
+    });
+
+    it("should not show next button when no service is selected", async () => {
+      const wrapper = createWrapper(null);
+      await nextTick();
+      const nextButton = wrapper.find(".m-button-group button");
+      expect(nextButton.exists()).toBe(false);
+    });
+  });
 
   describe("Show All Services Button", () => {
     it("should not show button when there are 5 or fewer services", async () => {


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded test coverage for the ServiceFinder component, including new scenarios for service selection, service count updates, and navigation controls. These tests ensure correct UI behavior when selecting services, adjusting quantities, and proceeding to the next step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->