### PR TITLE
feat(ZMSKVR-437): unit test coverage for zmscitizenview include some tests from the old eappointment-buergeransicht module

### DIFF
--- a/zmscitizenview/tests/unit/AltchaCaptcha.spec.ts
+++ b/zmscitizenview/tests/unit/AltchaCaptcha.spec.ts
@@ -1,0 +1,83 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { nextTick } from "vue";
+
+// @ts-expect-error: Vue SFC import for test
+import AltchaCaptcha from "@/components/Appointment/AltchaCaptcha.vue";
+
+// Mock window.scrollTo for jsdom
+globalThis.scrollTo = vi.fn();
+
+describe("AltchaCaptcha", () => {
+  const mockT = (key: string) => key;
+  const mockBaseUrl = "http://test.com";
+
+  const createWrapper = (props = {}) => {
+    return mount(AltchaCaptcha, {
+      props: {
+        baseUrl: mockBaseUrl,
+        t: mockT,
+        ...props,
+      },
+      global: {
+        stubs: {
+          'altcha-widget': {
+            template: "<div data-test='altcha-widget'></div>",
+            props: ["challengeurl", "verifyurl"],
+            emits: ["statechange", "serververification"],
+          },
+        },
+      },
+    });
+  };
+
+  describe("Rendering", () => {
+    it("shows error message when captcha is disabled", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.captchaEnabled = false;
+      await nextTick();
+      expect(wrapper.find('[data-test="altcha-widget"]').exists()).toBe(false);
+      expect(wrapper.text()).toContain("altcha.loadError");
+    });
+  });
+
+  describe("Event Handling", () => {
+    it("emits validationResult when statechange event is triggered", async () => {
+      const wrapper = createWrapper();
+      await nextTick();
+      const altchaWidget = wrapper.find('[data-test="altcha-widget"]');
+      if (altchaWidget.exists()) {
+        altchaWidget.trigger("statechange", { detail: { state: "verified" } });
+        const validationResult = wrapper.emitted("validationResult");
+        expect(validationResult).toBeTruthy();
+        if (validationResult) {
+          expect(validationResult[0]).toEqual([true]);
+        }
+      }
+    });
+
+    it("emits tokenChanged when serververification event is triggered", async () => {
+      const wrapper = createWrapper();
+      await nextTick();
+      const altchaWidget = wrapper.find('[data-test="altcha-widget"]');
+      if (altchaWidget.exists()) {
+        altchaWidget.trigger("serververification", { detail: { token: "test-token" } });
+        const tokenChanged = wrapper.emitted("tokenChanged");
+        expect(tokenChanged).toBeTruthy();
+        if (tokenChanged) {
+          expect(tokenChanged[0]).toEqual(["test-token"]);
+        }
+      }
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("disables captcha when fetchCaptchaDetails fails", async () => {
+      const wrapper = createWrapper();
+      await nextTick();
+      vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error("Fetch failed"));
+      await wrapper.vm.fetchCaptchaDetails();
+      expect(wrapper.vm.captchaEnabled).toBe(false);
+    });
+  });
+}); 

