### PR TITLE
clean(ZMSKVR-429): neutral error page, unified error handling, and test update for zmscalldisplay and zmsticketprinter

### DIFF
--- a/zmscalldisplay/templates/exception/default.twig
+++ b/zmscalldisplay/templates/exception/default.twig
@@ -3,113 +3,12 @@
 
 {% block content %}
 <div class="exception textile">
-			<h1>{{ title }}</h1>
+    <h1>Entschuldigung, es ist ein Fehler aufgetreten.</h1>
     <p>
-    Es ist ein Fehler aufgetreten und die gewünschte Seite kann
-    nicht angezeigt werden. Dies kann unterschiedliche Ursachen
-    haben. In der Regel beheben wir aufkommende Fehler innerhalb
-    kurzer Zeit. Sollte der Fehler wiederholt auftreten, würden
-    wir uns freuen, wenn Sie uns kurz per E-Mail eine Nachricht
-    zukommen lassen könnten. Bitte kopieren Sie auch die
-    Beschreibung des Fehlers mit in ihr Anschreiben, nur so können
-    wir eine schnelle Behebung gewährleisten. Unsere
-    Kontaktadresse für technische Fehler ist: <strong><a href="mailto:support@berlin.de">support@berlin.de</a></strong>
+        Die gewünschte Seite kann derzeit nicht angezeigt werden. Dies kann durch technische Probleme verursacht werden, die kurzfristig behoben werden.<br/>
+        Versuchen Sie bitte zunächst, dieses Gerät neu zu starten. Sollte das Problem weiterhin bestehen, melden Sie die Störung bitte unter:
+        <strong><a href="https://it-services.muenchen.de" target="_blank">https://it-services.muenchen.de</a></strong>
     </p>
-    <h2>
-        Beschreibung des Fehlers
-    </h2>
-    <p>
-    Bei Anfragen zum Fehler schicken Sie bitte die folgenden
-    Informationen mit. Dies hilft uns, den Fehler zuzuordnen und
-    schnell zu beheben.
-    </p>
-    <div class="table-responsive">
-        <table>
-            <tbody><tr>
-                <td>
-                    <strong>Fehlerbeschreibung:</strong>
-                </td>
-                <td>
-                    <span  style="overflow: auto; width: 100%;">{{ failed }}</span>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Fehlerklasse:</strong>
-                </td>
-                <td>
-                    {{exceptionclass}}
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Aufruf:</strong>
-                </td>
-                <td>
-                    {{requesturi}}
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Übertragene Daten:</strong>
-                </td>
-                <td>
-                    <pre style="overflow: auto; width: 100%;">{{requestdata}}</pre>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Methode:</strong>
-                </td>
-                <td>
-                    <span class="caps">{{requestmethod}}</span>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Serverzeit:</strong>
-                </td>
-                <td>
-                    {{servertime}}
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Trace:</strong>
-                </td>
-                <td>
-                see logs for ID #{{uniqueid}}
-                {% if debug %}
-                <pre style=" width: 100%;font-size:10px; background:#eee; border:1px solid #ccc; padding:2px; overflow:auto;">
-- {{file}} ({{line}})
-{{trace}}
-                </pre>
-                {% endif %}
-                </td>
-            </tr>
-            {% if debug %}
-            <tr>
-                <td>
-                    <strong>Curl:</strong>
-                </td>
-                <td>
-                    <pre style="overflow: auto; width: 100%;">curl -X "{{request.method}}" -d "{{requestdata|replace({"\n": "", "    ": ""})}}" "{{requesturi}}"
-                    </pre>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <strong>Response:</strong>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <iframe style="width:100%; height: 600px" src="data:text/html,{{responsedata|url_encode}}"></iframe>
-                </td>
-            </tr>
-            {% endif %}
-        </tbody></table>
-    </div>
 </div>
 
 {% endblock %}

--- a/zmscalldisplay/tests/Zmscalldisplay/IndexTest.php
+++ b/zmscalldisplay/tests/Zmscalldisplay/IndexTest.php
@@ -74,4 +74,17 @@ class IndexTest extends Base
             'Bürgeramt', 
             (string) $response->getBody()
         );    }
+
+    public function testNeutralErrorPageRendering()
+    {
+        $request = static::createBasicRequest('GET', '/');
+        $exception = new \Exception('Simulierter Fehler');
+        $errorMiddleware = \App::$slim->getContainer()->get('errorMiddleware');
+        $errorHandler = $errorMiddleware->getDefaultErrorHandler();
+        $response = $errorHandler($request, $exception, true, true, true);
+
+        $body = (string)$response->getBody();
+        $this->assertStringContainsString('Entschuldigung, es ist ein Fehler aufgetreten.', $body);
+        $this->assertStringContainsString('https://it-services.muenchen.de', $body);
+    }
 }

