### PR TITLE
fix(ZMSKVR): prevent the FK error during the hourly full refresh by first setting all child request.parent_id references to NULL for the source, then deleting and reimporting the source’s requests.

### DIFF
--- a/zmsdb/tests/Zmsdb/RequestTest.php
+++ b/zmsdb/tests/Zmsdb/RequestTest.php
@@ -101,7 +101,9 @@ class RequestTest extends Base
         $parentRequest = new \BO\Zmsentities\Request();
         $parentRequest['id'] = '999001';
         $parentRequest['name'] = 'Parent Request';
-        $parentRequest['source'] = 'test';
+        $parentRequest['source'] = 'dldb';
+        $parentRequest['group'] = 'Testgruppe';
+        $parentRequest['link'] = '';
         $parentRequest['parent_id'] = null;
         $parentRequest = $query->writeEntity($parentRequest);
         
@@ -109,7 +111,9 @@ class RequestTest extends Base
         $childRequest = new \BO\Zmsentities\Request();
         $childRequest['id'] = '999002';
         $childRequest['name'] = 'Child Request';
-        $childRequest['source'] = 'test';
+        $childRequest['source'] = 'dldb';
+        $childRequest['group'] = 'Testgruppe';
+        $childRequest['link'] = '';
         $childRequest['parent_id'] = '999001';
         $childRequest = $query->writeEntity($childRequest);
         
@@ -117,11 +121,11 @@ class RequestTest extends Base
         $this->assertEquals('999001', $childRequest->getParentId());
         
         // Now delete all requests from 'test' source - this should work without foreign key constraint violation
-        $result = $query->writeDeleteListBySource('test');
+        $result = $query->writeDeleteListBySource('dldb');
         $this->assertTrue($result);
         
         // Verify both requests are deleted
         $this->expectException('BO\Zmsdb\Exception\Request\RequestNotFound');
-        $query->readEntity('test', '999001');
+        $query->readEntity('dldb', '999001');
     }
 }


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion of requests by source to safely handle parent–child relationships, preventing foreign key errors and ensuring consistent data cleanup.
  * Enhances reliability when removing large batches of requests tied to a specific source.

* **Tests**
  * Added automated test to verify deletion behavior with linked parent–child requests, ensuring children are unlinked before removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->