### PR TITLE
hotfix(ZMSKVR-741): set zmsticketprinter appointment priority to middle

### DIFF
--- a/zmsdb/src/Zmsdb/ProcessStatusQueued.php
+++ b/zmsdb/src/Zmsdb/ProcessStatusQueued.php
@@ -17,6 +17,7 @@ class ProcessStatusQueued extends Process
     ) {
         $process = Entity::createFromScope($scope, $dateTime);
         $process->setStatus('queued');
+        $process->priority = 2;
         $newQueueNumber = (new Scope())->readWaitingNumberUpdated($scope->id, $dateTime);
         $process->addQueue($newQueueNumber, $dateTime);
         $process = $this->writeNewProcess($process, $dateTime);

--- a/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
+++ b/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
@@ -65,20 +65,20 @@ class ExchangeWaitingscopeTest extends Base
         (new \BO\Zmsdb\ProcessStatusQueued())->writeNewFromTicketprinter($scope, $now);
         $query->writeWaitingTimeCalculated($scope, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(14, $entry['waitingcalculated']);
+        $this->assertEquals(15, $entry['waitingcalculated']);
         $this->assertEquals(0, $entry['waitingcount']);
         $this->assertEquals(0, $entry['waitingtime']);
         // highest values should not be decreased
         $now =  new DateTime('2016-04-01 08:17:00');
         $query->writeWaitingTimeCalculated($scope, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(14, $entry['waitingcalculated']);
+        $this->assertEquals(15, $entry['waitingcalculated']);
         $this->assertEquals(0, $entry['waitingcount']);
         $this->assertEquals(0, $entry['waitingtime']);
         // set waitingtime
         $query->writeWaitingTime($process, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(14, $entry['waitingcalculated']);
+        $this->assertEquals(15, $entry['waitingcalculated']);
         $this->assertEquals(0, $entry['waitingcount']);
         $this->assertEquals(6, $entry['waitingtime']);
         // higher waitingtime

--- a/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
+++ b/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
@@ -54,7 +54,7 @@ class ExchangeWaitingscopeTest extends Base
 
         $query->writeWaitingTimeCalculated($scope, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(7, $entry['waitingcalculated']);
+        $this->assertEquals(11, $entry['waitingcalculated']);
 
         // we now actually expect waitingcount to be zero because it will only be updated in the call to "updateWaitingStatistics" 
         $this->assertEquals(0, $entry['waitingcount']);

--- a/zmsdb/tests/Zmsdb/ProcessTest.php
+++ b/zmsdb/tests/Zmsdb/ProcessTest.php
@@ -880,4 +880,17 @@ class ProcessTest extends Base
         ));
         return $input;
     }
+
+    public function testTicketPrinterProcessPriority()
+    {
+        $now = static::$now;
+        $query = new ProcessStatusQueued();
+        $scope = (new ScopeQuery())->readEntity(141, 0, true);
+        
+        $process = $query->writeNewFromTicketprinter($scope, $now);
+        
+        $this->assertEquals(2, $process->priority, 'Ticket printer processes should have priority 2 (Mittel)');
+        $this->assertEquals(2, $process->queue['priority'], 'Queue priority should be set to 2 for ticket printer processes');
+        $this->assertEquals('queued', $process->status, 'Ticket printer processes should be in queued status');
+    }
 }


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Processes created from the ticket printer are now assigned a priority value of 2.

* **Bug Fixes**
  * Updated test assertions to reflect new expected waiting time values.

* **Tests**
  * Added a new test to verify that ticket printer processes are assigned the correct priority and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->