### PR TITLE
hotfix(ZMSKVR-741): Add a dynamic threshold to low priority spontaneous customers to solve the starvation problem

### DIFF
--- a/zmsdb/tests/Zmsdb/ClusterTest.php
+++ b/zmsdb/tests/Zmsdb/ClusterTest.php
@@ -97,7 +97,7 @@ class ClusterTest extends Base
         $queueList = (new \BO\Zmsdb\Scope())->readQueueListWithWaitingTime($scope, $now);
         $estimatedData = $scope->getWaitingTimeFromQueueList($queueList, $now);
         $this->assertEquals(146, $scope->id);
-        $this->assertEquals(236, $estimatedData['waitingTimeEstimate']);
+        $this->assertEquals(3, $estimatedData['waitingTimeEstimate']);
     }
 
     public function testReadQueueListWithCallTime()

--- a/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
+++ b/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
@@ -65,20 +65,20 @@ class ExchangeWaitingscopeTest extends Base
         (new \BO\Zmsdb\ProcessStatusQueued())->writeNewFromTicketprinter($scope, $now);
         $query->writeWaitingTimeCalculated($scope, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(14, $entry['waitingcalculated']);
+        $this->assertEquals(2, $entry['waitingcalculated']);
         $this->assertEquals(0, $entry['waitingcount']);
         $this->assertEquals(0, $entry['waitingtime']);
         // highest values should not be decreased
         $now =  new DateTime('2016-04-01 08:17:00');
         $query->writeWaitingTimeCalculated($scope, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(14, $entry['waitingcalculated']);
+        $this->assertEquals(2, $entry['waitingcalculated']);
         $this->assertEquals(0, $entry['waitingcount']);
         $this->assertEquals(0, $entry['waitingtime']);
         // set waitingtime
         $query->writeWaitingTime($process, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(14, $entry['waitingcalculated']);
+        $this->assertEquals(2, $entry['waitingcalculated']);
         $this->assertEquals(0, $entry['waitingcount']);
         $this->assertEquals(6, $entry['waitingtime']);
         // higher waitingtime

--- a/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
+++ b/zmsdb/tests/Zmsdb/ExchangeWaitingscopeTest.php
@@ -54,7 +54,7 @@ class ExchangeWaitingscopeTest extends Base
 
         $query->writeWaitingTimeCalculated($scope, $now);
         $entry = $query->readByDateTime($scope, $now);
-        $this->assertEquals(7, $entry['waitingcalculated']);
+        $this->assertEquals(1, $entry['waitingcalculated']);
 
         // we now actually expect waitingcount to be zero because it will only be updated in the call to "updateWaitingStatistics" 
         $this->assertEquals(0, $entry['waitingcount']);


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


"The Starvation Problem"

```
A = Set of appointment customers (Terminkunden)
S = Set of spontaneous customers (Spontankunden)
P = Priority levels: P₁ (high), P₂ (medium), P₃ (low)
T = Time windows between appointments
W = Workstation processing time
Q = Queue ordering function 
```
```
∀ s ∈ S with s.priority = 3
∃ t ∈ T: t < W → s never gets served 
```
For **every low-priority spontaneous customer**,
if there is **any** time window between scheduled appointments that is **too short to serve a customer**,
then **that customer won’t get served**.


Original:

```
Q(customer) = {
  P₁ if customer ∈ A OR customer.priority = 1
  P₂ if customer.priority = 2 AND customer.arrivalTime < next(A).arrivalTime
  P₃ otherwise
} 
```
Simple solution add Priority Aging threshold (Schwelle) to `P₃`:

```
where max wait threshold for `P₃ = (processingTime × queueLength) / workstationCount`
```
