### PR TITLE
fix(deps): update dependency altcha to v2

### DIFF
--- a/zmscitizenview/package-lock.json
+++ b/zmscitizenview/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@muenchen/muc-patternlab-vue": "5.6.2",
-        "altcha": "^2.0.0",
+        "altcha": "^1.2.0",
         "dompurify": "^3.2.4",
         "jsdom": "^26.0.0",
         "vue": "^3.5.12",
@@ -2558,9 +2558,9 @@
       "license": "MIT"
     },
     "node_modules/altcha": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/altcha/-/altcha-2.2.3.tgz",
-      "integrity": "sha512-LcGCNTOYtkcRthJgFU5ycgVE6ffcp3/WMSrAMri/UN+WcBEwfzb0RnUmhWee9VA52cHUL9ONeQsrE/zCkUoZiQ==",
+      "version": "1.5.1",
+      "integrity": "sha512-o3+k9uETJ/p5FgzsG8sbRFqtzMbywAh2bAcsHanfMUUj0WXT8+h87dZ8ZISM7E/ufidZLUI5TCiO97eJDTwayg==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@altcha/crypto": "^0.0.1"

--- a/zmscitizenview/package.json
+++ b/zmscitizenview/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@muenchen/muc-patternlab-vue": "5.6.2",
-    "altcha": "^2.0.0",
+    "altcha": "^1.2.0",
     "jsdom": "^26.0.0",
     "vue": "^3.5.12",
     "vue-i18n": "10.0.8",


### PR DESCRIPTION
Reverts it-at-m/eappointment#1353

With the new version the altcha widget does not behave properly. It remains in the "verifying" state although verification is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted a third-party dependency version to ensure compatibility.
  * No changes to exported or public APIs.

* **User Impact**
  * No user-facing changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->