### PR TITLE
restore(ZMSKVR-416): With cherry pick: git cherry-pick -m 1 4b993469284c723e3f80958e81e25d64165870d3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "html",
+  "name": "eappointment",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/zmsadmin/templates/block/process/finished.twig
+++ b/zmsadmin/templates/block/process/finished.twig
@@ -17,7 +17,7 @@
                                 "autofocus": 1,
                                 "name": "process[clients][0][familyName]",
                                 "value": workstation.process.clients|first.familyName,
-                                "maxlength": 50,
+                                "maxlength": 101,
                             }
                         }]
                     ) }}

--- a/zmscitizenview/package-lock.json
+++ b/zmscitizenview/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@muenchen/muc-patternlab-vue": "5.5.0",
-        "@muenchen/muc-patternlab-vue": "5.5.0",
         "altcha": "^1.2.0",
         "jsdom": "^26.0.0",
         "vue": "^3.5.12",

--- a/zmscitizenview/src/components/Appointment/CustomerInfo.vue
+++ b/zmscitizenview/src/components/Appointment/CustomerInfo.vue
@@ -9,24 +9,25 @@
     <muc-input
       id="firstname"
       v-model="customerData.firstName"
-      :error-msg="showErrorMessage ? errorMessageFirstName : undefined"
+      :error-msg="errorDisplayFirstName"
       :label="t('firstName')"
-      max="60"
+      max="50"
       required
     />
     <muc-input
       id="lastname"
       v-model="customerData.lastName"
-      :error-msg="showErrorMessage ? errorMessageLastName : undefined"
+      :error-msg="errorDisplayLastName"
       :label="t('lastName')"
-      max="60"
+      max="50"
       required
     />
     <muc-input
       id="mailaddress"
       v-model="customerData.mailAddress"
-      :error-msg="showErrorMessage ? errorMessageMailAddress : undefined"
+      :error-msg="errorDisplayMailAddress"
       :label="t('mailAddress')"
+      max="50"
       required
     />
     <muc-input
@@ -37,9 +38,10 @@
       "
       id="telephonenumber"
       v-model="customerData.telephoneNumber"
-      :error-msg="showErrorMessage ? errorMessageTelephoneNumber : undefined"
+      :error-msg="errorDisplayTelephoneNumber"
       :label="t('telephoneNumber')"
       :required="selectedProvider.scope.telephoneRequired"
+      max="50"
       placeholder="+491511234567"
     />
     <muc-text-area
@@ -50,9 +52,10 @@
       "
       id="remarks"
       v-model="customerData.customTextfield"
-      :error-msg="showErrorMessage ? errorMessageCustomTextfield : undefined"
+      :error-msg="errorDisplayCustomTextfield"
       :label="selectedProvider.scope.customTextfieldLabel"
       :required="selectedProvider.scope.customTextfieldRequired"
+      maxlength="100"
     />
     <muc-text-area
       v-if="
@@ -62,9 +65,10 @@
       "
       id="remarks2"
       v-model="customerData.customTextfield2"
-      :error-msg="showErrorMessage ? errorMessageCustomTextfield2 : undefined"
+      :error-msg="errorDisplayCustomTextfield2"
       :label="selectedProvider.scope.customTextfield2Label"
       :required="selectedProvider.scope.customTextfield2Required"
+      maxlength="100"
     />
   </form>
   <div class="m-button-group">
@@ -130,34 +134,69 @@ const showErrorMessage = ref<boolean>(false);
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const telephonPattern = /^\+?[0-9]\d{6,14}$/;
 
