### PR TITLE
fix(ZMSKVR-471 ZMSKVR-486): centralize and correct estimated service duration calculation in zmscitizenview and add comprehensive unit tests for calculateEstimatedDuration utility

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentSummary.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSummary.vue
@@ -259,6 +259,7 @@ import {
   SelectedTimeslotProvider,
 } from "@/types/ProvideInjectTypes";
 import { SubService } from "@/types/SubService";
+import { calculateEstimatedDuration } from "@/utils/calculateEstimatedDuration";
 
 defineProps<{
   isRebooking: boolean;
@@ -344,36 +345,10 @@ const rescheduleAppointment = () => emit("rescheduleAppointment");
  * The provider is queried for the service and each subservice because the slots for the respective service are stored in this provider.
  */
 const estimatedDuration = () => {
-  let time = 0;
-  const serviceProvider = selectedService.value?.providers?.find(
-    (provider: OfficeImpl) => provider.id == selectedProvider.value?.id
+  return calculateEstimatedDuration(
+    selectedService.value,
+    selectedProvider.value
   );
-  if (
-    serviceProvider &&
-    serviceProvider.slots &&
-    selectedService.value &&
-    selectedService.value.count
-  ) {
-    time =
-      selectedService.value.count *
-      serviceProvider.slots *
-      serviceProvider.slotTimeInMinutes;
-  }
-
-  if (selectedService.value?.subServices) {
-    selectedService.value.subServices.forEach((subservice: SubService) => {
-      const subserviceProvider = subservice.providers?.find(
-        (provider: OfficeImpl) => provider.id == selectedProvider.value?.id
-      );
-      if (subserviceProvider && subservice.count && subserviceProvider.slots) {
-        time +=
-          subservice.count *
-          subserviceProvider.slots *
-          subserviceProvider.slotTimeInMinutes;
-      }
-    });
-  }
-  return time;
 };
 </script>
 

--- a/zmscitizenview/src/components/Appointment/CalendarView.vue
+++ b/zmscitizenview/src/components/Appointment/CalendarView.vue
@@ -467,6 +467,7 @@ import {
   SelectedServiceProvider,
   SelectedTimeslotProvider,
 } from "@/types/ProvideInjectTypes";
+import { calculateEstimatedDuration } from "@/utils/calculateEstimatedDuration";
 
 const props = defineProps<{
   baseUrl: string | undefined;
@@ -1069,36 +1070,10 @@ const handleTimeSlotSelection = async (officeId: number, timeSlot: number) => {
  * The provider is queried for the service and each subservice because the slots for the respective service are stored in this provider.
  */
 const estimatedDuration = () => {
-  let time = 0;
-  const serviceProvider = selectedService.value?.providers?.find(
-    (provider) => provider.id == selectedProvider.value?.id
+  return calculateEstimatedDuration(
+    selectedService.value,
+    selectedProvider.value
   );
-  if (
-    serviceProvider &&
-    serviceProvider.slots &&
-    selectedService.value &&
-    selectedService.value.count
-  ) {
-    time =
-      selectedService.value.count *
-      serviceProvider.slots *
-      serviceProvider.slotTimeInMinutes;
-  }
-
-  if (selectedService.value?.subServices) {
-    selectedService.value.subServices.forEach((subservice) => {
-      const subserviceProvider = subservice.providers?.find(
-        (provider) => provider.id == selectedProvider.value?.id
-      );
-      if (subserviceProvider && subservice.count && subserviceProvider.slots) {
-        time +=
-          subservice.count *
-          subserviceProvider.slots *
-          subserviceProvider.slotTimeInMinutes;
-      }
-    });
-  }
-  return time;
 };
 
 const nextStep = () => emit("next");

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -142,6 +142,7 @@ import SubserviceListItem from "@/components/Appointment/SubserviceListItem.vue"
 import { OfficeImpl } from "@/types/OfficeImpl";
 import { SelectedServiceProvider } from "@/types/ProvideInjectTypes";
 import { ServiceImpl } from "@/types/ServiceImpl";
+import { calculateEstimatedDuration } from "@/utils/calculateEstimatedDuration";
 import {
   getServiceBaseURL,
   MAX_SLOTS,
@@ -334,9 +335,8 @@ const changeAppointmentCountOfSubservice = (id: string, count: number) => {
 };
 
 const estimatedDuration = computed(() => {
-  return service.value?.providers?.[0]?.slotTimeInMinutes
-    ? service.value.providers[0].slotTimeInMinutes * currentSlots.value
-    : 0;
+  const provider = service.value?.providers?.[0];
+  return calculateEstimatedDuration(service.value, provider);
 });
 
 /**

--- a/zmscitizenview/src/utils/calculateEstimatedDuration.ts
+++ b/zmscitizenview/src/utils/calculateEstimatedDuration.ts
@@ -1,0 +1,47 @@
+import { OfficeImpl } from "@/types/OfficeImpl";
+import { ServiceImpl } from "@/types/ServiceImpl";
+import { SubService } from "@/types/SubService";
+
+/**
+ * Calculates the total estimated duration for the selected service and subservices for a given provider.
+ * @param service The main service (with subServices and counts)
+ * @param provider The selected provider/office
+ * @returns The total estimated duration in minutes
+ */
+export function calculateEstimatedDuration(
+  service: ServiceImpl | undefined,
+  provider: OfficeImpl | undefined
+): number {
+  if (!service || !provider) return 0;
+
+  let total = 0;
+
+  // Main service
+  const mainProvider = service.providers?.find((p) => p.id == provider.id);
+  if (
+    mainProvider &&
+    service.count &&
+    mainProvider.slots &&
+    mainProvider.slotTimeInMinutes
+  ) {
+    total +=
+      service.count * mainProvider.slots * mainProvider.slotTimeInMinutes;
+  }
+
+  // Subservices
+  if (service.subServices) {
+    for (const sub of service.subServices) {
+      const subProvider = sub.providers?.find((p) => p.id == provider.id);
+      if (
+        subProvider &&
+        sub.count &&
+        subProvider.slots &&
+        subProvider.slotTimeInMinutes
+      ) {
+        total += sub.count * subProvider.slots * subProvider.slotTimeInMinutes;
+      }
+    }
+  }
+
+  return total;
+}

--- a/zmscitizenview/tests/unit/SubserviceListItem.spec.ts
+++ b/zmscitizenview/tests/unit/SubserviceListItem.spec.ts
@@ -127,5 +127,37 @@ describe("SubserviceListItem", () => {
         expect(changeEvent[0]).toEqual([mockSubService.id, 3]);
       }
     });
+
+    it("disables subservice when adding it would exceed maxSlotsPerAppointment", () => {
+      // Simulate a scenario where current slots + subservice slots > maxSlotsPerAppointment
+      const wrapper = createWrapper({
+        currentSlots: 8, // Current slots used
+        maxSlotsPerAppointment: 10, // Maximum allowed
+        subService: { 
+          ...mockSubService, 
+          providers: [{ slots: 3 }] // This subservice needs 3 slots
+        },
+      });
+      
+      // 8 + 3 = 11, which exceeds maxSlotsPerAppointment of 10
+      expect(wrapper.vm.checkPlusEndabled).toBe(false);
+      expect(wrapper.vm.disabled).toBe(true); // Should be disabled when count is 0
+    });
+
+    it("enables subservice when adding it would not exceed maxSlotsPerAppointment", () => {
+      // Simulate a scenario where current slots + subservice slots <= maxSlotsPerAppointment
+      const wrapper = createWrapper({
+        currentSlots: 7, // Current slots used
+        maxSlotsPerAppointment: 10, // Maximum allowed
+        subService: { 
+          ...mockSubService, 
+          providers: [{ slots: 3 }] // This subservice needs 3 slots
+        },
+      });
+      
+      // 7 + 3 = 10, which equals maxSlotsPerAppointment of 10
+      expect(wrapper.vm.checkPlusEndabled).toBe(true);
+      expect(wrapper.vm.disabled).toBe(false); // Should be enabled when count is 0
+    });
   });
 }); 

--- a/zmscitizenview/tests/unit/calculateEstimatedDuration.spec.ts
+++ b/zmscitizenview/tests/unit/calculateEstimatedDuration.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error: Vue SFC import for test
+import { calculateEstimatedDuration } from "@/utils/calculateEstimatedDuration";
+// @ts-expect-error: Vue SFC import for test
+import { ServiceImpl } from "@/types/ServiceImpl";
+// @ts-expect-error: Vue SFC import for test
+import { OfficeImpl } from "@/types/OfficeImpl";
+// @ts-expect-error: Vue SFC import for test
+import { SubService } from "@/types/SubService";
+
+function makeProvider(id: string, slotTimeInMinutes = 10, slots = 1): OfficeImpl {
+  // Minimal OfficeImpl mock
+  return {
+    id,
+    name: `Provider ${id}`,
+    address: { street: "Test", house_number: "1", postal_code: "12345", city: "Teststadt" },
+    showAlternativeLocations: false,
+    displayNameAlternatives: [],
+    organization: "Org",
+    slotTimeInMinutes,
+    priority: 1,
+    slots,
+  } as OfficeImpl;
+}
+
+describe("calculateEstimatedDuration", () => {
+  it("returns 0 if service or provider is undefined", () => {
+    expect(calculateEstimatedDuration(undefined, undefined)).toBe(0);
+    expect(calculateEstimatedDuration({} as ServiceImpl, undefined)).toBe(0);
+    expect(calculateEstimatedDuration(undefined, makeProvider("1"))).toBe(0);
+  });
+
+  it("calculates duration for main service only", () => {
+    const provider = makeProvider("1", 15, 2);
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 2,
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(2 * 2 * 15);
+  });
+
+  it("calculates duration for main service and subservices", () => {
+    const provider = makeProvider("1", 10, 1);
+    const subProvider = makeProvider("1", 5, 3);
+    const subService = {
+      id: "sub1",
+      name: "Sub",
+      maxQuantity: 3,
+      providers: [subProvider],
+      count: 2,
+    } as SubService;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+      subServices: [subService],
+    } as ServiceImpl;
+    // Main: 1*1*10 = 10, Sub: 2*3*5 = 30
+    expect(calculateEstimatedDuration(service, provider)).toBe(40);
+  });
+
+  it("returns 0 if provider is not in service.providers", () => {
+    const provider = makeProvider("1");
+    const otherProvider = makeProvider("2");
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [otherProvider],
+      count: 1,
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(0);
+  });
+
+  it("returns 0 if counts or slots are zero or missing", () => {
+    const provider = makeProvider("1", 10, 0);
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 0,
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(0);
+  });
+
+  it("sums durations for multiple subservices", () => {
+    const provider = makeProvider("1", 10, 1);
+    const sub1 = { id: "sub1", name: "A", maxQuantity: 2, providers: [provider], count: 1 } as SubService;
+    const sub2 = { id: "sub2", name: "B", maxQuantity: 2, providers: [provider], count: 2 } as SubService;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+      subServices: [sub1, sub2],
+    } as ServiceImpl;
+    // Main: 1*1*10 = 10, Sub1: 1*1*10 = 10, Sub2: 2*1*10 = 20
+    expect(calculateEstimatedDuration(service, provider)).toBe(40);
+  });
+
+  it("ignores subservices with no providers", () => {
+    const provider = makeProvider("1", 10, 1);
+    const sub = { id: "sub1", name: "A", maxQuantity: 2, providers: [], count: 2 } as SubService;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+      subServices: [sub],
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(10);
+  });
+
+  it("ignores subservices whose provider does not match", () => {
+    const provider = makeProvider("1", 10, 1);
+    const otherProvider = makeProvider("2", 5, 2);
+    const sub = { id: "sub1", name: "A", maxQuantity: 2, providers: [otherProvider], count: 2 } as SubService;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+      subServices: [sub],
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(10);
+  });
+
+  it("returns 0 if slotTimeInMinutes is missing", () => {
+    const provider = { ...makeProvider("1"), slotTimeInMinutes: undefined } as OfficeImpl;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(0);
+  });
+
+  it("returns 0 if slots is missing", () => {
+    const provider = { ...makeProvider("1"), slots: undefined } as OfficeImpl;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(0);
+  });
+
+  it("ignores subservices with count 0", () => {
+    const provider = makeProvider("1", 10, 1);
+    const sub = { id: "sub1", name: "A", maxQuantity: 2, providers: [provider], count: 0 } as SubService;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+      subServices: [sub],
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(10);
+  });
+
+  it("returns 0 if service.providers is empty", () => {
+    const provider = makeProvider("1", 10, 1);
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [],
+      count: 1,
+    } as ServiceImpl;
+    expect(calculateEstimatedDuration(service, provider)).toBe(0);
+  });
+
+  it("uses only matching provider if subservice has multiple providers", () => {
+    const provider = makeProvider("1", 10, 1);
+    const otherProvider = makeProvider("2", 5, 2);
+    const sub = { id: "sub1", name: "A", maxQuantity: 2, providers: [provider, otherProvider], count: 2 } as SubService;
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+      subServices: [sub],
+    } as ServiceImpl;
+    // Main: 1*1*10 = 10, Sub: 2*1*10 = 20
+    expect(calculateEstimatedDuration(service, provider)).toBe(30);
+  });
+
+  it("matches provider IDs as numbers and strings", () => {
+    const provider = makeProvider(1 as any, 10, 1); // id as number
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 1,
+    } as ServiceImpl;
+    // Pass id as string
+    expect(calculateEstimatedDuration(service, { ...provider, id: "1" } as OfficeImpl)).toBe(10);
+    // Pass id as number
+    expect(calculateEstimatedDuration(service, { ...provider, id: 1 } as OfficeImpl)).toBe(10);
+  });
+
+  it("correctly sums durations with differing slotTimeInMinutes for service and subservices", () => {
+    const provider = makeProvider("1", 10, 1); // main service: 10min per slot
+    const subProvider1 = makeProvider("1", 5, 2); // subservice1: 5min per slot, 2 slots
+    const subProvider2 = makeProvider("1", 20, 1); // subservice2: 20min per slot, 1 slot
+
+    const subService1 = {
+      id: "sub1",
+      name: "Sub1",
+      maxQuantity: 2,
+      providers: [subProvider1],
+      count: 2,
+    } as SubService;
+
+    const subService2 = {
+      id: "sub2",
+      name: "Sub2",
+      maxQuantity: 2,
+      providers: [subProvider2],
+      count: 1,
+    } as SubService;
+
+    const service = {
+      id: "s1",
+      name: "Main",
+      maxQuantity: 5,
+      providers: [provider],
+      count: 3,
+      subServices: [subService1, subService2],
+    } as ServiceImpl;
+
+    // Main: 3*1*10 = 30
+    // Sub1: 2*2*5 = 20
+    // Sub2: 1*1*20 = 20
+    // Total: 30 + 20 + 20 = 70
+    expect(calculateEstimatedDuration(service, provider)).toBe(70);
+  });
+}); 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined appointment duration estimation across multiple components by centralizing the calculation logic into a new utility function.
* **New Features**
  * Introduced a unified method for calculating estimated appointment duration, ensuring consistent results throughout the application.
* **Tests**
  * Added comprehensive tests covering various scenarios to verify the accuracy and reliability of the new duration calculation method.
  * Added tests to validate slot capacity logic in subservice selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->