### PR TITLE
fix(ZMSKVR-446): fix fallback to X-AuthKey cookie in getXAuthKey, remove legacy Zmsclient cookie fallback

### DIFF
--- a/zmsapi/src/Zmsapi/Helper/UserAuth.php
+++ b/zmsapi/src/Zmsapi/Helper/UserAuth.php
@@ -106,6 +106,7 @@ class UserAuth
 
     /**
      * Get XAuthKey from header
+     * Falls back to X-AuthKey cookie if header is not present
      *
      * @return array $useraccount
     */


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

MailList is now accessible again as superuser.
https://zms.ddev.site/terminvereinbarung/api/2/mails/?resolveReferences=2&limit=1


- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling by updating the fallback method for retrieving authentication keys from cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->