-const errorMessageFirstName = computed(() =>
-  customerData.value.firstName?.trim()
+const errorMessageFirstName = computed(() => {
+  if (!showErrorMessage.value) return undefined;
+
+  return customerData.value.firstName?.trim()
     ? undefined
-    : props.t("errorMessageFirstName")
+    : props.t("errorMessageFirstName");
+});
+
+const maxLengthMessageFirstName = computed(() =>
+  customerData.value.firstName?.length >= 50
+    ? props.t("errorMessageMaxLength", { max: 50 })
+    : undefined
 );
 
-const errorMessageLastName = computed(() =>
-  customerData.value.lastName?.trim()
+const errorDisplayFirstName = computed(
+  () => errorMessageFirstName.value ?? maxLengthMessageFirstName.value
+);
+
+const errorMessageLastName = computed(() => {
+  if (!showErrorMessage.value) return undefined;
+
+  return customerData.value.lastName?.trim()
     ? undefined
-    : props.t("errorMessageLastName")
+    : props.t("errorMessageLastName");
+});
+
+const maxLengthMessageLastName = computed(() =>
+  customerData.value.lastName?.length >= 50
+    ? props.t("errorMessageMaxLength", { max: 50 })
+    : undefined
+);
+
+const errorDisplayLastName = computed(
+  () => errorMessageLastName.value ?? maxLengthMessageLastName.value
 );
 
 const errorMessageMailAddress = computed(() => {
+  if (!showErrorMessage.value) return undefined;
+
   if (!customerData.value.mailAddress) {
     return props.t("errorMessageMailAddressRequired");
   } else if (!emailPattern.test(customerData.value.mailAddress)) {
     return props.t("errorMessageMailAddressValidation");
-  } else {
-    return undefined;
   }
+  return undefined;
 });
 
+const maxLengthMessageMailAddress = computed(() =>
+  customerData.value.mailAddress?.length >= 50
+    ? props.t("errorMessageMaxLength", { max: 50 })
+    : undefined
+);
+
+const errorDisplayMailAddress = computed(
+  () => errorMessageMailAddress.value ?? maxLengthMessageMailAddress.value
+);
+
 const errorMessageTelephoneNumber = computed(() => {
+  if (!showErrorMessage.value) return undefined;
+
   if (
     !customerData.value.telephoneNumber &&
-    selectedProvider.value &&
-    selectedProvider.value.scope &&
-    selectedProvider.value.scope.telephoneRequired
+    selectedProvider.value?.scope?.telephoneRequired
   ) {
     return props.t("errorMessageTelephoneNumberRequired");
   } else if (
@@ -165,36 +204,66 @@ const errorMessageTelephoneNumber = computed(() => {
     !telephonPattern.test(customerData.value.telephoneNumber)
   ) {
     return props.t("errorMessageTelephoneNumberValidation");
-  } else {
-    return undefined;
   }
+  return undefined;
 });
+
+const maxLengthMessageTelephoneNumber = computed(() =>
+  customerData.value.telephoneNumber?.length >= 50
+    ? props.t("errorMessageMaxLength", { max: 50 })
+    : undefined
+);
+
+const errorDisplayTelephoneNumber = computed(
+  () =>
+    errorMessageTelephoneNumber.value ?? maxLengthMessageTelephoneNumber.value
+);
 
 const errorMessageCustomTextfield = computed(() => {
+  if (!showErrorMessage.value) return undefined;
+
   if (
     !customerData.value.customTextfield &&
-    selectedProvider.value &&
-    selectedProvider.value.scope &&
-    selectedProvider.value.scope.customTextfieldRequired
+    selectedProvider.value?.scope?.customTextfieldRequired
   ) {
     return props.t("errorMessageCustomTextfield");
-  } else {
-    return undefined;
   }
+  return undefined;
 });
 
+const maxLengthMessageCustomTextfield = computed(() =>
+  customerData.value.customTextfield?.length >= 100
+    ? props.t("errorMessageMaxLength", { max: 100 })
+    : undefined
+);
+
+const errorDisplayCustomTextfield = computed(
+  () =>
+    errorMessageCustomTextfield.value ?? maxLengthMessageCustomTextfield.value
+);
+
 const errorMessageCustomTextfield2 = computed(() => {
+  if (!showErrorMessage.value) return undefined;
+
   if (
     !customerData.value.customTextfield2 &&
-    selectedProvider.value &&
-    selectedProvider.value.scope &&
-    selectedProvider.value.scope.customTextfield2Required
+    selectedProvider.value?.scope?.customTextfield2Required
   ) {
     return props.t("errorMessageCustomTextfield2");
-  } else {
-    return undefined;
   }
+  return undefined;
 });
+
+const maxLengthMessageCustomTextfield2 = computed(() =>
+  customerData.value.customTextfield2?.length >= 100
+    ? props.t("errorMessageMaxLength", { max: 100 })
+    : undefined
+);
+
+const errorDisplayCustomTextfield2 = computed(
+  () =>
+    errorMessageCustomTextfield2.value ?? maxLengthMessageCustomTextfield2.value
+);
 
 const validForm = computed(
   () =>

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -32,6 +32,7 @@
   "errorMessageLastName": "Bitte geben Sie Ihren Nachnamen an.",
   "errorMessageMailAddressRequired": "Bitte geben Sie Ihre E-Mail-Adresse an.",
   "errorMessageMailAddressValidation": "Ihre E-Mail-Adresse entspricht nicht dem vorgegebenen Format. Bitte prüfen Sie nochmal, ob Sie sie richtig geschrieben haben.",
+  "errorMessageMaxLength": "Die maximale Länge von {max} Zeichen wurde erreicht.",
   "errorMessageProviderSelection": "Bitte wählen Sie mindestens einen Ort aus, um passende Termine zu sehen.",
   "errorMessageTelephoneNumberRequired": "Bitte geben Sie Ihre Telefonnummer an.",
   "errorMessageTelephoneNumberValidation": "Ihre Telefonnummer entspricht nicht dem vorgegebenen Format. Bitte geben Sie nur ein +-Zeichen und Zahlen ein.",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -34,6 +34,7 @@
   "errorMessageLastName": "Please enter your surname.",
   "errorMessageMailAddressRequired": "Please enter your email address.",
   "errorMessageMailAddressValidation": "Your email address does not correspond to the specified format. Please check again that you have spelt it correctly",
+  "errorMessageMaxLength": "The maximum length of {max} characters has been reached.",
   "errorMessageProviderSelection": "Please select at least one location to see suitable dates.",
   "errorMessageTelephoneNumberRequired": "Please enter your telephone number.",
   "errorMessageTelephoneNumberValidation": "Your telephone number does not correspond to the specified format. Please enter only a + sign and numbers.",

--- a/zmscitizenview/tests/unit/CustomerInfo.spec.ts
+++ b/zmscitizenview/tests/unit/CustomerInfo.spec.ts
@@ -267,4 +267,68 @@ describe("CustomerInfo", () => {
       expect(nextButton.attributes('disabled')).toBe('false');
     });
   });
+
+  const MAX_LENGTH_STANDARD = 50;
+  const MAX_LENGTH_CUSTOM = 100;
+  const setupValidCustomerData = () => {
+    mockCustomerData.value.firstName = "Max";
+    mockCustomerData.value.lastName = "Mustermann";
+    mockCustomerData.value.mailAddress = "max@example.com";
+  };
+
+  describe("Field length validation", () => {
+    it("should show max length error when firstName exceeds maximum length", async () => {
+      setupValidCustomerData();
+      mockCustomerData.value.firstName = "A".repeat(MAX_LENGTH_STANDARD);
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.html()).toContain("errorMessageMaxLength");
+    });
+
+    it("should show max length error when lastName exceeds maximum length", async () => {
+      setupValidCustomerData();
+      mockCustomerData.value.lastName = "B".repeat(MAX_LENGTH_STANDARD);
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.html()).toContain("errorMessageMaxLength");
+    });
+
+    it("should show max length error when mailAdress exceeds maximum length", async () => {
+      setupValidCustomerData();
+      mockCustomerData.value.mailAddress = "a".repeat(MAX_LENGTH_STANDARD - 12) + "@example.com";
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.html()).toContain("errorMessageMaxLength");
+    });
+
+    it("should show max length error when telephoneNumber exceeds maximum length", async () => {
+      setupValidCustomerData();
+      mockCustomerData.value.telephoneNumber = "1".repeat(MAX_LENGTH_CUSTOM);
+      mockSelectedProvider.value.scope.telephoneActivated = true;
+      mockSelectedProvider.value.scope.telephoneRequired = true;
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.html()).toContain("errorMessageMaxLength");
+    });
+
+    it("should show max length error when customTextfield exceeds maximum length", async () => {
+      setupValidCustomerData();
+      mockCustomerData.value.customTextfield = "X".repeat(100);
+      mockSelectedProvider.value.scope.customTextfieldActivated = true;
+      mockSelectedProvider.value.scope.customTextfieldRequired = true;
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.html()).toContain("errorMessageMaxLength");
+    });
+
+    it("should show max length error when customTextfield2 exceeds macimum length", async () => {
+      setupValidCustomerData();
+      mockCustomerData.value.customTextfield2 = "Y".repeat(100);
+      mockSelectedProvider.value.scope.customTextfield2Activated = true;
+      mockSelectedProvider.value.scope.customTextfield2Required = true;
+      const wrapper = createWrapper();
+      await nextTick();
+      expect(wrapper.html()).toContain("errorMessageMaxLength");
+    });
+  });
 });

--- a/zmsdb/migrations/91752499005-change-varchar-of-buerger-name.sql
+++ b/zmsdb/migrations/91752499005-change-varchar-of-buerger-name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `buerger`
+MODIFY `Name` VARCHAR(200)
+    CHARACTER SET utf8
+    COLLATE utf8_unicode_ci
+    NOT NULL DEFAULT '';


### PR DESCRIPTION
feat(zmskvr-416): counter for customtextfields

restored with pull request https://github.com/it-at-m/eappointment/pull/1223 commit hash 4b993469284c723e3f80958e81e25d64165870d3:
```
git cherry-pick -m 1 4b993469284c723e3f80958e81e25d64165870d3
```

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form validation with clear error messages for both missing/invalid input and maximum length violations across all customer input fields.
  * Added standardized error messages for maximum character length in both English and German.

* **Bug Fixes**
  * Input fields now enforce updated maximum character lengths (50 for standard fields, 100 for custom fields).

* **Tests**
  * Added tests to ensure maximum length error messages display correctly for all relevant fields.

* **Chores**
  * Updated database and template to support longer family names (up to 200 characters).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->