### PR TITLE
feat(GH-1341): Add zmscitizenview coverage report generation to GitHub actions workflow

### DIFF
--- a/.github/workflows/combined-workflow-with-docs.yaml
+++ b/.github/workflows/combined-workflow-with-docs.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/owasp-security-checks.yaml
 
   aggregate-reports:
-    needs: [call-php-unit-tests, call-owasp-security-checks]
+    needs: [call-php-unit-tests, call-zmscitizenview-coverage, call-owasp-security-checks]
     runs-on: ubuntu-latest
     steps:
       - name: Create directories
@@ -49,7 +49,7 @@ jobs:
       - name: Fix directory structure
         run: |
           # Fix coverage reports
-          for module in zmsadmin zmscalldisplay zmscitizenapi zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter zmsapi zmsdb zmsclient; do
+          for module in zmsadmin zmscalldisplay zmscitizenapi zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter zmsapi zmsdb zmsclient zmscitizenview; do
             if [ -d "public/coverage-temp/coverage-$module" ]; then
               mkdir -p "public/coverage/coverage-$module"
               mv "public/coverage-temp/coverage-$module"/* "public/coverage/coverage-$module/"
@@ -58,7 +58,7 @@ jobs:
           rm -rf public/coverage-temp
 
           # Fix security reports
-          for module in zmsadmin zmscalldisplay zmscitizenapi zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter zmsapi zmsdb zmsclient; do
+          for module in zmsadmin zmscalldisplay zmscitizenapi zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter zmsapi zmsdb zmsclient zmscitizenview; do
             if [ -f "public/security-temp/security-report-$module/dependency-check-report.html" ]; then
               mkdir -p "public/security/security-report-$module"
               mv "public/security-temp/security-report-$module/dependency-check-report.html" "public/security/security-report-$module/"

--- a/.github/workflows/combined-workflow-with-docs.yaml
+++ b/.github/workflows/combined-workflow-with-docs.yaml
@@ -2,7 +2,7 @@ name: Combined Workflow with Documentation
 
 on:
   push:
-    branches: [next]
+    branches: [feat-gh-1341-add-zmscitizenview-coverage-report-generation-to-github-actions-workflow]
 
 permissions:
   contents: read
@@ -16,6 +16,9 @@ jobs:
 
   call-php-unit-tests:
     uses: ./.github/workflows/php-unit-tests.yaml
+
+  call-zmscitizenview-coverage:
+    uses: ./.github/workflows/zmscitizenview-coverage.yaml
 
   call-owasp-security-checks:
     uses: ./.github/workflows/owasp-security-checks.yaml

--- a/.github/workflows/combined-workflow-with-docs.yaml
+++ b/.github/workflows/combined-workflow-with-docs.yaml
@@ -2,7 +2,7 @@ name: Combined Workflow with Documentation
 
 on:
   push:
-    branches: [feat-gh-1341-add-zmscitizenview-coverage-report-generation-to-github-actions-workflow]
+    branches: [next]
 
 permissions:
   contents: read

--- a/.github/workflows/combined-workflow.yaml
+++ b/.github/workflows/combined-workflow.yaml
@@ -2,7 +2,7 @@ name: Combined Workflow
 
 on:
   push:
-    branches-ignore: [next]
+    branches-ignore: [feat-gh-1341-add-zmscitizenview-coverage-report-generation-to-github-actions-workflow]
     tags: ['*']
   workflow_call:
 

--- a/.github/workflows/combined-workflow.yaml
+++ b/.github/workflows/combined-workflow.yaml
@@ -2,7 +2,7 @@ name: Combined Workflow
 
 on:
   push:
-    branches-ignore: [feat-gh-1341-add-zmscitizenview-coverage-report-generation-to-github-actions-workflow]
+    branches-ignore: [next]
     tags: ['*']
   workflow_call:
 

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -162,6 +162,7 @@ jobs:
                     <li><a href="coverage/coverage-zmsapi/html/">Zmsapi Coverage</a></li>
                     <li><a href="coverage/coverage-zmsdb/html/">Zmsdb Coverage</a></li>
                     <li><a href="coverage/coverage-zmsclient/html/">Zmsclient Coverage</a></li>
+                    <li><a href="coverage/coverage-zmscitizenview/html/">Zmscitizenview Coverage</a></li>
                   </ul>
                 </div>
 
@@ -180,6 +181,7 @@ jobs:
                     <li><a href="security/security-report-zmsapi/dependency-check-report.html">Zmsapi Security Report</a></li>
                     <li><a href="security/security-report-zmsdb/dependency-check-report.html">Zmsdb Security Report</a></li>
                     <li><a href="security/security-report-zmsclient/dependency-check-report.html">Zmsclient Security Report</a></li>
+                    <li><a href="security/security-report-zmscitizenview/dependency-check-report.html">Zmscitizenview Security Report</a></li>
                     <li><a href="security/zap/zap-scan-report.html">ZAP Scan Reports</a></li>
                   </ul>
                 </div>

--- a/.github/workflows/zmscitizenview-coverage.yaml
+++ b/.github/workflows/zmscitizenview-coverage.yaml
@@ -1,0 +1,110 @@
+name: ZMSCitizenView Coverage
+
+on:
+  workflow_call:
+    outputs:
+      zmscitizenview-test-result:
+        description: "ZMSCitizenView test result"
+        value: ${{ jobs.zmscitizenview-test.outputs.result }}
+
+jobs:
+  zmscitizenview-test:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.set-result.outputs.result }}
+    steps:
+      - name: Checkout GitHub Action
+        uses: actions/checkout@main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: zmscitizenview/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd zmscitizenview
+          npm ci
+
+      - name: Configure Vitest for coverage
+        run: |
+          cd zmscitizenview
+          # Create a temporary vitest config with coverage enabled
+          cat > vitest.coverage.config.ts << 'EOL'
+          import {defineConfig} from "vite";
+          import vue from "@vitejs/plugin-vue";
+          import {fileURLToPath} from "node:url";
+
+          export default defineConfig({
+            plugins: [
+              vue({
+                features: {
+                  customElement: true
+                }
+              })
+            ],
+            resolve: {
+              alias: {
+                "@": fileURLToPath(new URL("./src", import.meta.url)),
+              },
+            },
+            test: {
+              environment: "jsdom",
+              globals: true,
+              coverage: {
+                provider: 'v8',
+                reporter: ['html', 'json', 'lcov', 'text'],
+                reportsDirectory: './coverage',
+                exclude: [
+                  'node_modules/',
+                  'tests/',
+                  'processes/',
+                  '**/*.d.ts',
+                  '**/*.config.*',
+                  '**/*.test.*',
+                  '**/*.spec.*'
+                ]
+              }
+            }
+          })
+          EOL
+
+      - name: Run tests with coverage
+        run: |
+          cd zmscitizenview
+          mkdir -p coverage
+          echo "Running tests with coverage for zmscitizenview"
+          
+          # Run tests with coverage using the temporary config
+          npx vitest run --config vitest.coverage.config.ts --coverage
+          
+          # Clean up temporary config
+          rm vitest.coverage.config.ts
+
+      - name: Verify coverage output
+        run: |
+          cd zmscitizenview
+          echo "=== Coverage directory contents ==="
+          ls -la coverage/
+          if [ -d "coverage/html" ]; then
+            echo "=== HTML coverage files ==="
+            ls -la coverage/html/
+          fi
+          if [ -f "coverage/lcov.info" ]; then
+            echo "=== LCOV file exists ==="
+            head -5 coverage/lcov.info
+          fi
+
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-zmscitizenview
+          path: zmscitizenview/coverage/
+          retention-days: 1
+
+      - name: Set job result
+        id: set-result
+        if: always()
+        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT

