### PR TITLE
fix(ZMSKVR-351): Skip weekday validation for split series parts

### DIFF
--- a/zmsadmin/js/page/availabilityDay/form/validate.js
+++ b/zmsadmin/js/page/availabilityDay/form/validate.js
@@ -37,7 +37,14 @@ const validate = (data, props) => {
 
 function validateWeekdays(data) {
     let errorList = [];
+
+    console.log(data);
     
+    // Skip validation if this is part of a split series
+    if (data.kind === 'origin' || data.kind === 'future') {
+        return errorList;
+    }
+
     // Check if date range is valid
     const startDate = moment.unix(data.startDate);
     const endDate = moment.unix(data.endDate);

--- a/zmsadmin/js/page/availabilityDay/form/validate.js
+++ b/zmsadmin/js/page/availabilityDay/form/validate.js
@@ -37,8 +37,6 @@ const validate = (data, props) => {
 
 function validateWeekdays(data) {
     let errorList = [];
-
-    console.log(data);
     
     // Skip validation if this is part of a split series
     if (data.kind === 'origin' || data.kind === 'future') {

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -477,9 +477,14 @@ class Availability extends Schema\Entity
         return $errorList;
     }
 
-    public function validateWeekdays(\DateTimeInterface $startDate, \DateTimeInterface $endDate, array $weekday): array
+    public function validateWeekdays(\DateTimeInterface $startDate, \DateTimeInterface $endDate, array $weekday, string $kind): array
     {
         $errorList = [];
+
+        // Skip validation if this is part of a split series
+        if ($kind === 'origin' || $kind === 'future') {
+            return $errorList;
+        }
 
         if ($startDate > $endDate) {
             return $errorList;

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -219,7 +219,7 @@ class AvailabilityList extends Base
         foreach ($this as $availability) {
             $errorList = array_merge(
                 $errorList,
-                $availability->validateWeekdays($startDate, $endDate, $weekday),
+                $availability->validateWeekdays($startDate, $endDate, $weekday, $kind),
                 $availability->validateStartTime($today, $tomorrow, $startDate, $endDate, $selectedDate, $kind),
                 $availability->validateEndTime($startDate, $endDate),
                 $availability->validateOriginEndTime($today, $yesterday, $endDate, $selectedDate, $kind),


### PR DESCRIPTION
 Skip weekday validation for split series parts when creating an exclusion that splits an availability series into three parts (before/exclusion/after), the weekday validation was preventing saving of the split parts because they might not contain the originally selected weekday in their shorter date ranges. Add kind parameter to PHP validateWeekdays() method, skip weekday validation for 'origin' and 'future' parts of split series, update JavaScript validation to use kind instead of processType, and add debug logging for validation data.
 
 
 e.g. the following series
 ```
Montag	jede Woche	17.06.2025	30.06.2025	07:00 - 20:00	Terminkunden	5min	4/0/4	2-60	Neue Öffnungszeit
```

is split:
```
Zeitraum: 17.06.2025 bis 22.06.2025, Uhrzeit: von 07:00 bis 20:00, : Neue Öffnungszeit

Zeitraum: 23.06.2025 bis 23.06.2025, Uhrzeit: von 07:00 bis 20:00, Typ: Terminkunden, Wochentag: Montag: Ausnahme zu Terminserie Neue Öffnungszeit

Zeitraum: 24.06.2025 bis 30.06.2025, Uhrzeit: von 07:00 bis 20:00, Typ: Terminkunden, Wochentag: Montag: Fortführung der Terminserie Neue Öffnungszeit
 ```

Monday no longer appears in the first date range 17.06.2025 bis 22.06.2025.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Weekday validation is now automatically skipped for availability entries marked as "origin" or "future".

- **Bug Fixes**
  - Improved validation logic to prevent unnecessary weekday checks for certain types of availability entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->