### PR TITLE
hotfix(ZMSKVR): Do not display the unbookable days in available-days filter in ZmsApiClientService.php

### DIFF
--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
@@ -116,7 +116,14 @@ class ZmsApiClientService
             if (!$entity instanceof Calendar) {
                 return new Calendar();
             }
-
+            $bookableDays = new DayList();
+            foreach ($entity->days as $day) {
+                if (isset($day['status']) && $day['status'] === 'bookable') {
+                    $bookableDays->addEntity($day);
+                }
+            }
+            $entity->days = $bookableDays;
+            
             return $entity;
         } catch (\Exception $e) {
             ExceptionService::handleException($e);

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
@@ -123,7 +123,7 @@ class ZmsApiClientService
                 }
             }
             $entity->days = $bookableDays;
-            
+
             return $entity;
         } catch (\Exception $e) {
             ExceptionService::handleException($e);

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableDaysListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Availability/AvailableDaysListControllerTest.php
@@ -50,7 +50,6 @@ class AvailableDaysListControllerTest extends ControllerTestCase
         $responseBody = json_decode((string) $response->getBody(), true);
         $expectedResponse = [
             'availableDays' => [
-                "2024-08-21",
                 "2024-08-22",
                 "2024-08-23",
                 "2024-08-26",


### PR DESCRIPTION
…ter in ZmsApiClientService.php

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of available booking days by displaying only days marked as "bookable" in the calendar view.
  * Updated availability display to exclude a specific date no longer considered bookable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->