### PR TITLE
feat(zmskvr-344): adjust wording in waitingstastic and in report

### DIFF
--- a/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
@@ -18,11 +18,11 @@ class WaitingReport extends Base
 {
     protected $reportParts = [
         'waitingcount' => 'Wartende Spontankunden',
-        'waitingtime' => 'gemessene Wartezeit Spontankunden',
+        'waitingtime' => 'Durchschnittliche Wartezeit in Min. (Spontankunden)',
         'waitingcount_termin' => 'Wartende Terminkunden',
-        'waitingtime_termin' => 'gemessene Wartezeit Terminkunden',
-        'waytime' => 'gemessene Wegezeit Spontankunden',
-        'waytime_termin' => 'gemessene Wegezeit Terminkunden',
+        'waitingtime_termin' => 'Durchschnittliche Wartezeit in Min. (Terminkunden)',
+        'waytime' => 'Durchschnittliche Wegezeit in Min. (Spontankunden)',
+        'waytime_termin' => 'Durchschnittliche Wegezeit in Min. (Terminkunden)',
     ];
 
     /**
@@ -84,9 +84,9 @@ class WaitingReport extends Base
     {
         $entity = clone $report;
         $totals = array_pop($entity->data);
-        $reportTotal['max'][] = 'Tagesmaximum Spontankunden der gemessenen Zeit';
-        $reportTotal['average'][] = 'Tagesdurchschnitt Spontankunden der gemessenen Zeit';
-        $reportTotal['average_waytime'][] = 'Tagesdurchschnitt Wegezeit Spontankunden';
+        $reportTotal['max'][] = 'Tagesmaximum der Wartezeit in Min. (Spontankunden)';
+        $reportTotal['average'][] = 'Tagesdurchschnitt der Wartezeit in Min. (Spontankunden)';
+        $reportTotal['average_waytime'][] = 'Tagesdurchschnitt der Wegezeit in Min. (Spontankunden)';
         $reportTotal['max'][] = ReportHelper::formatTimeValue($totals['max_waitingtime']);
         $reportTotal['average'][] = ReportHelper::formatTimeValue($totals['average_waitingtime']);
         $reportTotal['average_waytime'][] = ReportHelper::formatTimeValue($totals['average_waytime']);
@@ -97,9 +97,9 @@ class WaitingReport extends Base
         }
         $sheet->fromArray($reportTotal, null, 'A' . ($sheet->getHighestRow() + 1));
 
-        $reportTotal2['max'][] = 'Tagesmaximum Terminkunden der gemessenen Zeit';
-        $reportTotal2['average'][] = 'Tagesdurchschnitt Terminkunden der gemessenen Zeit';
-        $reportTotal2['average_waytime'][] = 'Tagesdurchschnitt Wegezeit Terminkunden';
+        $reportTotal2['max'][] = 'Tagesmaximum der Wartezeit in Min. (Terminkunden)';
+        $reportTotal2['average'][] = 'Tagesdurchschnitt der Wartezeit in Min. (Terminkunden)';
+        $reportTotal2['average_waytime'][] = 'Tagesdurchschnitt der Wegezeit in Min. (Terminkunden)';
         $reportTotal2['max'][] = ReportHelper::formatTimeValue($totals['max_waitingtime_termin']);
         $reportTotal2['average'][] = ReportHelper::formatTimeValue($totals['average_waitingtime_termin']);
         $reportTotal2['average_waytime'][] = ReportHelper::formatTimeValue($totals['average_waytime_termin']);

--- a/zmsstatistic/templates/page/reportWaitingIndex.twig
+++ b/zmsstatistic/templates/page/reportWaitingIndex.twig
@@ -73,7 +73,7 @@
                                 <th class="statistik">
                                     <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesmaximum der<br>Wartezeit in Min.{% endtrans %}</p><br>
                                     <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>Wartezeit in Min.{% endtrans %}</p><br>
-                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br> Wegezeit in Min.{% endtrans %}</p>
+                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>Wegezeit in Min.{% endtrans %}</p>
                                 </th>
                                 <td class="statistik" style="text-align: right;">
                                     <br>
@@ -210,7 +210,7 @@
                                     <br>
                                     <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>Wartezeit in Min.{% endtrans %}</p>
                                     <br>
-                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br> Wegezeit in Min.{% endtrans %}</p>
+                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>Wegezeit in Min.{% endtrans %}</p>
                                 </th>
                                 <td class="statistik" style="text-align: right;">
                                     <br>

--- a/zmsstatistic/templates/page/reportWaitingIndex.twig
+++ b/zmsstatistic/templates/page/reportWaitingIndex.twig
@@ -55,7 +55,7 @@
                                     </span>
                                 </th>
                                 {% if exchangeWaiting.period == "day" %}
-                                <th class="statistik">{{ startDate|format_date(pattern="LLL") }} (Max.)</th>
+                                <th class="statistik">{{ startDate|format_date(pattern="LLL") }} </th>
                                 {% elseif exchangeWaiting.period == "month" %}
                                 <th class="statistik">{{ startDate|date('Y') }}</th>
                                 {% endif %}
@@ -73,7 +73,7 @@
                                 <th class="statistik">
                                     <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesmaximum der<br>Wartezeit in Min.{% endtrans %}</p><br>
                                     <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>Wartezeit in Min.{% endtrans %}</p><br>
-                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>gemessenen Wegezeit in Min.{% endtrans %}</p>
+                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br> Wegezeit in Min.{% endtrans %}</p>
                                 </th>
                                 <td class="statistik" style="text-align: right;">
                                     <br>
@@ -210,7 +210,7 @@
                                     <br>
                                     <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>Wartezeit in Min.{% endtrans %}</p>
                                     <br>
-                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br>gemessenen Wegezeit in Min.{% endtrans %}</p>
+                                    <p style="white-space: nowrap; margin: 0px 0px;">{% trans %}Tagesdurchschnitt der<br> Wegezeit in Min.{% endtrans %}</p>
                                 </th>
                                 <td class="statistik" style="text-align: right;">
                                     <br>

--- a/zmsstatistic/tests/Zmsstatistic/ReportWaitingDepartmentTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportWaitingDepartmentTest.php
@@ -188,7 +188,7 @@ class ReportWaitingDepartmentTest extends Base
 
         $this->assertStringContainsString('csv', $response->getHeaderLine('Content-Disposition'));
         $this->assertStringContainsString(
-            '"Tagesmaximum Spontankunden der gemessenen Zeit";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
+            '"Tagesmaximum der Wartezeit in Min. (Spontankunden)";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
             (string) $response->getBody()
         );
     }

--- a/zmsstatistic/tests/Zmsstatistic/ReportWaitingOrganisationTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportWaitingOrganisationTest.php
@@ -188,7 +188,7 @@ class ReportWaitingOrganisationTest extends Base
 
         $this->assertStringContainsString('csv', $response->getHeaderLine('Content-Disposition'));
         $this->assertStringContainsString(
-            '"Tagesmaximum der Wartezeit in Min. (Spontankunden)t";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
+            '"Tagesmaximum der Wartezeit in Min. (Spontankunden)";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
             (string) $response->getBody()
         );
     }

--- a/zmsstatistic/tests/Zmsstatistic/ReportWaitingOrganisationTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportWaitingOrganisationTest.php
@@ -188,7 +188,7 @@ class ReportWaitingOrganisationTest extends Base
 
         $this->assertStringContainsString('csv', $response->getHeaderLine('Content-Disposition'));
         $this->assertStringContainsString(
-            '"Tagesmaximum Spontankunden der gemessenen Zeit";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
+            '"Tagesmaximum der Wartezeit in Min. (Spontankunden)t";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
             (string) $response->getBody()
         );
     }

--- a/zmsstatistic/tests/Zmsstatistic/ReportWaitingScopeTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportWaitingScopeTest.php
@@ -233,7 +233,7 @@ class ReportWaitingScopeTest extends Base
 
         $this->assertStringContainsString('csv', $response->getHeaderLine('Content-Disposition'));
         $this->assertStringContainsString(
-            'Tagesmaximum Spontankunden der gemessenen Zeit";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
+            'Tagesmaximum der Wartezeit in Min. (Spontankunden)";"532:00";"414:00";"280:00";"160:00";"256:00";"437:00";"455:00";"202:00";"532:00";"359:00";"384:00";"417:00";"148:00";"375:00";"343:00";',
             (string) $response->getBody()
         );
     }
@@ -280,6 +280,6 @@ class ReportWaitingScopeTest extends Base
 
         $this->assertStringContainsString('csv', $response->getHeaderLine('Content-Disposition'));
         $this->assertStringContainsString('"2016";"Januar";"Februar";"März"', (string) $response->getBody());
-        $this->assertStringContainsString('Tagesmaximum Spontankunden der gemessenen Zeit";"532:00";"384:00";"506:00";"532:00"', (string) $response->getBody());
+        $this->assertStringContainsString('Tagesmaximum der Wartezeit in Min. (Spontankunden)";"532:00";"384:00";"506:00";"532:00"', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated report labels to clearly state "Average waiting time in minutes" and "Average way time in minutes" for both spontaneous and appointment customers.
  * Simplified table headers and labels by removing unnecessary wording and clarifying units.
  * Removed the "(Max.)" suffix from certain date headers for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->