### PR TITLE
feat(ZMSKVR-488): create 404 page for jumpin links with invalid location service or relation in zmscitizenview

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -726,8 +726,10 @@ const handleInvalidJumpinLink = () => {
 };
 
 const redirectToAppointmentStart = () => {
-  window.location.href =
-    "https://stadt.muenchen.de/buergerservice/terminvereinbarung.html#/";
+  // Clear jump-in link parameters and reset to clean start state
+  // This keeps users within our application instead of redirecting to external site
+  const baseUrl = window.location.origin + window.location.pathname;
+  window.location.href = baseUrl;
 };
 
 onMounted(() => {

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -4,6 +4,7 @@
       v-if="
         !confirmAppointmentHash &&
         !apiErrorAppointmentNotFound &&
+        !apiErrorInvalidJumpinLink &&
         currentView < 4
       "
     >
@@ -25,6 +26,7 @@
                 :t="t"
                 @next="setServices"
                 @captchaTokenChanged="captchaToken = $event ?? undefined"
+                @invalidJumpinLink="handleInvalidJumpinLink"
               />
             </div>
 
@@ -179,6 +181,31 @@
               {{ t(apiErrorTranslation.headerKey) }}
             </template>
           </muc-callout>
+
+          <muc-callout
+            v-if="apiErrorInvalidJumpinLink"
+            type="error"
+          >
+            <template #content>
+              <p>{{ t("apiErrorInvalidJumpinLinkText") }}</p>
+              <div
+                class="m-button-group"
+                style="margin-top: 1rem"
+              >
+                <muc-button
+                  icon="arrow-right"
+                  @click="redirectToAppointmentStart"
+                  style="margin-bottom: 0; margin-right: 0"
+                >
+                  {{ t("bookAppointmentStart") }}
+                </muc-button>
+              </div>
+            </template>
+
+            <template #header>
+              {{ t("apiErrorInvalidJumpinLinkHeader") }}
+            </template>
+          </muc-callout>
         </div>
       </div>
     </div>
@@ -188,7 +215,11 @@
 <script setup lang="ts">
 import type { ApiErrorTranslation, ErrorStateMap } from "@/utils/errorHandler";
 
-import { MucCallout, MucStepper } from "@muenchen/muc-patternlab-vue";
+import {
+  MucButton,
+  MucCallout,
+  MucStepper,
+} from "@muenchen/muc-patternlab-vue";
 import { computed, nextTick, onMounted, provide, ref, watch } from "vue";
 
 import { AppointmentDTO } from "@/api/models/AppointmentDTO";
@@ -322,6 +353,7 @@ const apiErrorAppointmentNotAvailable =
   errorStateMap.value.apiErrorAppointmentNotAvailable;
 const apiErrorAppointmentNotFound =
   errorStateMap.value.apiErrorAppointmentNotFound;
+const apiErrorInvalidJumpinLink = errorStateMap.value.apiErrorInvalidJumpinLink;
 
 const isReservingAppointment = ref<boolean>(false);
 const isUpdatingAppointment = ref<boolean>(false);
@@ -687,6 +719,15 @@ const parseAppointmentHash = (hash: string): AppointmentHash | null => {
   } catch {
     return null;
   }
+};
+
+const handleInvalidJumpinLink = () => {
+  handleApiError("invalidJumpinLink", errorStateMap.value);
+};
+
+const redirectToAppointmentStart = () => {
+  window.location.href =
+    "https://stadt.muenchen.de/buergerservice/terminvereinbarung.html#/";
 };
 
 onMounted(() => {

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -162,6 +162,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "next"): void;
   (e: "captchaTokenChanged", token: string | null): void;
+  (e: "invalidJumpinLink"): void;
 }>();
 
 const services = ref<Service[]>([]);
@@ -459,6 +460,28 @@ onMounted(() => {
             subServices: [],
             combinable: foundService.combinable as unknown as Combinable,
           } as ServiceImpl;
+        } else {
+          emit("invalidJumpinLink");
+        }
+      }
+
+      if (props.preselectedOfficeId) {
+        const foundOffice = offices.value.find(
+          (office) => office.id == props.preselectedOfficeId
+        );
+        if (!foundOffice) {
+          emit("invalidJumpinLink");
+        }
+      }
+
+      if (props.preselectedServiceId && props.preselectedOfficeId) {
+        const hasValidRelation = relations.value.some(
+          (relation) =>
+            relation.serviceId == props.preselectedServiceId &&
+            relation.officeId == props.preselectedOfficeId
+        );
+        if (!hasValidRelation) {
+          emit("invalidJumpinLink");
         }
       }
     });

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -121,7 +121,7 @@
   "apiErrorZmsClientCommunicationErrorHeader": "Der Service ist vorübergehend nicht verfügbar.",
   "apiErrorZmsClientCommunicationErrorText": "Der Service ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später noch einmal.",
   "apiErrorInvalidJumpinLinkHeader": "Diese Ansicht kann nicht geladen werden.",