--- a/zmsticketprinter/bootstrap.php
+++ b/zmsticketprinter/bootstrap.php
@@ -39,3 +39,9 @@ require(APP_PATH . '/config.php');
 
 // load routing
 \BO\Slim\Bootstrap::loadRouting(\App::APP_PATH . '/routing.php');
+
+// Register error handler for all errors (Slim v4 style)
+if (\App::$slim->getContainer()->has('errorMiddleware')) {
+    $errorMiddleware = \App::$slim->getContainer()->get('errorMiddleware');
+    $errorMiddleware->setDefaultErrorHandler(new \BO\Zmsticketprinter\Helper\TwigExceptionHandler());
+}

--- a/zmsticketprinter/routing.php
+++ b/zmsticketprinter/routing.php
@@ -69,8 +69,3 @@ use \Psr\Http\Message\ResponseInterface;
         return \BO\Slim\Render::withHtml($response, '404.twig');
     };
 });
-
-\App::$slim->getContainer()->offsetSet(
-    'errorHandler',
-    new \BO\Zmsticketprinter\Helper\TwigExceptionHandler()
-);

--- a/zmsticketprinter/templates/exception/default.twig
+++ b/zmsticketprinter/templates/exception/default.twig
@@ -1,121 +1,14 @@
 {% extends "layout/main.twig" %}
 {% block title %}{% trans %}Ein Fehler ist aufgetreten{% endtrans %}{% endblock %}
 
-{% block headline %}
-    {{ snippets.headline1(title) }}
-{% endblock %}
-
 {% block pageid %}exception{% endblock %}
 {% block content %}
-
     <div class="textile">
-                <p>
-                Es ist ein Fehler aufgetreten und die gewünschte Seite kann
-                nicht angezeigt werden. Dies kann unterschiedliche Ursachen
-                haben. In der Regel beheben wir aufkommende Fehler innerhalb
-                kurzer Zeit. Sollte der Fehler wiederholt auftreten, würden
-                wir uns freuen, wenn Sie uns kurz per E-Mail eine Nachricht
-                zukommen lassen könnten. Bitte kopieren Sie auch die
-                Beschreibung des Fehlers mit in ihr Anschreiben, nur so können
-                wir eine schnelle Behebung gewährleisten.
-
-                    Bei generellen technischen Fehlern, bitte diese <a href="https://gitlab.com/eappointment/eappointment/-/issues/new">hier melden</a>.
-                </p>
-                <h2>
-                    Beschreibung des Fehlers
-                </h2>
-                <p>
-                Bei Anfragen zum Fehler schicken Sie bitte die folgenden
-                Informationen mit. Dies hilft uns, den Fehler zuzuordnen und
-                schnell zu beheben.
-                </p>
-                <div class="table-responsive">
-                    <table>
-                        <tbody><tr>
-                            <td>
-                                <strong>Fehlerbeschreibung:</strong>
-                            </td>
-                            <td>
-                                <span  style="overflow: auto; width: 100%;">{{ failed }}</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>Fehlerklasse:</strong>
-                            </td>
-                            <td>
-                                {{exceptionclass}}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>Aufruf:</strong>
-                            </td>
-                            <td>
-                                {{requesturi}}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>Übertragene Daten:</strong>
-                            </td>
-                            <td>
-                                <pre style="overflow: auto; width: 100%;">{{requestdata}}</pre>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>Methode:</strong>
-                            </td>
-                            <td>
-                                <span class="caps">{{requestmethod}}</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>Serverzeit:</strong>
-                            </td>
-                            <td>
-                                {{servertime}}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>Trace:</strong>
-                            </td>
-                            <td>
-                            see logs for ID #{{uniqueid}}
-                            {% if debug %}
-                            <pre style=" width: 100%;font-size:10px; background:#eee; border:1px solid #ccc; padding:2px; overflow:auto;">
-- {{file}} ({{line}})
-{{trace}}
-                            </pre>
-                            {% endif %}
-                            </td>
-                        </tr>
-                        {% if debug %}
-                        <tr>
-                            <td>
-                                <strong>Curl:</strong>
-                            </td>
-                            <td>
-                                <pre style="overflow: auto; width: 100%;">curl -X "{{request.method}}" -d "{{requestdata|replace({"\n": "", "    ": ""})}}" "{{requesturi}}"
-                                </pre>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2">
-                                <strong>Response:</strong>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2">
-                                <iframe style="width:100%; height: 600px" src="data:text/html,{{responsedata|url_encode}}"></iframe>
-                            </td>
-                        </tr>
-                        {% endif %}
-                    </tbody></table>
-                </div>
-            </div>
-
+        <h1>Entschuldigung, es ist ein Fehler aufgetreten.</h1>
+        <p>
+            Die gewünschte Seite kann derzeit nicht angezeigt werden. Dies kann durch technische Probleme verursacht werden, die kurzfristig behoben werden.<br/>
+            Versuchen Sie bitte zunächst, dieses Gerät neu zu starten. Sollte das Problem weiterhin bestehen, melden Sie die Störung bitte unter:
+            <strong><a href="https://it-services.muenchen.de" target="_blank">https://it-services.muenchen.de</a></strong>
+        </p>
+    </div>
 {% endblock %}