--- a/zmscitizenview/tests/unit/AppointmentSummary.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentSummary.spec.ts
@@ -1,0 +1,192 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { nextTick, ref } from "vue";
+
+// @ts-expect-error: Vue SFC import for test
+import AppointmentSummary from "@/components/Appointment/AppointmentSummary.vue";
+
+describe("AppointmentSummary", () => {
+  const mockT = (key: string) => key;
+  const mockSelectedService = ref({
+    id: "123",
+    name: "Test Service",
+    count: 2,
+    subServices: [
+      {
+        id: "456",
+        name: "Sub Service 1",
+        count: 1,
+      },
+    ],
+  });
+
+  const mockSelectedProvider = ref({
+    id: "789",
+    name: "Test Provider",
+    address: {
+      street: "Test Street",
+      house_number: "123",
+      postal_code: "12345",
+      city: "Test City",
+    },
+    scope: {
+      displayInfo: "Test Info",
+      customTextfieldLabel: "Custom Field 1",
+      customTextfield2Label: "Custom Field 2",
+    },
+  });
+
+  const mockAppointment = ref({
+    timestamp: Math.floor(Date.now() / 1000),
+    familyName: "John Doe",
+    email: "john@example.com",
+    telephone: "1234567890",
+    customTextfield: "Custom Value 1",
+    customTextfield2: "Custom Value 2",
+  });
+
+  const createWrapper = (props = {}) => {
+    return mount(AppointmentSummary, {
+      props: {
+        t: mockT,
+        isRebooking: false,
+        rebookOrCancelDialog: false,
+        ...props,
+      },
+      global: {
+        provide: {
+          selectedServiceProvider: {
+            selectedService: mockSelectedService,
+          },
+          selectedTimeslot: {
+            selectedProvider: mockSelectedProvider,
+          },
+          appointment: {
+            appointment: mockAppointment,
+          },
+        },
+        stubs: {
+          "muc-button": true,
+        },
+      },
+    });
+  };
+
+  describe("Rendering", () => {
+    it("renders service information correctly", () => {
+      const wrapper = createWrapper();
+      expect(wrapper.text()).toContain("Test Service");
+      expect(wrapper.text()).toContain("2x");
+      expect(wrapper.text()).toContain("Sub Service 1");
+      expect(wrapper.text()).toContain("1x");
+    });
+
+    it("renders provider information correctly", () => {
+      const wrapper = createWrapper();
+      expect(wrapper.text()).toContain("Test Provider");
+      expect(wrapper.text()).toContain("Test Street 123");
+      expect(wrapper.text()).toContain("12345 Test City");
+      expect(wrapper.text()).toContain("Test Info");
+    });
+
+    it("renders appointment time correctly", () => {
+      const wrapper = createWrapper();
+      const date = new Date(mockAppointment.value.timestamp * 1000);
+      const formatterDate = new Intl.DateTimeFormat("de-DE", {
+        weekday: "long",
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+      });
+      const formatterTime = new Intl.DateTimeFormat("de-DE", {
+        timeZone: "Europe/Berlin",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: false,
+      });
+      const expectedDate = formatterDate.format(date) + ", " + formatterTime.format(date);
+      expect(wrapper.text()).toContain(expectedDate);
+    });
+
+    it("renders customer information correctly", () => {
+      const wrapper = createWrapper();
+      expect(wrapper.text()).toContain("John Doe");
+      expect(wrapper.text()).toContain("john@example.com");
+      expect(wrapper.text()).toContain("1234567890");
+      expect(wrapper.text()).toContain("Custom Value 1");
+      expect(wrapper.text()).toContain("Custom Value 2");
+    });
+  });
+
+  describe("Form Validation", () => {
+    it("disables book button when checkboxes are not checked", () => {
+      const wrapper = createWrapper();
+      const bookButton = wrapper.find('muc-button-stub[icon="check"]');
+      expect(bookButton.attributes("disabled")).toBe("true");
+    });
+
+    it("enables book button when both checkboxes are checked", async () => {
+      const wrapper = createWrapper();
+      await wrapper.find('input[name="checkbox-privacy-policy"]').trigger("click");
+      await wrapper.find('input[name="checkbox-electronic-communication"]').trigger("click");
+      const bookButton = wrapper.find('muc-button-stub[icon="check"]');
+      expect(bookButton.attributes("disabled")).toBe("false");
+    });
+  });
+
+  describe("Navigation", () => {
+    it("emits back event when back button is clicked", async () => {
+      const wrapper = createWrapper();
+      await wrapper.find('muc-button-stub[icon="arrow-left"]').trigger("click");
+      expect(wrapper.emitted("back")).toBeTruthy();
+    });
+
+    it("emits bookAppointment event when book button is clicked", async () => {
+      const wrapper = createWrapper();
+      await wrapper.find('input[name="checkbox-privacy-policy"]').trigger("click");
+      await wrapper.find('input[name="checkbox-electronic-communication"]').trigger("click");
+      await wrapper.find('muc-button-stub[icon="check"]').trigger("click");
+      expect(wrapper.emitted("bookAppointment")).toBeTruthy();
+    });
+  });
+
+  describe("Rebooking Mode", () => {
+    it("shows reschedule and cancel buttons in rebookOrCancelDialog mode", () => {
+      const wrapper = createWrapper({ rebookOrCancelDialog: true });
+      expect(wrapper.find('muc-button-stub[icon="arrow-right"]').exists()).toBe(true);
+      expect(wrapper.find('muc-button-stub[icon="close"]').exists()).toBe(true);
+    });
+
+    it("emits rescheduleAppointment event when reschedule button is clicked", async () => {
+      const wrapper = createWrapper({ rebookOrCancelDialog: true });
+      await wrapper.find('muc-button-stub[icon="arrow-right"]').trigger("click");
+      expect(wrapper.emitted("rescheduleAppointment")).toBeTruthy();
+    });
+
+    it("emits cancelAppointment event when cancel button is clicked", async () => {
+      const wrapper = createWrapper({ rebookOrCancelDialog: true });
+      await wrapper.find('muc-button-stub[icon="close"]').trigger("click");
+      expect(wrapper.emitted("cancelAppointment")).toBeTruthy();
+    });
+  });
+
+  describe("Rebooking Flow", () => {
+    it("shows reschedule and cancel buttons in rebooking mode", () => {
+      const wrapper = createWrapper({ isRebooking: true });
+      expect(wrapper.find('muc-button-stub[icon="check"]').exists()).toBe(true);
+      expect(wrapper.find('muc-button-stub[icon="close"]').exists()).toBe(true);
+    });
+
+    it("emits bookAppointment event when reschedule button is clicked", async () => {
+      const wrapper = createWrapper({ isRebooking: true });
+      await wrapper.find('muc-button-stub[icon="check"]').trigger("click");
+      expect(wrapper.emitted("bookAppointment")).toBeTruthy();
+    });
+
+    it("emits cancelReschedule event when cancel button is clicked", async () => {
+      const wrapper = createWrapper({ isRebooking: true });
+      await wrapper.find('muc-button-stub[icon="close"]').trigger("click");
+      expect(wrapper.emitted("cancelReschedule")).toBeTruthy();
+    });
+  });
+}); 

