### PR TITLE
fix(TV-38): prevent double callout on confirm in webcomponent by clearing stale errors on success and guarding confirm error rendering

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -246,7 +246,7 @@
             </muc-button>
           </div>
           <muc-callout
-            v-if="hasConfirmAppointmentError"
+            v-if="!confirmAppointmentSuccess && hasConfirmAppointmentError"
             :type="toCalloutType(apiErrorTranslation.errorType)"
           >
             <template #content>
@@ -909,6 +909,7 @@ onMounted(() => {
       (data) => {
         if ((data as AppointmentDTO).processId != undefined) {
           confirmAppointmentSuccess.value = true;
+          clearContextErrors(errorStateMap.value);
         } else {
           const firstErrorCode = (data as any).errors?.[0]?.errorCode ?? "";
 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The error callout during appointment confirmation now appears only when the confirmation fails, preventing false or premature error displays.
  * After a successful confirmation, any previous error messages are cleared to avoid lingering or stale alerts.
  * Improves clarity and consistency of user feedback during the confirmation flow, reducing confusion and ensuring the interface accurately reflects the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->