-  "apiErrorInvalidJumpinLinkText": "Der Link zu dieser Seite ist leider fehlerhaft. Starten Sie erneut in die Terminvereinbarung und wählen Sie eine Leistung.",
+  "apiErrorInvalidJumpinLinkText": "Der Link zu dieser Seite ist leider fehlerhaft. Starten Sie die Terminvereinbarung neu, um eine Leistung zu wählen.",
   "appointment": "Termin",
   "appointmentBookingErrorHeader": "Aktivierung fehlgeschlagen",
   "appointmentBookingErrorText": "Aktivierung fehlgeschlagen",

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -120,6 +120,8 @@
   "apiErrorGenericFallbackText": "Bitte versuchen Sie es später erneut.",
   "apiErrorZmsClientCommunicationErrorHeader": "Der Service ist vorübergehend nicht verfügbar.",
   "apiErrorZmsClientCommunicationErrorText": "Der Service ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später noch einmal.",
+  "apiErrorInvalidJumpinLinkHeader": "Diese Ansicht kann nicht geladen werden.",
+  "apiErrorInvalidJumpinLinkText": "Der Link zu dieser Seite ist leider fehlerhaft. Starten Sie erneut in die Terminvereinbarung und wählen Sie eine Leistung.",
   "appointment": "Termin",
   "appointmentBookingErrorHeader": "Aktivierung fehlgeschlagen",
   "appointmentBookingErrorText": "Aktivierung fehlgeschlagen",
@@ -216,5 +218,6 @@
   },
   "listView": "Listenansicht",
   "calendarView": "Kalenderansicht",
-  "loadMore": "Mehr laden"
+  "loadMore": "Mehr laden",
+  "bookAppointmentStart": "Termin vereinbaren"
 }

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -120,6 +120,8 @@
   "apiErrorGenericFallbackText": "Please try again later.",
   "apiErrorZmsClientCommunicationErrorHeader": "Service is temporarily unavailable.",
   "apiErrorZmsClientCommunicationErrorText": "The service is temporarily unavailable. Please try again later.",
+  "apiErrorInvalidJumpinLinkHeader": "This view cannot be loaded.",
+  "apiErrorInvalidJumpinLinkText": "The link to this page is unfortunately incorrect. Please restart the appointment booking and select a service.",
   "appointment": "Appointment",
   "appointmentBookingErrorHeader": "Activation failed.",
   "appointmentBookingErrorText": "Activation failed.",
@@ -216,5 +218,6 @@
   },
   "listView": "List view",
   "calendarView": "Calendar view",
-  "loadMore": "Load more"
+  "loadMore": "Load more",
+  "bookAppointmentStart": "Book appointment"
 }

--- a/zmscitizenview/src/utils/errorHandler.ts
+++ b/zmscitizenview/src/utils/errorHandler.ts
@@ -67,6 +67,7 @@ export function createErrorStateMap(): ErrorStateMap {
     "apiErrorTooManyAppointmentsWithSameMail",
     "apiErrorUnknownError",
     "apiErrorZmsClientCommunicationError",
+    "apiErrorInvalidJumpinLink",
     "apiErrorGenericFallback",
   ] as const;
 

