### PR TITLE
feat(GH-1397): zmsdb and zmsapi php unit tests run locally in separate docker container instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,6 @@ cd zmsapi
 docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
 ```
 
-### Containerized Unit Testing (Docker Compose)
-For `zmsapi` and `zmsdb`, see the [Containerized Testing section above](#special-cases-zmsapi--zmsdb) for the recommended Docker Compose workflow.
-
-For other modules that support containerized testing:
-
 **zmsclient:**
 ```bash
 cd zmsclient

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ cd zmsclient
 docker-compose down && docker-compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
 ```
 
+#### Traditional DDEV Method (overwrites local DB)
 For the modules **zmsapi** and **zmsdb**, test data must be imported. Please note that this will overwrite your local database.
 
-#### Traditional DDEV Method (overwrites local DB)
-zmsapi:
+**zmsapi:**
 ```bash
 cd zmsapi
 rm -rf data
@@ -192,7 +192,7 @@ vendor/bin/importTestData --commit
 ./vendor/bin/phpunit
 ```
 
-zmsdb:
+**zmsdb:**
 ```bash
 ddev ssh
 cd zmsdb

--- a/README.md
+++ b/README.md
@@ -166,14 +166,19 @@ To run unit tests locally refer to the [Github Workflows](https://github.com/it-
   * `--display-failures`
   * `--debug` - Provides detailed test execution information including deprecation warnings and memory usage
 
-For `zmsapi` and `zmsdb` you must first import the test data (see below). 
+
+### Special Cases (zmsapi zmsdb & zmsclient)
+
+**zmsclient:**
 
 For `zmsclient` you need the php base image which starts a local mock server. This json in the mocks must match the signature the entity returned in the requests (usually this is the issue whenever tests fail in `zmsclient`). 
-- `cd zmsclient`
-- `docker-compose down && docker-compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit`
 
-### Special Cases (zmsapi & zmsdb)
-For the modules zmsapi and zmsdb, test data must be imported. Please note that this will overwrite your local database.
+```bash
+cd zmsclient
+docker-compose down && docker-compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
+```
+
+For the modules **zmsapi** and **zmsdb**, test data must be imported. Please note that this will overwrite your local database.
 
 #### Traditional DDEV Method (overwrites local DB)
 zmsapi:
@@ -218,12 +223,6 @@ docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
 # For zmsapi
 cd zmsapi
 docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
-```
-
-**zmsclient:**
-```bash
-cd zmsclient
-docker-compose down && docker-compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
 ```
 
 ### Common Errors

--- a/README.md
+++ b/README.md
@@ -209,11 +209,13 @@ To run isolated, repeatable tests without touching your local database, use Dock
 cd zmsdb
 ./zmsdb-test                    # Run all tests
 ./zmsdb-test --filter="StatusTest::testBasic"  # Run specific test
+./zmsdb-test --reset            # Reset all containers and volumes
 
 # For zmsapi  
 cd zmsapi
 ./zmsapi-test                   # Run all tests
 ./zmsapi-test --filter="StatusGetTest::testRendering"  # Run specific test
+./zmsapi-test --reset           # Reset all containers and volumes
 ```
 
 **Available PHPUnit Flags:**
@@ -262,6 +264,12 @@ cd zmsapi
 * **Subsequent runs**: Reuses existing setup for fast test execution
 * **Filter support**: Accepts all PHPUnit arguments for flexible test execution
 * **DB startup**: Automatically starts MariaDB; if the host port is in use, adjust the compose ports mapping.
+
+**Reset Functionality:**
+* **`--reset`**: Completely removes all containers, volumes, and networks for a fresh start
+* **Use when**: You want to clear all cached dependencies and start completely fresh
+* **What it does**: Runs `docker-compose down -v` to remove everything
+* **After reset**: Next run will be treated as a "first run" with full setup
 
 ### Common Errors
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,47 @@ bin/importTestData --commit
 ./vendor/bin/phpunit
 ```
 
+### Containerized Unit Testing (Docker Compose)
+To run isolated, repeatable tests for `zmsapi` and `zmsdb` without touching your local DB, use the Docker Compose setup. The first run builds and installs everything; subsequent runs reuse containers and skip Composer/apt.
+
+One-time setup (per module):
+
+- zmsdb
+```bash
+cd zmsdb
+docker-compose up -d --build
+docker-compose logs -f test
+```
+
+- zmsapi
+```bash
+cd zmsapi
+docker-compose up -d --build
+docker-compose logs -f test
+```
+
+Fast re-runs (no rebuilds, no container recreation):
+
+- zmsdb
+```bash
+cd zmsdb
+docker-compose up -d --no-build --no-recreate
+docker exec zmsdb-test-1 bash -lc "php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit"
+```
+
+- zmsapi
+```bash
+cd zmsapi
+docker-compose up -d --no-build --no-recreate
+docker exec zmsapi-test-1 bash -lc "php -d memory_limit=1G /zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit"
+```
+
+Tip: If you want to keep containers between sessions (avoid re-installing OS packages), stop/start instead of down/up:
+```bash
+docker-compose stop
+docker-compose start
+```
+
 ### Common Errors
 
 - If you encounter `Too many levels of symbolic links`, remove the `<exclude>` rule for the vendor directory in the module's phpunit.xml.

--- a/README.md
+++ b/README.md
@@ -220,9 +220,15 @@ docker-compose down && docker-compose up --build && docker-compose logs -f test
 cd zmsdb
 docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
 
+Run any test super fast while the mariadb container is up:
+docker-compose run --rm --no-deps test bash -lc 'cd /tmp/workspace/zmsdb && php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter="StatusTest::testBasic"'
+
 # For zmsapi
 cd zmsapi
 docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
+
+Run any test super fast while the mariadb container is up:
+docker-compose run --rm --no-deps test bash -lc 'cd /tmp/workspace/zmsapi && rm -rf data && ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter="StatusGetTest::testRendering"'
 ```
 
 ### Common Errors

--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ cd zmsapi
 ```
 
 **How the Scripts Work:**
-- **First run**: Automatically detects and does full setup (builds containers, installs dependencies)
-- **Subsequent runs**: Reuses existing setup for fast test execution
-- **Filter support**: Accepts `--filter` argument for running specific tests
-- **Port management**: Automatically handles MariaDB startup and port conflicts
+* **First run**: Automatically detects and does full setup (builds containers, installs dependencies)
+* **Subsequent runs**: Reuses existing setup for fast test execution
+* **Filter support**: Accepts `--filter` argument for running specific tests
+* **DB startup**: Automatically starts MariaDB; if the host port is in use, adjust the compose ports mapping.
 
 ### Common Errors
 

--- a/README.md
+++ b/README.md
@@ -203,33 +203,24 @@ bin/importTestData --commit
 #### Containerized Testing (Recommended - isolated environment)
 To run isolated, repeatable tests without touching your local database, use Docker Compose:
 
-**First run (builds and installs everything):**
+**Smart Testing Scripts (Recommended):**
 ```bash
 # For zmsdb
 cd zmsdb
-docker-compose down && docker-compose up --build && docker-compose logs -f test
+./zmsdb-test                    # Run all tests
+./zmsdb-test --filter="StatusTest::testBasic"  # Run specific test
 
 # For zmsapi  
 cd zmsapi
-docker-compose down && docker-compose up --build && docker-compose logs -f test
+./zmsapi-test                   # Run all tests
+./zmsapi-test --filter="StatusGetTest::testRendering"  # Run specific test
 ```
 
-**Subsequent runs (reuses containers, skips dependencies):**
-```bash
-# For zmsdb
-cd zmsdb
-docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
-
-Run any test super fast while the mariadb container is up:
-docker-compose run --rm --no-deps test bash -lc 'cd /tmp/workspace/zmsdb && php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter="StatusTest::testBasic"'
-
-# For zmsapi
-cd zmsapi
-docker-compose up -d mariadb && docker-compose up --no-build --no-deps test
-
-Run any test super fast while the mariadb container is up:
-docker-compose run --rm --no-deps test bash -lc 'cd /tmp/workspace/zmsapi && rm -rf data && ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter="StatusGetTest::testRendering"'
-```
+**How the Scripts Work:**
+- **First run**: Automatically detects and does full setup (builds containers, installs dependencies)
+- **Subsequent runs**: Reuses existing setup for fast test execution
+- **Filter support**: Accepts `--filter` argument for running specific tests
+- **Port management**: Automatically handles MariaDB startup and port conflicts
 
 ### Common Errors
 

--- a/README.md
+++ b/README.md
@@ -216,10 +216,51 @@ cd zmsapi
 ./zmsapi-test --filter="StatusGetTest::testRendering"  # Run specific test
 ```
 
+**Available PHPUnit Flags:**
+```bash
+# Test Selection
+--filter="TestClass::testMethod"    # Run specific test method
+--filter="TestClass"                # Run all tests in a class
+--filter="testMethod"               # Run all tests with matching method name
+--filter="pattern"                  # Run tests matching regex pattern
+
+# Output & Verbosity
+--verbose                           # More detailed output
+--debug                            # Debug information
+--stop-on-failure                  # Stop on first failure
+--stop-on-error                    # Stop on first error
+--stop-on-warning                  # Stop on first warning
+
+# Coverage & Reports
+--coverage-text                    # Text coverage report
+--coverage-html=dir               # HTML coverage report
+--coverage-clover=file.xml        # XML coverage report
+
+# Test Execution
+--group="groupName"                # Run tests in specific group
+--exclude-group="groupName"        # Exclude tests in group
+--testsuite="suiteName"            # Run specific test suite
+```
+
+**Examples:**
+```bash
+# Run specific test with verbose output
+./zmsdb-test --filter="StatusTest::testBasic" --verbose
+
+# Run all tests in a class and stop on first failure
+./zmsapi-test --filter="StatusGetTest" --stop-on-failure
+
+# Run tests with coverage report
+./zmsdb-test --coverage-text
+
+# Run tests excluding a specific group
+./zmsapi-test --exclude-group="slow"
+```
+
 **How the Scripts Work:**
 * **First run**: Automatically detects and does full setup (builds containers, installs dependencies)
 * **Subsequent runs**: Reuses existing setup for fast test execution
-* **Filter support**: Accepts `--filter` argument for running specific tests
+* **Filter support**: Accepts all PHPUnit arguments for flexible test execution
 * **DB startup**: Automatically starts MariaDB; if the host port is in use, adjust the compose ports mapping.
 
 ### Common Errors

--- a/zmsapi/docker-compose.yml
+++ b/zmsapi/docker-compose.yml
@@ -1,0 +1,78 @@
+services:
+  mariadb:
+    image: mariadb:10.11
+    environment:
+      MYSQL_ROOT_PASSWORD: zmsapi
+      MYSQL_DATABASE: zmsbo
+      MYSQL_CHARACTER_SET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
+    ports:
+      - 3306:3306
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pzmsapi"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+  test:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    image: ghcr.io/it-at-m/eappointment-php-base:8.3-dev
+    volumes:
+      - type: bind
+        source: "."
+        target: "/app"
+        consistency: cached
+      - type: bind
+        source: "../zmsdb"
+        target: "/zmsdb"
+      - type: bind
+        source: "../zmsentities"
+        target: "/zmsentities"
+      - type: bind
+        source: "../zmsslim"
+        target: "/zmsslim"
+      - type: bind
+        source: ".."
+        target: "/workspace"
+    environment:
+      MYSQL_PORT: "tcp://mariadb:3306"
+      MYSQL_DATABASE: zmsbo
+      MYSQL_ROOT_PASSWORD: zmsapi
+      ZMS_CONFIG_SECURE_TOKEN: secure-token
+      PHP_MEMORY_LIMIT: "1G"
+    working_dir: /app
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 512M
+    command: >
+      bash -c "
+        set -e
+        echo 'Installing Python dependencies...'
+        apt update && apt install -y python3 python3-click python3-git
+        echo 'Installing MySQL client...'
+        apt install -y mariadb-client
+        echo 'Waiting for database to be ready...'
+        until mysql -h mariadb -u root -pzmsapi -e 'SELECT 1' >/dev/null 2>&1; do
+          echo 'Database not ready yet, waiting...'
+          sleep 2
+        done
+        echo 'Database is ready!'
+        echo 'Setting up module dependencies...'
+        cd /workspace && python3 cli modules reference-libraries --no-symlink
+        echo 'Waiting for composer operations to complete...'
+        sleep 10
+        echo 'Setting PHP memory limit...'
+        php -d memory_limit=1G -v
+        echo 'Setting up test fixtures...'
+        cd /app
+        rm -rf data
+        ln -s /zmsdb/data data
+        php -d memory_limit=1G /zmsdb/bin/importTestData --commit
+        echo 'Running tests...'
+        php -d memory_limit=1G vendor/bin/phpunit
+      "

--- a/zmsapi/docker-compose.yml
+++ b/zmsapi/docker-compose.yml
@@ -4,8 +4,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: zmsapi
       MYSQL_DATABASE: zmsbo
-      MYSQL_CHARACTER_SET: utf8mb4
-      MYSQL_COLLATION: utf8mb4_unicode_ci
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     ports:
       - 3308:3306
     healthcheck:

--- a/zmsapi/docker-compose.yml
+++ b/zmsapi/docker-compose.yml
@@ -24,6 +24,9 @@ services:
         source: ".."
         target: "/host"
         read_only: true
+      - type: volume
+        source: zmsapi-workspace
+        target: /tmp/workspace
     environment:
       MYSQL_PORT: "tcp://mariadb:3306"
       MYSQL_DATABASE: zmsbo
@@ -40,31 +43,40 @@ services:
     command: >
       bash -c "
         set -e
-        echo 'Installing Python dependencies...'
-        apt update && apt install -y python3 python3-click python3-git
-        echo 'Installing MySQL client...'
-        apt install -y mariadb-client rsync
+        echo 'Installing base dependencies (idempotent)...'
+        if [ ! -f /tmp/workspace/.deps_installed ]; then \
+          apt update && apt install -y python3 python3-click python3-git mariadb-client rsync && \
+          touch /tmp/workspace/.deps_installed; \
+        else \
+          echo 'Base dependencies already installed. Skipping.'; \
+        fi
         echo 'Preparing isolated workspace...'
         mkdir -p /tmp/workspace
-        rsync -a --delete /host/ /tmp/workspace/
+        rsync -a --delete --exclude='zmsdb/vendor/' --exclude='zmsapi/vendor/' /host/ /tmp/workspace/
         echo 'Waiting for database to be ready...'
         until mysql -h mariadb -u root -pzmsapi -e 'SELECT 1' >/dev/null 2>&1; do
           echo 'Database not ready yet, waiting...'
           sleep 2
         done
         echo 'Database is ready!'
-        echo 'Setting up module dependencies (symlinks) in isolated workspace...'
-        cd /tmp/workspace && python3 cli modules reference-libraries
-        echo 'Installing composer dependencies...'
-        cd /tmp/workspace/zmsapi && composer install --no-progress --prefer-dist --optimize-autoloader
-        echo 'Regenerating autoloader...'
-        composer dump-autoload -o
+        cd /tmp/workspace
+        if [ ! -d /tmp/workspace/zmsapi/vendor ]; then \
+          echo 'Setting up module dependencies (symlinks) in isolated workspace...'; \
+          python3 cli modules reference-libraries; \
+          echo 'Installing composer dependencies (first run)...'; \
+          cd /tmp/workspace/zmsapi && composer install --no-progress --prefer-dist --optimize-autoloader && composer dump-autoload -o; \
+        else \
+          echo 'Vendor already present. Skipping cli+composer.'; \
+        fi
         echo 'Setting PHP memory limit...'
         php -d memory_limit=1G -v
         echo 'Setting up test fixtures...'
+        cd /tmp/workspace/zmsapi
         rm -rf data
-        ln -s /tmp/workspace/zmsdb/data data
+        ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data
         php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit
         echo 'Running tests...'
         php -d memory_limit=1G vendor/bin/phpunit
       "
+volumes:
+  zmsapi-workspace:

--- a/zmsapi/docker-compose.yml
+++ b/zmsapi/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       MYSQL_CHARACTER_SET: utf8mb4
       MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
-      - 3306:3306
+      - 3308:3306
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pzmsapi"]
       interval: 10s

--- a/zmsapi/docker-compose.yml
+++ b/zmsapi/docker-compose.yml
@@ -21,28 +21,16 @@ services:
     image: ghcr.io/it-at-m/eappointment-php-base:8.3-dev
     volumes:
       - type: bind
-        source: "."
-        target: "/app"
-        consistency: cached
-      - type: bind
-        source: "../zmsdb"
-        target: "/zmsdb"
-      - type: bind
-        source: "../zmsentities"
-        target: "/zmsentities"
-      - type: bind
-        source: "../zmsslim"
-        target: "/zmsslim"
-      - type: bind
         source: ".."
-        target: "/workspace"
+        target: "/host"
+        read_only: true
     environment:
       MYSQL_PORT: "tcp://mariadb:3306"
       MYSQL_DATABASE: zmsbo
       MYSQL_ROOT_PASSWORD: zmsapi
       ZMS_CONFIG_SECURE_TOKEN: secure-token
       PHP_MEMORY_LIMIT: "1G"
-    working_dir: /app
+    working_dir: /tmp/workspace/zmsapi
     deploy:
       resources:
         limits:
@@ -55,24 +43,28 @@ services:
         echo 'Installing Python dependencies...'
         apt update && apt install -y python3 python3-click python3-git
         echo 'Installing MySQL client...'
-        apt install -y mariadb-client
+        apt install -y mariadb-client rsync
+        echo 'Preparing isolated workspace...'
+        mkdir -p /tmp/workspace
+        rsync -a --delete /host/ /tmp/workspace/
         echo 'Waiting for database to be ready...'
         until mysql -h mariadb -u root -pzmsapi -e 'SELECT 1' >/dev/null 2>&1; do
           echo 'Database not ready yet, waiting...'
           sleep 2
         done
         echo 'Database is ready!'
-        echo 'Setting up module dependencies...'
-        cd /workspace && python3 cli modules reference-libraries --no-symlink
-        echo 'Waiting for composer operations to complete...'
-        sleep 10
+        echo 'Setting up module dependencies (symlinks) in isolated workspace...'
+        cd /tmp/workspace && python3 cli modules reference-libraries
+        echo 'Installing composer dependencies...'
+        cd /tmp/workspace/zmsapi && composer install --no-progress --prefer-dist --optimize-autoloader
+        echo 'Regenerating autoloader...'
+        composer dump-autoload -o
         echo 'Setting PHP memory limit...'
         php -d memory_limit=1G -v
         echo 'Setting up test fixtures...'
-        cd /app
         rm -rf data
-        ln -s /zmsdb/data data
-        php -d memory_limit=1G /zmsdb/bin/importTestData --commit
+        ln -s /tmp/workspace/zmsdb/data data
+        php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit
         echo 'Running tests...'
         php -d memory_limit=1G vendor/bin/phpunit
       "

--- a/zmsapi/zmsapi-test
+++ b/zmsapi/zmsapi-test
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # zmsapi-test - Automated testing script for zmsapi module
-# Usage: ./zmsapi-test [--filter="TestClass::testMethod"]
+# Usage: ./zmsapi-test [PHPUnit arguments...]
 
 set -e
 
-# Parse filter argument
-FILTER=""
-if [[ $1 == --filter=* ]]; then
-    FILTER="${1#--filter=}"
-    echo "Running tests with filter: $FILTER"
+# Parse all PHPUnit arguments
+PHPUNIT_ARGS=""
+if [[ $# -gt 0 ]]; then
+    PHPUNIT_ARGS="$*"
+    echo "Running tests with arguments: $PHPUNIT_ARGS"
 fi
 
 # Already in zmsapi directory
@@ -37,8 +37,8 @@ if ! docker-compose ps | grep -q "zmsapi"; then
 else
     echo "Test environment already set up, running tests..."
     # Run tests with or without filter
-                    if [ -n "$FILTER" ]; then
-                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsapi && rm -rf data && ln -sfn /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit --filter=\"$FILTER\""
+                    if [ -n "$PHPUNIT_ARGS" ]; then
+                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsapi && rm -rf data && ln -sfn /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit $PHPUNIT_ARGS"
                 else
                     docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsapi && rm -rf data && ln -sfn /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit"
                 fi

--- a/zmsapi/zmsapi-test
+++ b/zmsapi/zmsapi-test
@@ -20,7 +20,7 @@ if ! docker-compose ps mariadb | grep -q "Up"; then
     docker-compose up -d mariadb
     # Wait for mariadb to be healthy
     echo "Waiting for mariadb to be ready..."
-    until docker-compose exec mariadb mysqladmin ping -h localhost -u root -pzmsapi >/dev/null 2>&1; do
+                    until docker-compose exec -T mariadb mysqladmin ping -h localhost -u root -pzmsapi >/dev/null 2>&1; do
         sleep 2
     done
     echo "MariaDB is ready!"

--- a/zmsapi/zmsapi-test
+++ b/zmsapi/zmsapi-test
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# zmsapi-test - Automated testing script for zmsapi module
+# Usage: ./zmsapi-test [--filter="TestClass::testMethod"]
+
+set -e
+
+# Parse filter argument
+FILTER=""
+if [[ $1 == --filter=* ]]; then
+    FILTER="${1#--filter=}"
+    echo "Running tests with filter: $FILTER"
+fi
+
+# Already in zmsapi directory
+
+# Check if mariadb is running, start if not
+if ! docker-compose ps mariadb | grep -q "Up"; then
+    echo "Starting mariadb container..."
+    docker-compose up -d mariadb
+    # Wait for mariadb to be healthy
+    echo "Waiting for mariadb to be ready..."
+    until docker-compose exec mariadb mysqladmin ping -h localhost -u root -pzmsapi >/dev/null 2>&1; do
+        sleep 2
+    done
+    echo "MariaDB is ready!"
+else
+    echo "MariaDB is already running"
+fi
+
+# Check if docker-compose services are already running
+if ! docker-compose ps | grep -q "zmsapi"; then
+    echo "Setting up test environment (first run)..."
+    docker-compose down
+    docker-compose up --build
+    docker-compose logs -f test
+else
+    echo "Test environment already set up, running tests..."
+    # Run tests with or without filter
+    if [ -n "$FILTER" ]; then
+        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsapi && rm -rf data && ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter=\"$FILTER\""
+    else
+        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsapi && rm -rf data && ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit"
+    fi
+fi

--- a/zmsapi/zmsapi-test
+++ b/zmsapi/zmsapi-test
@@ -2,8 +2,17 @@
 
 # zmsapi-test - Automated testing script for zmsapi module
 # Usage: ./zmsapi-test [PHPUnit arguments...]
+#        ./zmsapi-test --reset (reset all containers and volumes)
 
 set -e
+
+# Check for reset command
+if [[ $1 == "--reset" ]]; then
+    echo "🧹 Resetting zmsapi test environment..."
+    docker-compose down -v
+    echo "✅ Reset complete! All containers and volumes removed."
+    exit 0
+fi
 
 # Parse all PHPUnit arguments
 PHPUNIT_ARGS=""

--- a/zmsapi/zmsapi-test
+++ b/zmsapi/zmsapi-test
@@ -32,7 +32,7 @@ fi
 if ! docker-compose ps | grep -q "zmsapi"; then
     echo "Setting up test environment (first run)..."
     docker-compose down
-    docker-compose up --build
+    docker-compose up -d --build
     docker-compose logs -f test
 else
     echo "Test environment already set up, running tests..."

--- a/zmsapi/zmsapi-test
+++ b/zmsapi/zmsapi-test
@@ -37,9 +37,9 @@ if ! docker-compose ps | grep -q "zmsapi"; then
 else
     echo "Test environment already set up, running tests..."
     # Run tests with or without filter
-    if [ -n "$FILTER" ]; then
-        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsapi && rm -rf data && ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter=\"$FILTER\""
-    else
-        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsapi && rm -rf data && ln -s /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=1G /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit"
-    fi
+                    if [ -n "$FILTER" ]; then
+                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsapi && rm -rf data && ln -sfn /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit --filter=\"$FILTER\""
+                else
+                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsapi && rm -rf data && ln -sfn /tmp/workspace/zmsdb/tests/Zmsdb/fixtures data && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} /tmp/workspace/zmsdb/bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit"
+                fi
 fi

--- a/zmsdb/docker-compose.yml
+++ b/zmsdb/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       MYSQL_CHARACTER_SET: utf8mb4
       MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
-      - 3306:3306
+      - 3307:3306
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pzmsdb"]
       interval: 10s

--- a/zmsdb/docker-compose.yml
+++ b/zmsdb/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  mariadb:
+    image: mariadb:10.11
+    environment:
+      MYSQL_ROOT_PASSWORD: zmsdb
+      MYSQL_DATABASE: zmsbo
+      MYSQL_CHARACTER_SET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
+    ports:
+      - 3306:3306
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pzmsdb"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+  test:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    image: ghcr.io/it-at-m/eappointment-php-base:8.3-dev
+    volumes:
+      - type: bind
+        source: "."
+        target: "/app"
+        consistency: cached
+      - type: bind
+        source: "../zmsentities"
+        target: "/zmsentities"
+      - type: bind
+        source: "../zmsslim"
+        target: "/zmsslim"
+      - type: bind
+        source: ".."
+        target: "/workspace"
+    environment:
+      MYSQL_PORT: "tcp://mariadb:3306"
+      MYSQL_DATABASE: zmsbo
+      MYSQL_ROOT_PASSWORD: zmsdb
+      ZMS_CONFIG_SECURE_TOKEN: secure-token
+      PHP_MEMORY_LIMIT: "1G"
+    working_dir: /app
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 512M
+    command: >
+      bash -c "
+        set -e
+        echo 'Installing Python dependencies...'
+        apt update && apt install -y python3 python3-click python3-git
+        echo 'Installing MySQL client...'
+        apt install -y mariadb-client
+        echo 'Waiting for database to be ready...'
+        until mysql -h mariadb -u root -pzmsdb -e 'SELECT 1' >/dev/null 2>&1; do
+          echo 'Database not ready yet, waiting...'
+          sleep 2
+        done
+        echo 'Database is ready!'
+        echo 'Setting up module dependencies...'
+        cd /workspace && python3 cli modules reference-libraries --no-symlink
+        echo 'Waiting for composer operations to complete...'
+        sleep 10
+        echo 'Setting PHP memory limit...'
+        php -d memory_limit=1G -v
+        echo 'Importing test data...'
+        cd /app
+        php -d memory_limit=1G bin/importTestData --commit
+        echo 'Running tests...'
+        php -d memory_limit=1G vendor/bin/phpunit
+      "

--- a/zmsdb/docker-compose.yml
+++ b/zmsdb/docker-compose.yml
@@ -4,8 +4,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: zmsdb
       MYSQL_DATABASE: zmsbo
-      MYSQL_CHARACTER_SET: utf8mb4
-      MYSQL_COLLATION: utf8mb4_unicode_ci
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     ports:
       - 3307:3306
     healthcheck:

--- a/zmsdb/docker-compose.yml
+++ b/zmsdb/docker-compose.yml
@@ -21,25 +21,16 @@ services:
     image: ghcr.io/it-at-m/eappointment-php-base:8.3-dev
     volumes:
       - type: bind
-        source: "."
-        target: "/app"
-        consistency: cached
-      - type: bind
-        source: "../zmsentities"
-        target: "/zmsentities"
-      - type: bind
-        source: "../zmsslim"
-        target: "/zmsslim"
-      - type: bind
         source: ".."
-        target: "/workspace"
+        target: "/host"
+        read_only: true
     environment:
       MYSQL_PORT: "tcp://mariadb:3306"
       MYSQL_DATABASE: zmsbo
       MYSQL_ROOT_PASSWORD: zmsdb
       ZMS_CONFIG_SECURE_TOKEN: secure-token
       PHP_MEMORY_LIMIT: "1G"
-    working_dir: /app
+    working_dir: /tmp/workspace/zmsdb
     deploy:
       resources:
         limits:
@@ -52,21 +43,25 @@ services:
         echo 'Installing Python dependencies...'
         apt update && apt install -y python3 python3-click python3-git
         echo 'Installing MySQL client...'
-        apt install -y mariadb-client
+        apt install -y mariadb-client rsync
+        echo 'Preparing isolated workspace...'
+        mkdir -p /tmp/workspace
+        rsync -a --delete /host/ /tmp/workspace/
         echo 'Waiting for database to be ready...'
         until mysql -h mariadb -u root -pzmsdb -e 'SELECT 1' >/dev/null 2>&1; do
           echo 'Database not ready yet, waiting...'
           sleep 2
         done
         echo 'Database is ready!'
-        echo 'Setting up module dependencies...'
-        cd /workspace && python3 cli modules reference-libraries --no-symlink
-        echo 'Waiting for composer operations to complete...'
-        sleep 10
+        echo 'Setting up module dependencies (symlinks) in isolated workspace...'
+        cd /tmp/workspace && python3 cli modules reference-libraries
+        echo 'Installing composer dependencies...'
+        cd /tmp/workspace/zmsdb && composer install --no-progress --prefer-dist --optimize-autoloader
+        echo 'Regenerating autoloader...'
+        composer dump-autoload -o
         echo 'Setting PHP memory limit...'
         php -d memory_limit=1G -v
         echo 'Importing test data...'
-        cd /app
         php -d memory_limit=1G bin/importTestData --commit
         echo 'Running tests...'
         php -d memory_limit=1G vendor/bin/phpunit

--- a/zmsdb/docker-compose.yml
+++ b/zmsdb/docker-compose.yml
@@ -71,6 +71,7 @@ services:
         echo 'Setting PHP memory limit...'
         php -d memory_limit=1G -v
         echo 'Importing test data...'
+        cd /tmp/workspace/zmsdb
         php -d memory_limit=1G bin/importTestData --commit
         echo 'Running tests...'
         php -d memory_limit=1G vendor/bin/phpunit

--- a/zmsdb/docker-compose.yml
+++ b/zmsdb/docker-compose.yml
@@ -24,6 +24,9 @@ services:
         source: ".."
         target: "/host"
         read_only: true
+      - type: volume
+        source: zmsdb-workspace
+        target: /tmp/workspace
     environment:
       MYSQL_PORT: "tcp://mariadb:3306"
       MYSQL_DATABASE: zmsbo
@@ -40,25 +43,31 @@ services:
     command: >
       bash -c "
         set -e
-        echo 'Installing Python dependencies...'
-        apt update && apt install -y python3 python3-click python3-git
-        echo 'Installing MySQL client...'
-        apt install -y mariadb-client rsync
+        echo 'Installing base dependencies (idempotent)...'
+        if [ ! -f /tmp/workspace/.deps_installed ]; then \
+          apt update && apt install -y python3 python3-click python3-git mariadb-client rsync && \
+          touch /tmp/workspace/.deps_installed; \
+        else \
+          echo 'Base dependencies already installed. Skipping.'; \
+        fi
         echo 'Preparing isolated workspace...'
         mkdir -p /tmp/workspace
-        rsync -a --delete /host/ /tmp/workspace/
+        rsync -a --delete --exclude='zmsdb/vendor/' --exclude='zmsapi/vendor/' /host/ /tmp/workspace/
         echo 'Waiting for database to be ready...'
         until mysql -h mariadb -u root -pzmsdb -e 'SELECT 1' >/dev/null 2>&1; do
           echo 'Database not ready yet, waiting...'
           sleep 2
         done
         echo 'Database is ready!'
-        echo 'Setting up module dependencies (symlinks) in isolated workspace...'
-        cd /tmp/workspace && python3 cli modules reference-libraries
-        echo 'Installing composer dependencies...'
-        cd /tmp/workspace/zmsdb && composer install --no-progress --prefer-dist --optimize-autoloader
-        echo 'Regenerating autoloader...'
-        composer dump-autoload -o
+        cd /tmp/workspace
+        if [ ! -d /tmp/workspace/zmsdb/vendor ]; then \
+          echo 'Setting up module dependencies (symlinks) in isolated workspace...'; \
+          python3 cli modules reference-libraries; \
+          echo 'Installing composer dependencies (first run)...'; \
+          cd /tmp/workspace/zmsdb && composer install --no-progress --prefer-dist --optimize-autoloader && composer dump-autoload -o; \
+        else \
+          echo 'Vendor already present. Skipping cli+composer.'; \
+        fi
         echo 'Setting PHP memory limit...'
         php -d memory_limit=1G -v
         echo 'Importing test data...'
@@ -66,3 +75,5 @@ services:
         echo 'Running tests...'
         php -d memory_limit=1G vendor/bin/phpunit
       "
+volumes:
+  zmsdb-workspace:

--- a/zmsdb/zmsdb-test
+++ b/zmsdb/zmsdb-test
@@ -32,7 +32,7 @@ fi
 if ! docker-compose ps | grep -q "zmsdb"; then
     echo "Setting up test environment (first run)..."
     docker-compose down
-    docker-compose up --build
+    docker-compose up -d --build
     docker-compose logs -f test
 else
     echo "Test environment already set up, running tests..."

--- a/zmsdb/zmsdb-test
+++ b/zmsdb/zmsdb-test
@@ -2,8 +2,17 @@
 
 # zmsdb-test - Automated testing script for zmsdb module
 # Usage: ./zmsdb-test [PHPUnit arguments...]
+#        ./zmsdb-test --reset (reset all containers and volumes)
 
 set -e
+
+# Check for reset command
+if [[ $1 == "--reset" ]]; then
+    echo "🧹 Resetting zmsdb test environment..."
+    docker-compose down -v
+    echo "✅ Reset complete! All containers and volumes removed."
+    exit 0
+fi
 
 # Parse all PHPUnit arguments
 PHPUNIT_ARGS=""

--- a/zmsdb/zmsdb-test
+++ b/zmsdb/zmsdb-test
@@ -20,7 +20,7 @@ if ! docker-compose ps mariadb | grep -q "Up"; then
     docker-compose up -d mariadb
     # Wait for mariadb to be healthy
     echo "Waiting for mariadb to be ready..."
-    until docker-compose exec mariadb mysqladmin ping -h localhost -u root -pzmsdb >/dev/null 2>&1; do
+                    until docker-compose exec -T mariadb mysqladmin ping -h localhost -u root -pzmsdb >/dev/null 2>&1; do
         sleep 2
     done
     echo "MariaDB is ready!"

--- a/zmsdb/zmsdb-test
+++ b/zmsdb/zmsdb-test
@@ -37,9 +37,9 @@ if ! docker-compose ps | grep -q "zmsdb"; then
 else
     echo "Test environment already set up, running tests..."
     # Run tests with or without filter
-    if [ -n "$FILTER" ]; then
-        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsdb && php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter=\"$FILTER\""
-    else
-        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsdb && php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit"
-    fi
+                    if [ -n "$FILTER" ]; then
+                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsdb && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit --filter=\"$FILTER\""
+                else
+                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsdb && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit"
+                fi
 fi

--- a/zmsdb/zmsdb-test
+++ b/zmsdb/zmsdb-test
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # zmsdb-test - Automated testing script for zmsdb module
-# Usage: ./zmsdb-test [--filter="TestClass::testMethod"]
+# Usage: ./zmsdb-test [PHPUnit arguments...]
 
 set -e
 
-# Parse filter argument
-FILTER=""
-if [[ $1 == --filter=* ]]; then
-    FILTER="${1#--filter=}"
-    echo "Running tests with filter: $FILTER"
+# Parse all PHPUnit arguments
+PHPUNIT_ARGS=""
+if [[ $# -gt 0 ]]; then
+    PHPUNIT_ARGS="$*"
+    echo "Running tests with arguments: $PHPUNIT_ARGS"
 fi
 
 # Already in zmsdb directory
@@ -37,9 +37,9 @@ if ! docker-compose ps | grep -q "zmsdb"; then
 else
     echo "Test environment already set up, running tests..."
     # Run tests with or without filter
-                    if [ -n "$FILTER" ]; then
-                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsdb && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit --filter=\"$FILTER\""
-                else
-                    docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsdb && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit"
-                fi
+                    if [ -n "$PHPUNIT_ARGS" ]; then
+                        docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsdb && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit $PHPUNIT_ARGS"
+                    else
+                        docker-compose run --rm --no-deps test bash -lc "apt update && apt install -y rsync && rsync -a --delete /host/ /tmp/workspace/ && cd /tmp/workspace/zmsdb && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} bin/importTestData --commit && php -d memory_limit=\${PHP_MEMORY_LIMIT:-1G} vendor/bin/phpunit"
+                    fi
 fi

--- a/zmsdb/zmsdb-test
+++ b/zmsdb/zmsdb-test
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# zmsdb-test - Automated testing script for zmsdb module
+# Usage: ./zmsdb-test [--filter="TestClass::testMethod"]
+
+set -e
+
+# Parse filter argument
+FILTER=""
+if [[ $1 == --filter=* ]]; then
+    FILTER="${1#--filter=}"
+    echo "Running tests with filter: $FILTER"
+fi
+
+# Already in zmsdb directory
+
+# Check if mariadb is running, start if not
+if ! docker-compose ps mariadb | grep -q "Up"; then
+    echo "Starting mariadb container..."
+    docker-compose up -d mariadb
+    # Wait for mariadb to be healthy
+    echo "Waiting for mariadb to be ready..."
+    until docker-compose exec mariadb mysqladmin ping -h localhost -u root -pzmsdb >/dev/null 2>&1; do
+        sleep 2
+    done
+    echo "MariaDB is ready!"
+else
+    echo "MariaDB is already running"
+fi
+
+# Check if docker-compose services are already running
+if ! docker-compose ps | grep -q "zmsdb"; then
+    echo "Setting up test environment (first run)..."
+    docker-compose down
+    docker-compose up --build
+    docker-compose logs -f test
+else
+    echo "Test environment already set up, running tests..."
+    # Run tests with or without filter
+    if [ -n "$FILTER" ]; then
+        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsdb && php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit --filter=\"$FILTER\""
+    else
+        docker-compose run --rm --no-deps test bash -lc "cd /tmp/workspace/zmsdb && php -d memory_limit=1G bin/importTestData --commit && php -d memory_limit=1G vendor/bin/phpunit"
+    fi
+fi


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.

e.g.
`./zmsdb-test --filter="StatusTest::testBasic" `
`./zmsapi-test --filter="StatusGetTest::testRendering" `

<img width="1159" height="255" alt="Screenshot 2025-08-27 at 18 10 36" src="https://github.com/user-attachments/assets/a8613e14-4c4c-46ba-8fb1-83fce33f856c" />
<img width="895" height="775" alt="Screenshot 2025-08-27 at 18 09 35" src="https://github.com/user-attachments/assets/cd51cb70-f07a-46ea-9785-9a79993007f8" />
<img width="890" height="783" alt="Screenshot 2025-08-27 at 18 09 47" src="https://github.com/user-attachments/assets/21636acc-1678-4930-942d-c8be492d6230" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Containerized test environments for zmsapi and zmsdb: docker-compose setups, workspace syncing, fixture symlinks, automated fixture import, PHP memory-limit support, optional PHPUnit arguments, and a reset option for zmsdb.
  - New helper scripts to automate first-run and subsequent test flows.

- **Documentation**
  - README rework: dedicated Special Cases, Traditional DDEV and Containerized Testing flows, zmsclient guidance, how-the-scripts-work, flags/examples, and expanded common errors.

- **Chores**
  - Documentation-only restructurings; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->