### PR TITLE
chore(GH-1303): reenable esbuild configuration

### DIFF
--- a/zmscitizenview/vite.config.ts
+++ b/zmscitizenview/vite.config.ts
@@ -62,8 +62,8 @@ export default defineConfig({
       },
     }
   },
-  // esbuild: {
-  //   drop: process.env.NODE_ENV === 'development' ? [] : ['console', 'debugger'],
-  // },
+  esbuild: {
+    drop: process.env.NODE_ENV === 'development' ? [] : ['console', 'debugger'],
+  },
   base: './',
 })


### PR DESCRIPTION
This restores the dropping of console and debugger statements in non-development builds.

Fixes #1303

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
