### PR TITLE
fix(TV-38): prevent double callout on confirm in webcomponent by clearing stale errors on success and guarding confirm error rendering

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -246,7 +246,7 @@
             </muc-button>
           </div>
           <muc-callout
-            v-if="hasConfirmAppointmentError"
+            v-if="!confirmAppointmentSuccess && hasConfirmAppointmentError"
             :type="toCalloutType(apiErrorTranslation.errorType)"
           >
             <template #content>
@@ -909,6 +909,7 @@ onMounted(() => {
       (data) => {
         if ((data as AppointmentDTO).processId != undefined) {
           confirmAppointmentSuccess.value = true;
+          clearContextErrors(errorStateMap.value);
         } else {
           const firstErrorCode = (data as any).errors?.[0]?.errorCode ?? "";
 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.

<img width="1506" height="848" alt="image" src="https://github.com/user-attachments/assets/d0714985-79ff-4c2b-9838-8c19166e9e7c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Appointment confirmation now clears prior errors after a successful confirmation, preventing stale messages from persisting.
  * Error callout is shown only when confirmation fails, reducing false error alerts and improving clarity.
  * Prevents simultaneous success and error banners, ensuring consistent post-confirmation feedback.
  * Improved reliability of success/error state handling during the confirmation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->