--- a/zmscitizenview/tests/unit/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentView.spec.ts
@@ -335,7 +335,12 @@ describe("AppointmentView", () => {
     it("calls redirectToAppointmentStart when button is clicked", async () => {
       const originalLocation = window.location;
       delete (window as any).location;
-      (window as any).location = { ...originalLocation, href: "" };
+      (window as any).location = { 
+        ...originalLocation, 
+        href: "http://localhost:8082/#/services/000000000000/locations/000000000000",
+        origin: "http://localhost:8082",
+        pathname: "/"
+      };
       
       const wrapper = createWrapper();
       wrapper.vm.errorStates.apiErrorInvalidJumpinLink.value = true;
@@ -344,7 +349,7 @@ describe("AppointmentView", () => {
       const button = wrapper.find('.m-button-group button');
       await button.trigger('click');
       
-      expect(window.location.href).toBe("https://stadt.muenchen.de/buergerservice/terminvereinbarung.html#/");
+      expect(window.location.href).toBe("http://localhost:8082/");
       
       (window as any).location = originalLocation;
     });

--- a/zmscitizenview/tests/unit/errorHandler.spec.ts
+++ b/zmscitizenview/tests/unit/errorHandler.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 
 // @ts-expect-error: Vue SFC import for test
-import { handleApiResponse, createErrorStates } from "@/utils/errorHandler";
+import { handleApiResponse, createErrorStates, handleApiError } from "@/utils/errorHandler";
 
 describe("errorHandler", () => {
   let errorStates: ReturnType<typeof createErrorStates>;
@@ -88,7 +88,6 @@ describe("errorHandler", () => {
       
       handleApiResponse(mixedErrorResponse, errorStates);
       
-      // Should handle the first error with errorCode
       expect(errorStates.apiErrorAppointmentNotFound.value).toBe(true);
       expect(errorStates.apiErrorGenericFallback.value).toBe(false);
     });
@@ -108,6 +107,36 @@ describe("errorHandler", () => {
       handleApiResponse(responseWithoutErrors, errorStates);
       
       expect(errorStates.apiErrorGenericFallback.value).toBe(false);
+    });
+  });
+
+  describe("createErrorStates", () => {
+    it("should include apiErrorInvalidJumpinLink error state", () => {
+      expect(errorStates.apiErrorInvalidJumpinLink).toBeDefined();
+      expect(errorStates.apiErrorInvalidJumpinLink.value).toBe(false);
+    });
+
+    it("should be able to set apiErrorInvalidJumpinLink error state", () => {
+      errorStates.apiErrorInvalidJumpinLink.value = true;
+      expect(errorStates.apiErrorInvalidJumpinLink.value).toBe(true);
+    });
+  });
+
+  describe("handleApiError", () => {
+    it("should set apiErrorInvalidJumpinLink when invalidJumpinLink error is handled", () => {
+      handleApiError("invalidJumpinLink", errorStates.errorStateMap);
+      
+      expect(errorStates.apiErrorInvalidJumpinLink.value).toBe(true);
+      expect(errorStates.apiErrorGenericFallback.value).toBe(false);
+    });
+
+    it("should reset other error states when setting invalidJumpinLink", () => {
+      errorStates.apiErrorAppointmentNotFound.value = true;
+      
+      handleApiError("invalidJumpinLink", errorStates.errorStateMap);
+      
+      expect(errorStates.apiErrorInvalidJumpinLink.value).toBe(true);
+      expect(errorStates.apiErrorAppointmentNotFound.value).toBe(false);
     });
   });
 }); 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-facing error handling for invalid appointment booking links, including a clear error message and a button to restart the booking process.
  * Expanded and standardized error messages for a wide range of appointment and service scenarios in both English and German.

* **Bug Fixes**
  * Improved validation for preselected service and office IDs, ensuring users are notified if an invalid link is used.

* **Tests**
  * Enhanced and added tests to cover invalid link scenarios and comprehensive error state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->