### PR TITLE
fix(ZMSKVR-887) handle undefined startTime and guard scrollIntoView in availability day

### DIFF
--- a/zmsadmin/js/page/availabilityDay/index.js
+++ b/zmsadmin/js/page/availabilityDay/index.js
@@ -559,7 +559,7 @@ class AvailabilityPage extends Component {
                         )
                     })
                     if (data.conflictIdList.length > 0) {
-                        this.errorElement.scrollIntoView()
+                        this.errorElement && this.errorElement.scrollIntoView()
                     }
                 },
                 (err) => {

--- a/zmsadmin/js/page/availabilityDay/timetable/tableview.js
+++ b/zmsadmin/js/page/availabilityDay/timetable/tableview.js
@@ -16,7 +16,9 @@ const TableView = (props) => {
         if (a.type === 'appointment' && b.type !== 'appointment') return -1;
         if (a.type !== 'appointment' && b.type === 'appointment') return 1;
 
-        return a.startTime.localeCompare(b.startTime);
+        const aTime = a.startTime || '';
+        const bTime = b.startTime || '';
+        return aTime.localeCompare(bTime);
     });
 
     const titleTime = moment(timestamp, 'X').format('dddd, DD.MM.YYYY')


### PR DESCRIPTION
Prevent crash when sorting availabilities without start/end times in table view. Sorting comparator assumed startTime is always defined and called localeCompare on undefined, causing a TypeError when creating multiple availabilities without setting times

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents occasional errors when viewing conflict details by ensuring the interface only scrolls to an error message when it’s available, improving stability during conflict resolution.
  * Improves timetable reliability by safely handling entries without a start time, maintaining correct ordering without causing display errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->