### PR TITLE
fix(ZMSKVR-614): adjust error callout when appointment no longer available

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -40,17 +40,6 @@
                 @back="decreaseCurrentView"
                 @next="nextReserveAppointment"
               />
-              <div v-if="appointmentNotAvailableError">
-                <muc-callout type="error">
-                  <template #content>
-                    {{ t("selectedDateNoLongerAvailableText") }}
-                  </template>
-
-                  <template #header>{{
-                    t("selectedDateNoLongerAvailableHeader")
-                  }}</template>
-                </muc-callout>
-              </div>
             </div>
             <div v-if="currentView === 2">
               <customer-info

--- a/zmscitizenview/src/components/Appointment/CalendarView.vue
+++ b/zmscitizenview/src/components/Appointment/CalendarView.vue
@@ -410,13 +410,17 @@
     <muc-callout type="warning">
       <template #header>
         {{
-          showErrorKey === "altcha.invalidCaptcha"
-            ? t("altcha.invalidCaptchaHeader")
-            : t("noAppointmentsAvailableHeader")
+          showErrorKey === "noAppointmentsAvailable" && selectedHour !== null
+            ? t("selectedDateNoLongerAvailableHeader")
+            : t(`${showErrorKey}Header`)
         }}
       </template>
       <template #content>
-        {{ t(showErrorKey) }}
+        {{
+          showErrorKey === "noAppointmentsAvailable" && selectedHour !== null
+            ? t("selectedDateNoLongerAvailableText")
+            : t(`${showErrorKey}Text`)
+        }}
       </template>
     </muc-callout>
   </div>

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -88,7 +88,7 @@
     "expired": "Verifizierung abgelaufen. Versuche es erneut.",
     "footer": "Geschützt durch ALTCHA",
     "invalidCaptchaHeader": "Das hat leider nicht geklappt.",
-    "invalidCaptcha": "Bitte aktualisieren Sie diese Seite.",
+    "invalidCaptchaText": "Bitte aktualisieren Sie diese Seite.",
     "label": "Ich bin kein Bot.",
     "loadError": "Das Widget konnte nicht geladen werden.",
     "verified": "Erfolgreich verifiziert!",

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -43,7 +43,7 @@
   "minutes": "Minuten",
   "next": "Weiter",
   "noAppointmentsAvailableHeader": "Aktuell ist kein Termin verfügbar.",
-  "noAppointmentsAvailable": " Bitte versuchen Sie es noch einmal zu einem späteren Zeitpunkt.",
+  "noAppointmentsAvailableText": " Bitte versuchen Sie es noch einmal zu einem späteren Zeitpunkt.",
   "noServiceFound": "Keine Leistung gefunden",
   "oftenSearchedService": "Häufig gesuchte Leistungen:",
   "overview": "Übersicht",

--- a/zmscitizenview/tests/unit/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentView.spec.ts
@@ -280,14 +280,6 @@ describe("AppointmentView", () => {
       expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="muc-callout"]').attributes('data-type')).toBe("error");
     });
-
-    it("shows error callout in calendar view if appointmentNotAvailableError is set", async () => {
-      const wrapper = createWrapper();
-      wrapper.vm.currentView = 1;
-      wrapper.vm.appointmentNotAvailableError = true;
-      await nextTick();
-      expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
-    });
   });
 
   describe("Confirmation View", () => {

--- a/zmscitizenview/tests/unit/CalendarView.spec.ts
+++ b/zmscitizenview/tests/unit/CalendarView.spec.ts
@@ -1638,7 +1638,7 @@ describe("CalendarView", () => {
       const wrapper = createWrapper({
         props: {
           bookingError: true,
-          bookingErrorKey: "selectedDateNoLongerAvailable",
+          bookingErrorKey: "noAppointmentsAvailable",
         }
       });
 

--- a/zmscitizenview/tests/unit/CalendarView.spec.ts
+++ b/zmscitizenview/tests/unit/CalendarView.spec.ts
@@ -1643,7 +1643,7 @@ describe("CalendarView", () => {
       });
 
       wrapper.vm.selectedHour = 10;
-      await nextTick()
+      await nextTick();
 
       const callout = wrapper.find('[data-test="muc-callout"]');
 

--- a/zmscitizenview/tests/unit/CalendarView.spec.ts
+++ b/zmscitizenview/tests/unit/CalendarView.spec.ts
@@ -1599,8 +1599,8 @@ describe("CalendarView", () => {
 
   });
 
-  describe("Edge Cases", () => {
-    it('shows invalidCaptcha callout when errorKey is altcha.invalidCaptcha', async () => {
+  describe("Error States", () => {
+    it('shows invalidCaptcha warning callout when errorKey is altcha.invalidCaptcha', async () => {
       const wrapper = createWrapper({
         props: {
           bookingError: true,
@@ -1617,7 +1617,7 @@ describe("CalendarView", () => {
       expect(callout.html()).toContain("altcha.invalidCaptcha");
     });
 
-    it('shows noAppointmentsAvailable callout when errorKey is noAppointmentsAvailable', async () => {
+    it('shows noAppointmentsAvailable warning callout when errorKey is noAppointmentsAvailable', async () => {
       const wrapper = createWrapper({
         props: {
           bookingError: true,
@@ -1634,7 +1634,7 @@ describe("CalendarView", () => {
       expect(callout.html()).toContain("noAppointmentsAvailable");
     });
 
-    it('shows selectedDateNoLongerAvailable callout when selectedHour is set and errorKey is noAppointmentsAvailable', async () => {
+    it('shows selectedDateNoLongerAvailable warning callout when selectedHour is set and errorKey is noAppointmentsAvailable', async () => {
       const wrapper = createWrapper({
         props: {
           bookingError: true,
@@ -1652,6 +1652,18 @@ describe("CalendarView", () => {
       expect(callout.html()).toContain("selectedDateNoLongerAvailable");
     });
 
+    it('does not show any callout when bookingError is false', async () => {
+      const wrapper = createWrapper({
+        props: {
+          bookingError: false,
+          bookingErrorKey: "",
+        }
+      });
+
+      await nextTick();
+      const callout = wrapper.find('[data-test="muc-callout"]');
+      expect(callout.exists()).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling in the appointment calendar view, providing more accurate and context-specific messages when no appointments are available or a selected date is no longer available.
  * Removed redundant error message display for unavailable appointments in the calendar view.

* **Style**
  * Updated German localization keys for appointment availability messages to improve consistency.

* **Tests**
  * Enhanced and expanded unit tests for error callout messages in the calendar view.
  * Removed outdated test related to appointment availability error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->