--- a/zmscitizenview/package-lock.json
+++ b/zmscitizenview/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^22.15.32",
         "@types/webfontloader": "^1.6.35",
         "@vitejs/plugin-vue": "^6.0.1",
+        "@vitest/coverage-v8": "^3.2.4",
         "@vue/eslint-config-prettier": "10.2.0",
         "@vue/eslint-config-typescript": "14.6.0",
         "@vue/test-utils": "^2.4.1",
@@ -38,6 +39,20 @@
       "resolved": "https://registry.npmjs.org/@altcha/crypto/-/crypto-0.0.1.tgz",
       "integrity": "sha512-qZMdnoD3lAyvfSUMNtC2adRi666Pxdcw9zqfMU5qBOaJWqpN9K+eqQGWqeiKDMqL0SF+EytNG4kR/Pr/99GJ6g==",
       "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -162,6 +177,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1072,6 +1097,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -1114,9 +1149,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2143,6 +2178,40 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -2634,6 +2703,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.4.tgz",
+      "integrity": "sha512-cxrAnZNLBnQwBPByK4CeDaw5sWZtMilJE/Q3iDA0aamgaIVNDF9T6K2/8DfYDZEejZ2jNnDrG9m8MY72HFd0KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.29",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -3875,6 +3963,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4067,6 +4162,60 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -4334,6 +4483,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5330,6 +5507,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {

--- a/zmscitizenview/package.json
+++ b/zmscitizenview/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^22.15.32",
     "@types/webfontloader": "^1.6.35",
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "@vue/eslint-config-prettier": "10.2.0",
     "@vue/eslint-config-typescript": "14.6.0",
     "@vue/test-utils": "^2.4.1",


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Zmscitizenview entries to the published reports site: Test Coverage and OWASP Security Report links.

- Documentation
  - Updated the GitHub Pages index to include Zmscitizenview coverage and security report navigation.

- Chores
  - Introduced an automated test coverage workflow for Zmscitizenview and integrated it into the combined pipeline.
  - Included Zmscitizenview in report aggregation, ensuring its coverage and security reports are organized and published with other modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->