### PR TITLE
fix(ZMSKVR): Fix PHP deprecation warnings for ucfirst() with null parameters

### DIFF
--- a/zmsapi/src/Zmsapi/WarehousePeriodGet.php
+++ b/zmsapi/src/Zmsapi/WarehousePeriodGet.php
@@ -28,7 +28,7 @@ class WarehousePeriodGet extends BaseController
         $validator = $request->getAttribute('validator');
         $groupby = $validator->getParameter('groupby')->isString()->isBiggerThan(2)->getValue();
 
-        $exchangeClass = '\BO\Zmsdb\Exchange' . ucfirst($subject);
+        $exchangeClass = '\BO\Zmsdb\Exchange' . ucfirst($subject ?? '');
         if (! class_exists($exchangeClass)) {
             throw new Exception\Warehouse\UnknownReportType();
         }

--- a/zmsapi/src/Zmsapi/WarehousePeriodListGet.php
+++ b/zmsapi/src/Zmsapi/WarehousePeriodListGet.php
@@ -26,7 +26,7 @@ class WarehousePeriodListGet extends BaseController
         $period = $validator->getParameter('period')->isString()->isBiggerThan(2)->setDefault('month')->getValue();
         $subject = Validator::value($args['subject'])->isString()->getValue();
         $subjectId = Validator::value($args['subjectId'])->isNumber()->getValue();
-        $exchangeClass = '\BO\Zmsdb\Exchange' . ucfirst($subject);
+        $exchangeClass = '\BO\Zmsdb\Exchange' . ucfirst($subject ?? '');
         if (! class_exists($exchangeClass)) {
             throw new Exception\Warehouse\UnknownReportType();
         }

--- a/zmsapi/src/Zmsapi/WarehouseSubjectGet.php
+++ b/zmsapi/src/Zmsapi/WarehouseSubjectGet.php
@@ -23,7 +23,7 @@ class WarehouseSubjectGet extends BaseController
     ) {
         $workstation = (new Helper\User($request, 2))->checkRights('scope');
         $subject = Validator::value($args['subject'])->isString()->getValue();
-        $exchangeClass = '\BO\Zmsdb\Exchange' . ucfirst($subject);
+        $exchangeClass = '\BO\Zmsdb\Exchange' . ucfirst($subject ?? '');
         if (! class_exists($exchangeClass)) {
             throw new Exception\Warehouse\UnknownReportType();
         }

--- a/zmsclient/src/Zmsclient/Result.php
+++ b/zmsclient/src/Zmsclient/Result.php
@@ -169,7 +169,7 @@ class Result
         $entity = $this->getEntity();
         if (null !== $entity) {
             $class = get_class($entity);
-            $alias = ucfirst(preg_replace('#^.*\\\#', '', $class));
+            $alias = ucfirst(preg_replace('#^.*\\\#', '', $class) ?? '');
             $className = "\\BO\\Zmsentities\\Collection\\" . $alias . "List";
             $collection = new $className($this->getData());
         }

--- a/zmsdldb/src/Dldb/Importer/MySQL/Entity/Base.php
+++ b/zmsdldb/src/Dldb/Importer/MySQL/Entity/Base.php
@@ -71,7 +71,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
     ) {
         try {
             $className = preg_replace_callback('/[_-]([a-z0-9]*)/i', function ($matches) {
-                return ucfirst($matches[1]);
+                return ucfirst($matches[1] ?? '');
             }, $entityName);
             $className = '\\BO\\Dldb\\Importer\\MySQL\\Entity' . $className;
 

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -42,8 +42,8 @@ class Base extends \ArrayObject implements \JsonSerializable
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
-                Sorter::toSortableString(ucfirst($a->name)),
-                Sorter::toSortableString(ucfirst($b->name))
+                Sorter::toSortableString(ucfirst($a->name ?? '')),
+                Sorter::toSortableString(ucfirst($b->name ?? ''))
             );
         });
         return $this;
@@ -53,8 +53,8 @@ class Base extends \ArrayObject implements \JsonSerializable
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
-                Sorter::toSortableString(ucfirst($a->contact['name'])),
-                Sorter::toSortableString(ucfirst($b->contact['name']))
+                Sorter::toSortableString(ucfirst($a->contact['name'] ?? '')),
+                Sorter::toSortableString(ucfirst($b->contact['name'] ?? ''))
             );
         });
         return $this;
@@ -72,8 +72,8 @@ class Base extends \ArrayObject implements \JsonSerializable
     {
         $this->uasort(function ($a, $b) use ($key) {
             return strcmp(
-                Sorter::toSortableString(ucfirst($a[$key])),
-                Sorter::toSortableString(ucfirst($b[$key]))
+                Sorter::toSortableString(ucfirst($a[$key] ?? '')),
+                Sorter::toSortableString(ucfirst($b[$key] ?? ''))
             );
         });
         return $this;

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -46,8 +46,8 @@ class ProcessList extends Base
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
-                Sorter::toSortableString(ucfirst($a->scope->contact['name'])),
-                Sorter::toSortableString(ucfirst($b->scope->contact['name']))
+                Sorter::toSortableString(ucfirst($a->scope->contact['name'] ?? '')),
+                Sorter::toSortableString(ucfirst($b->scope->contact['name'] ?? ''))
             );
         });
         return $this;

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -125,11 +125,11 @@ class ScopeList extends Base
     public function sortByName()
     {
         $this->uasort(function ($a, $b) {
-            $nameA = (isset($a->provider['name'])) ? $a->provider['name'] : $a->shortName;
-            $nameB = (isset($b->provider['name'])) ? $b->provider['name'] : $b->shortName;
+            $nameA = (isset($a->provider['name'])) ? $a->provider['name'] : ($a->shortName ?? '');
+            $nameB = (isset($b->provider['name'])) ? $b->provider['name'] : ($b->shortName ?? '');
             return strcmp(
-                Sorter::toSortableString(ucfirst($nameA)),
-                Sorter::toSortableString(ucfirst($nameB))
+                Sorter::toSortableString(ucfirst($nameA ?? '')),
+                Sorter::toSortableString(ucfirst($nameB ?? ''))
             );
         });
         return $this;

--- a/zmsentities/src/Zmsentities/Schema/Factory.php
+++ b/zmsentities/src/Zmsentities/Schema/Factory.php
@@ -48,6 +48,6 @@ class Factory
         }
         $schema = $this->data['$schema'];
         $entityName = preg_replace('#^.*/([^/]+)\.json#', '$1', $schema);
-        return ucfirst($entityName);
+        return ucfirst($entityName ?? '');
     }
 }


### PR DESCRIPTION
- Add null coalescing operator (??) to all ucfirst() calls to prevent passing null
- Fixes deprecation warnings in PHP 8.1+ for ucfirst() function
- Affected files:
  - zmsentities/src/Zmsentities/Collection/Base.php
  - zmsentities/src/Zmsentities/Collection/ScopeList.php
  - zmsentities/src/Zmsentities/Collection/ProcessList.php
  - zmsentities/src/Zmsentities/Schema/Factory.php
  - zmsapi/src/Zmsapi/WarehouseSubjectGet.php
  - zmsapi/src/Zmsapi/WarehousePeriodGet.php
  - zmsapi/src/Zmsapi/WarehousePeriodListGet.php
  - zmsclient/src/Zmsclient/Result.php
  - zmsdldb/src/Dldb/Importer/MySQL/Entity/Base.php

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
