### PR TITLE
fix(ZMSKVR-794): Calendar shows correct month with first available appointments

### DIFF
--- a/zmscitizenview/src/components/Appointment/CalendarView.vue
+++ b/zmscitizenview/src/components/Appointment/CalendarView.vue
@@ -1265,6 +1265,18 @@ const showSelectionForProvider = (provider: OfficeImpl) => {
       availableDaysFetched.value = true;
       minDate.value = new Date((days[0] as any).time);
       maxDate.value = new Date((days[days.length - 1] as any).time);
+
+      // Update viewMonth to show the month with the first available appointment
+      // This ensures the calendar displays the correct month instead of the current month
+      if (selectedDay.value) {
+        viewMonth.value = new Date(
+          selectedDay.value.getFullYear(),
+          selectedDay.value.getMonth(),
+          1
+        );
+        calendarKey.value++; // Force calendar re-render
+      }
+
       error.value = false;
     } else {
       handleError(data);
@@ -1632,6 +1644,18 @@ const handleDaySelection = async (day: any) => {
   selectedHour.value = null;
   selectedDayPart.value = null;
 
+  // Update viewMonth if the selected day is in a different month
+  // This ensures the calendar displays the correct month when navigating to different months
+  if (
+    day &&
+    (!viewMonth.value ||
+      day.getMonth() !== viewMonth.value.getMonth() ||
+      day.getFullYear() !== viewMonth.value.getFullYear())
+  ) {
+    viewMonth.value = new Date(day.getFullYear(), day.getMonth(), 1);
+    calendarKey.value++; // Force calendar re-render
+  }
+
   // Reset to earliest available appointment
   if (timeSlotsInHoursByOffice.value.size > 0) {
     // For hourly view
@@ -1709,6 +1733,20 @@ function updateDateRangeForSelectedProviders() {
         availableDaysForSelectedProviders.length - 1
       ].time
     );
+
+    // Update viewMonth to show the month with the first available appointment
+    // This ensures the calendar displays the correct month when provider selection changes
+    if (
+      minDate.value &&
+      (!selectedDay.value || selectedDay.value < minDate.value)
+    ) {
+      viewMonth.value = new Date(
+        minDate.value.getFullYear(),
+        minDate.value.getMonth(),
+        1
+      );
+      calendarKey.value++; // Force calendar re-render
+    }
   }
   return availableDaysForSelectedProviders;
 }


### PR DESCRIPTION
…pointment

- Update viewMonth to show month with first available appointment instead of current month
- Automatically navigate calendar to correct month when provider selection changes
- Update viewMonth when selecting days in different months
- Force calendar re-render when viewMonth changes via calendarKey increment
- Handle year rollover correctly in month calculations
- Maintain viewMonth when selecting dates within same month
- Add comprehensive test coverage for calendar month display functionality

Resolves issue where calendar displayed empty current month instead of month with available appointments

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Calendar now updates to the correct month when selecting a date in a different month.
  - View automatically aligns to the earliest month with available appointments after loading or changing providers.
  - Proper handling of minimum available date and year rollovers (e.g., December to January).
  - Maintains month view when selecting dates within the same month.

- Tests
  - Added comprehensive tests covering month syncing, provider changes, date validation, navigation boundaries, multi-provider scenarios, and year rollover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->