### PR TITLE
fix(ZMSKVR): remove eager canDelete checks in Provider/Request reads …

### DIFF
--- a/zmsadmin/package-lock.json
+++ b/zmsadmin/package-lock.json
@@ -2396,28 +2396,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
-      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^19.0.0"
-      }
-    },
     "node_modules/@types/trusted-types": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
@@ -3138,14 +3116,6 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4997,7 +4967,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5429,6 +5400,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6000,6 +5972,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/zmsdb/src/Zmsdb/Provider.php
+++ b/zmsdb/src/Zmsdb/Provider.php
@@ -19,9 +19,10 @@ class Provider extends Base
             ->addConditionProviderSource($source)
             ->addConditionProviderId($providerId);
         $provider = $this->fetchOne($query, new Entity());
-        $inUseByScope = (new Scope())->countByInfoDienstleister($providerId, $source) > 0;
-        $inUseByRel   = (new RequestRelation())->countByProviderId($providerId, $source) > 0;
-        $provider['canDelete'] = ! ($inUseByScope || $inUseByRel);
+        // NOTE: canDelete eager computation intentionally disabled for performance
+        // $inUseByScope = (new Scope())->countByInfoDienstleister($providerId, $source) > 0;
+        // $inUseByRel   = (new RequestRelation())->countByProviderId($providerId, $source) > 0;
+        // $provider['canDelete'] = ! ($inUseByScope || $inUseByRel);
         return $provider;
     }
 
@@ -35,11 +36,12 @@ class Provider extends Base
         $statement = $this->fetchStatement($query);
         while ($providerData = $statement->fetch(\PDO::FETCH_ASSOC)) {
             $entity = new Entity($query->postProcessJoins($providerData));
-            $source = $entity->getSource();
-            $id     = $entity->getId();
-            $inUseByScope = (new Scope())->countByInfoDienstleister($id, $source) > 0;
-            $inUseByRel   = (new RequestRelation())->countByProviderId($id, $source) > 0;
-            $entity['canDelete'] = ! ($inUseByScope || $inUseByRel);
+            // NOTE: canDelete eager computation intentionally disabled for performance
+            // $source = $entity->getSource();
+            // $id     = $entity->getId();
+            // $inUseByScope = (new Scope())->countByInfoDienstleister($id, $source) > 0;
+            // $inUseByRel   = (new RequestRelation())->countByProviderId($id, $source) > 0;
+            // $entity['canDelete'] = ! ($inUseByScope || $inUseByRel);
             $providerList->addEntity($entity);
         }
         return $providerList;

--- a/zmsdb/src/Zmsdb/Request.php
+++ b/zmsdb/src/Zmsdb/Request.php
@@ -40,7 +40,7 @@ class Request extends Base
     {
         $requestList = new Collection();
         $statement = $this->fetchStatement($query);
-        $requestRelation = new RequestRelation();
+        //$requestRelation = new RequestRelation();
         while ($requestData = $statement->fetch(\PDO::FETCH_ASSOC)) {
             $request = new Entity($query->postProcessJoins($requestData));
             // NOTE: canDelete eager computation intentionally disabled for performance

--- a/zmsdb/src/Zmsdb/Request.php
+++ b/zmsdb/src/Zmsdb/Request.php
@@ -25,9 +25,10 @@ class Request extends Base
         if (! $request->hasId()) {
             throw new Exception\Request\RequestNotFound("Could not find request with ID $source/$requestId");
         }
-        $inUseByRel = (new RequestRelation())->countByRequestId($requestId, $source) > 0;
-        $inUseByBa  = $this->countInBuergeranliegen($requestId) > 0;
-        $request['canDelete'] = ! ($inUseByRel || $inUseByBa);
+        // NOTE: canDelete eager computation intentionally disabled for performance
+        // $inUseByRel = (new RequestRelation())->countByRequestId($requestId, $source) > 0;
+        // $inUseByBa  = $this->countInBuergeranliegen($requestId) > 0;
+        // $request['canDelete'] = ! ($inUseByRel || $inUseByBa);
         return $request;
     }
 
@@ -42,11 +43,12 @@ class Request extends Base
         $requestRelation = new RequestRelation();
         while ($requestData = $statement->fetch(\PDO::FETCH_ASSOC)) {
             $request = new Entity($query->postProcessJoins($requestData));
-            $source = $request->getSource();
-            $id     = $request->getId();
-            $inUseByRel = $requestRelation->countByRequestId($id, $source) > 0;
-            $inUseByBa  = $this->countInBuergeranliegen($id) > 0;
-            $request['canDelete'] = ! ($inUseByRel || $inUseByBa);
+            // NOTE: canDelete eager computation intentionally disabled for performance
+            // $source = $request->getSource();
+            // $id     = $request->getId();
+            // $inUseByRel = $requestRelation->countByRequestId($id, $source) > 0;
+            // $inUseByBa  = $this->countInBuergeranliegen($id) > 0;
+            // $request['canDelete'] = ! ($inUseByRel || $inUseByBa);
             $requestList->addEntity($request);
         }
         return $requestList;


### PR DESCRIPTION
…to reduce DB load

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster loading when viewing Provider and Request details and lists.
  * The canDelete indicator is no longer shown for Provider and Request items.
  * Collections of Providers and Requests no longer include per-item canDelete status.
  * Individual Provider and Request views no longer display canDelete.
  * API responses and UI outputs for these entities omit canDelete, reducing payload and processing time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->