--- a/zmscitizenview/tests/unit/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentView.spec.ts
@@ -1,0 +1,306 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { nextTick, ref } from "vue";
+
+// @ts-expect-error: Vue SFC import for test
+import AppointmentView from "@/components/Appointment/AppointmentView.vue";
+
+// Mock window.scrollTo for jsdom
+globalThis.scrollTo = vi.fn();
+
+describe("AppointmentView", () => {
+  const mockT = (key: string) => key;
+  const mockBaseUrl = "http://test.com";
+  const mockServiceId = "123";
+  const mockLocationId = "456";
+  const mockExclusiveLocation = "test-location";
+  const mockAppointmentHash = "test-hash";
+
+  const mockSelectedService = ref({
+    id: "123",
+    name: "Test Service",
+    count: 2,
+    subServices: [
+      {
+        id: "456",
+        name: "Sub Service 1",
+        count: 1,
+      },
+    ],
+  });
+
+  const mockSelectedProvider = ref({
+    id: "789",
+    name: "Test Provider",
+    address: {
+      street: "Test Street",
+      house_number: "123",
+      postal_code: "12345",
+      city: "Test City",
+    },
+  });
+
+  const mockAppointment = ref({
+    timestamp: Math.floor(Date.now() / 1000),
+    familyName: "John Doe",
+    email: "john@example.com",
+    telephone: "1234567890",
+  });
+
+  const createWrapper = (props = {}) => {
+    return mount(AppointmentView, {
+      props: {
+        baseUrl: mockBaseUrl,
+        serviceId: mockServiceId,
+        locationId: mockLocationId,
+        exclusiveLocation: mockExclusiveLocation,
+        appointmentHash: mockAppointmentHash,
+        t: mockT,
+        ...props,
+      },
+      global: {
+        provide: {
+          selectedServiceProvider: {
+            selectedService: mockSelectedService,
+            updateSelectedService: vi.fn(),
+          },
+          selectedTimeslot: {
+            selectedProvider: mockSelectedProvider,
+            selectedTimeslot: ref(0),
+          },
+          customerData: {
+            customerData: ref({
+              firstName: "",
+              lastName: "",
+              mailAddress: "",
+              telephoneNumber: "",
+              customTextfield: "",
+              customTextfield2: "",
+            }),
+          },
+          appointment: {
+            appointment: mockAppointment,
+          },
+        },
+        stubs: {
+          'service-finder': {
+            template: "<div data-test='service-finder'></div>",
+            props: ["baseUrl", "preselectedServiceId", "preselectedOfficeId", "exclusiveLocation", "t"],
+            emits: ["next", "captchaTokenChanged"],
+          },
+          'calendar-view': {
+            template: "<div data-test='calendar-view'></div>",
+            props: ["baseUrl", "isRebooking", "exclusiveLocation", "preselectedOfficeId", "selectedServiceMap", "captchaToken", "t", "bookingError", "bookingErrorKey"],
+            emits: ["back", "next"],
+          },
+          'customer-info': {
+            template: "<div data-test='customer-info'></div>",
+            props: ["t"],
+            emits: ["back", "next"],
+          },
+          'appointment-summary': {
+            template: "<div data-test='appointment-summary'></div>",
+            props: ["isRebooking", "rebookOrCancelDialog", "t"],
+            emits: ["back", "bookAppointment", "cancelAppointment", "cancelReschedule", "rescheduleAppointment"],
+          },
+          'muc-stepper': {
+            template: "<div data-test='muc-stepper' :data-disable-previous-steps='disablePreviousSteps'></div>",
+            props: ["stepItems", "activeItem", "disablePreviousSteps"],
+            emits: ["changeStep"],
+          },
+          'muc-callout': {
+            props: ["type"],
+            template: `<div data-test='muc-callout' :data-type="type"></div>`
+          },
+        },
+      },
+    });
+  };
+
+  describe("View States", () => {
+    it("shows service finder in initial view", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.currentView = 0;
+      await nextTick();
+      expect(wrapper.find('[data-test="service-finder"]').exists()).toBe(true);
+    });
+
+    it("shows calendar view when service is selected", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.currentView = 1;
+      await nextTick();
+      expect(wrapper.find('[data-test="calendar-view"]').exists()).toBe(true);
+    });
+
+    it("shows customer info after calendar selection", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.currentView = 2;
+      await nextTick();
+      expect(wrapper.find('[data-test="customer-info"]').exists()).toBe(true);
+    });
+
+    it("shows appointment summary after customer info", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.currentView = 3;
+      await nextTick();
+      expect(wrapper.find('[data-test="appointment-summary"]').exists()).toBe(true);
+    });
+  });
+
+  describe("Error States", () => {
+    it("shows appointment not found error", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.appointmentNotFoundError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("error");
+    });
+
+    it("shows booking error", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.confirmAppointmentError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("error");
+    });
+  });
+
+  describe("Success States", () => {
+    it("shows success message after booking", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.confirmAppointmentSuccess = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("success");
+    });
+
+    it("shows success message after cancellation", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.cancelAppointmentSuccess = true;
+      wrapper.vm.currentView = 4;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("success");
+    });
+  });
+
+  describe("Navigation", () => {
+    it("allows going back to previous steps", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.currentView = 2;
+      await nextTick();
+      wrapper.vm.currentView = 1; // Simulate going back
+      await nextTick();
+      expect(wrapper.find('[data-test="calendar-view"]').exists()).toBe(true);
+    });
+
+    it("disables previous steps in stepper when appointment hash is present", async () => {
+      const wrapper = createWrapper({ appointmentHash: "valid" });
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-stepper"]').attributes('data-disable-previous-steps')).toBe("true");
+    });
+  });
+
+  describe("Stepper Navigation", () => {
+    it("updates view when stepper emits change-step", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.currentView = 1;
+      await nextTick();
+      wrapper.vm.currentView = 0; // Simulate stepper navigation
+      await nextTick();
+      expect(wrapper.find('[data-test="service-finder"]').exists()).toBe(true);
+    });
+  });
+
+  describe("Additional Error Callouts", () => {
+    it("shows tooManyAppointmentsWithSameMailError callout in summary", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.currentView = 3;
+      wrapper.vm.tooManyAppointmentsWithSameMailError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+    });
+
+    it("shows updateAppointmentError callout in summary", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.currentView = 3;
+      wrapper.vm.updateAppointmentError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+    });
+
+    it("shows confirmAppointmentError callout after booking", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.confirmAppointmentError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("error");
+    });
+  });
+
+  describe("Rebooking Flow", () => {
+    it("starts at summary and disables previous steps when appointmentHash is present", async () => {
+      const wrapper = createWrapper({ appointmentHash: "somehash" });
+      wrapper.vm.currentView = 3;
+      await nextTick();
+      expect(wrapper.find('[data-test="appointment-summary"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-stepper"]').attributes('data-disable-previous-steps')).toBe("true");
+    });
+
+    it("shows cancellation success callout after cancelling in rebooking", async () => {
+      const wrapper = createWrapper({ appointmentHash: "somehash" });
+      wrapper.vm.currentView = 4;
+      wrapper.vm.cancelAppointmentSuccess = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("success");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("shows booking error callout if confirmAppointmentHash is invalid", async () => {
+      const wrapper = createWrapper({ confirmAppointmentHash: "invalid" });
+      wrapper.vm.confirmAppointmentError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("error");
+    });
+
+    it("shows error callout in calendar view if appointmentNotAvailableError is set", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.currentView = 1;
+      wrapper.vm.appointmentNotAvailableError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+    });
+  });
+
+  describe("Confirmation View", () => {
+    it("shows only confirmation message when confirmAppointmentHash is present", async () => {
+      const wrapper = createWrapper({ confirmAppointmentHash: "valid" });
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-stepper"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="service-finder"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="calendar-view"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="customer-info"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="appointment-summary"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+    });
+
+    it("shows success message after successful confirmation", async () => {
+      const wrapper = createWrapper({ confirmAppointmentHash: "valid" });
+      wrapper.vm.confirmAppointmentSuccess = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("success");
+    });
+
+    it("shows error message if confirmation fails", async () => {
+      const wrapper = createWrapper({ confirmAppointmentHash: "invalid" });
+      wrapper.vm.confirmAppointmentError = true;
+      await nextTick();
+      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("error");
+    });
+  });
+}); 

--- a/zmscitizenview/tests/unit/CustomerInfo.spec.ts
+++ b/zmscitizenview/tests/unit/CustomerInfo.spec.ts
@@ -1,0 +1,153 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, beforeEach } from "vitest";
+import { nextTick, ref } from "vue";
+
+// @ts-expect-error: Vue SFC import for test
+import CustomerInfo from "@/components/Appointment/CustomerInfo.vue";
+
+describe("CustomerInfo", () => {
+  const mockT = (key: string) => key;
+  let mockCustomerData;
+  let mockSelectedProvider;
+
+  beforeEach(() => {
+    mockCustomerData = ref({
+      firstName: "",
+      lastName: "",
+      mailAddress: "",
+      telephoneNumber: "",
+      customTextfield: "",
+      customTextfield2: "",
+    });
+    mockSelectedProvider = ref({
+      scope: {
+        telephoneActivated: false,
+        telephoneRequired: false,
+        customTextfieldActivated: false,
+        customTextfieldRequired: false,
+        customTextfield2Activated: false,
+        customTextfield2Required: false,
+      },
+    });
+  });
+
+  const createWrapper = () => {
+    return mount(CustomerInfo, {
+      props: {
+        t: mockT,
+      },
+      global: {
+        provide: {
+          customerData: { customerData: mockCustomerData },
+          selectedTimeslot: { selectedProvider: mockSelectedProvider },
+        },
+        stubs: {
+          'muc-input': {
+            template: '<input :id="id" />',
+            props: ['id'],
+          },
+          'muc-text-area': {
+            template: '<textarea :id="id" />',
+            props: ['id'],
+          },
+        },
+      },
+    });
+  };
+
+  describe("Form Validation", () => {
+    it("should not emit next when form is invalid", async () => {
+      const wrapper = createWrapper();
+      await nextTick();
+      const nextButton = wrapper.find(".m-button-group button:last-child");
+      await nextButton.trigger("click");
+      await nextTick();
+      expect(wrapper.emitted("next")).toBeUndefined();
+    });
+
+    it("should show error message for invalid email format", async () => {
+      mockCustomerData.value.firstName = "Max";
+      mockCustomerData.value.lastName = "Mustermann";
+      mockCustomerData.value.mailAddress = "invalid-email";
+      const wrapper = createWrapper();
+      await nextTick();
+      const nextButton = wrapper.find(".m-button-group button:last-child");
+      await nextButton.trigger("click");
+      await nextTick();
+      // Check error message is present
+      expect(wrapper.html()).toContain("errorMessageMailAddressValidation");
+      expect(wrapper.emitted("next")).toBeUndefined();
+    });
+
+    it("should emit next when form is valid", async () => {
+      mockCustomerData.value.firstName = "Max";
+      mockCustomerData.value.lastName = "Mustermann";
+      mockCustomerData.value.mailAddress = "max@test.de";
+      const wrapper = createWrapper();
+      await nextTick();
+      const nextButton = wrapper.find(".m-button-group button:last-child");
+      await nextButton.trigger("click");
+      await nextTick();
+      expect(wrapper.emitted("next")).toBeTruthy();
+    });
+  });
+
+  describe("Optional Fields", () => {
+    it("should not show telephone field when not activated", async () => {
+      // default is not activated
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.find("#telephonenumber").exists()).toBe(false);
+    });
+
+    it("should show telephone field when activated", async () => {
+      mockSelectedProvider.value = {
+        scope: {
+          telephoneActivated: true,
+          telephoneRequired: false,
+          customTextfieldActivated: false,
+          customTextfieldRequired: false,
+          customTextfield2Activated: false,
+          customTextfield2Required: false,
+        },
+      };
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.find("#telephonenumber").exists()).toBe(true);
+    });
+
+    it("should not show custom textfield when not activated", async () => {
+      // default is not activated
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.find("#remarks").exists()).toBe(false);
+    });
+
+    it("should show custom textfield when activated", async () => {
+      mockSelectedProvider.value = {
+        scope: {
+          telephoneActivated: false,
+          telephoneRequired: false,
+          customTextfieldActivated: true,
+          customTextfieldRequired: false,
+          customTextfield2Activated: false,
+          customTextfield2Required: false,
+        },
+      };
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.find("#remarks").exists()).toBe(true);
+    });
+  });
+
+  describe("Navigation", () => {
+    it("should emit back when back button is clicked", async () => {
+      const wrapper = createWrapper();
+      await nextTick();
+      const backButton = wrapper.find(".m-button-group button:first-child");
+      await backButton.trigger("click");
+      await nextTick();
+      expect(wrapper.emitted("back")).toBeTruthy();
+    });
+  });
+}); 