--- a/zmsticketprinter/tests/Zmsticketprinter/RoutingTest.php
+++ b/zmsticketprinter/tests/Zmsticketprinter/RoutingTest.php
@@ -42,4 +42,17 @@ class RoutingTest extends Base
             (string)$response->getBody()
         );
     }
+
+    public function testNeutralErrorPageRendering()
+    {
+        $request = static::createBasicRequest('GET', '/');
+        $exception = new \Exception('Simulierter Fehler');
+        $errorMiddleware = \App::$slim->getContainer()->get('errorMiddleware');
+        $errorHandler = $errorMiddleware->getDefaultErrorHandler();
+        $response = $errorHandler($request, $exception, true, true, true);
+
+        $body = (string)$response->getBody();
+        $this->assertStringContainsString('Entschuldigung, es ist ein Fehler aufgetreten.', $body);
+        $this->assertStringContainsString('https://it-services.muenchen.de', $body);
+    }
 }

--- a/zmsticketprinter/tests/Zmsticketprinter/RoutingTest.php
+++ b/zmsticketprinter/tests/Zmsticketprinter/RoutingTest.php
@@ -18,12 +18,9 @@ class RoutingTest extends Base
         $request = static::createBasicRequest('GET', '/');
         \App::$language = new \BO\Slim\Language($request, \App::$supportedLanguages);
         $exception = new \BO\Zmsticketprinter\Exception\ScopeNotFound();
-        $container = \App::$slim->getContainer()->get('errorHandler');
-        
-        // Properly invoking the error handler with the correct arguments
-        $errorHandler = new \BO\Slim\TwigExceptionHandler();
+        $errorMiddleware = \App::$slim->getContainer()->get('errorMiddleware');
+        $errorHandler = $errorMiddleware->getDefaultErrorHandler();
         $response = $errorHandler($request, $exception, true, true, true);
-        
         $this->assertStringContainsString(
             'Es konnte zu den angegeben Daten kein Standort gefunden werden.',
             (string)$response->getBody()
@@ -36,12 +33,9 @@ class RoutingTest extends Base
         $exception = new \BO\Zmsclient\Exception();
         $exception->template = 'BO\Zmsapi\Exception\Organisation\OrganisationNotFound';
         $exception->data = ['scope' => new \BO\Zmsentities\Scope(['id' => 141])];
-        $container = \App::$slim->getContainer()->get('errorHandler');
-        
-        // Properly invoking the error handler with the correct arguments
-        $errorHandler = new \BO\Slim\TwigExceptionHandler();
+        $errorMiddleware = \App::$slim->getContainer()->get('errorMiddleware');
+        $errorHandler = $errorMiddleware->getDefaultErrorHandler();
         $response = $errorHandler($request, $exception, true, true, true);
-        
         $this->assertStringContainsString('Ein Fehler ist aufgetreten', (string)$response->getBody());
         $this->assertStringContainsString(
             'Zu dieser Auswahl konnte keine Organisation gefunden werden. Bitte prüfen Sie Ihre Angaben.',


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.

**No more slim application error in zmsticketprinter.**

<img width="1470" alt="Screenshot 2025-07-02 at 16 33 32" src="https://github.com/user-attachments/assets/53253e0b-fac7-4101-b607-826e78be7bfa" />
<img width="1470" alt="Screenshot 2025-07-02 at 16 33 38" src="https://github.com/user-attachments/assets/929b285b-79f4-444a-bca9-35ee6a361e67" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a simplified, neutral error page with a brief apology and external link for reporting issues.

* **Bug Fixes**
  * Updated error handling to display a generic message instead of detailed technical information.

* **Tests**
  * Added new tests to verify the rendering of the neutral error page and updated existing tests to align with the new error handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->