--- a/zmscitizenview/tests/unit/SubserviceListItem.spec.ts
+++ b/zmscitizenview/tests/unit/SubserviceListItem.spec.ts
@@ -1,0 +1,131 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, beforeEach } from "vitest";
+import { nextTick } from "vue";
+
+// @ts-expect-error: Vue SFC import for test
+import SubserviceListItem from "@/components/Appointment/SubserviceListItem.vue";
+
+describe("SubserviceListItem", () => {
+  const mockSubService = {
+    id: "1",
+    name: "Test Subservice",
+    count: 0,
+    maxQuantity: 5,
+    providers: [{ slots: 3 }],
+  };
+
+  const createWrapper = (props = {}) => {
+    return mount(SubserviceListItem, {
+      props: {
+        subService: mockSubService,
+        currentSlots: 0,
+        maxSlotsPerAppointment: 10,
+        ...props,
+      },
+    });
+  };
+
+  describe("Rendering", () => {
+    it("renders the subservice name", () => {
+      const wrapper = createWrapper();
+      expect(wrapper.text()).toContain(mockSubService.name);
+    });
+  });
+
+  describe("Event Handling", () => {
+    it("emits change event when count is updated", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.count = 2;
+      await nextTick();
+      const changeEvent = wrapper.emitted("change");
+      expect(changeEvent).toBeTruthy();
+      if (changeEvent) {
+        expect(changeEvent[0]).toEqual([mockSubService.id, 2]);
+      }
+    });
+  });
+
+  describe("Computed Properties", () => {
+    it("computes maxValue correctly", () => {
+      const wrapper = createWrapper();
+      expect(wrapper.vm.maxValue).toBe(mockSubService.maxQuantity);
+    });
+
+    it("computes disabled correctly", () => {
+      const wrapper = createWrapper();
+      expect(wrapper.vm.disabled).toBe(false);
+    });
+  });
+
+  describe("Business Logic", () => {
+    it("maxValue equals count when checkPlusEndabled is false", () => {
+      const wrapper = createWrapper({
+        currentSlots: 10, // will make checkPlusEndabled false
+        maxSlotsPerAppointment: 5,
+      });
+      wrapper.vm.count = 2;
+      expect(wrapper.vm.maxValue).toBe(2);
+    });
+
+    it("maxValue equals subService.maxQuantity when checkPlusEndabled is true", () => {
+      const wrapper = createWrapper({
+        currentSlots: 0, // will make checkPlusEndabled true
+        maxSlotsPerAppointment: 10,
+      });
+      expect(wrapper.vm.maxValue).toBe(mockSubService.maxQuantity);
+    });
+
+    it("disabled is true when checkPlusEndabled is false and count is 0", () => {
+      const wrapper = createWrapper({
+        currentSlots: 10, // will make checkPlusEndabled false
+        maxSlotsPerAppointment: 5,
+      });
+      wrapper.vm.count = 0;
+      expect(wrapper.vm.disabled).toBe(true);
+    });
+
+    it("disabled is false when checkPlusEndabled is true", () => {
+      const wrapper = createWrapper({
+        currentSlots: 0, // will make checkPlusEndabled true
+        maxSlotsPerAppointment: 10,
+      });
+      expect(wrapper.vm.disabled).toBe(false);
+    });
+
+    it("checkPlusEndabled is true when currentSlots + minProviderSlots <= maxSlotsPerAppointment", () => {
+      const wrapper = createWrapper({
+        currentSlots: 0,
+        maxSlotsPerAppointment: 10,
+        subService: { ...mockSubService, providers: [{ slots: 3 }, { slots: 2 }] },
+      });
+      expect(wrapper.vm.checkPlusEndabled).toBe(true);
+    });
+
+    it("checkPlusEndabled is false when currentSlots + minProviderSlots > maxSlotsPerAppointment", () => {
+      const wrapper = createWrapper({
+        currentSlots: 9,
+        maxSlotsPerAppointment: 10,
+        subService: { ...mockSubService, providers: [{ slots: 3 }, { slots: 2 }] },
+      });
+      expect(wrapper.vm.checkPlusEndabled).toBe(false);
+    });
+
+    it("getMinSlotOfProvider returns the minimum slot value", () => {
+      const wrapper = createWrapper({
+        subService: { ...mockSubService, providers: [{ slots: 5 }, { slots: 2 }, { slots: 8 }] },
+      });
+      expect(wrapper.vm.getMinSlotOfProvider(wrapper.vm.$props.subService.providers)).toBe(2);
+    });
+
+    it("emits correct id and count when count changes", async () => {
+      const wrapper = createWrapper();
+      wrapper.vm.count = 3;
+      await nextTick();
+      const changeEvent = wrapper.emitted("change");
+      expect(changeEvent).toBeTruthy();
+      if (changeEvent) {
+        expect(changeEvent[0]).toEqual([mockSubService.id, 3]);
+      }
+    });
+  });
+}); 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive unit tests for appointment booking components, including AppointmentView, AppointmentSummary, CustomerInfo, ServiceFinder, SubserviceListItem, and AltchaCaptcha.
  - Tests cover UI rendering, validation, event handling, navigation, error and success states, and conditional logic to ensure robust component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->