### PR TITLE
feat(ZMSKVR-489 GH-1457): queue UI cleanup — rename Wartezeit to Termindauer and show only duration; remove type/range; drop Wartezeit column in parked table to align with missed table; avoid float-to-int precision php depreciation warnings in finished table

### DIFF
--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -617,16 +617,16 @@
 										Spontankunde
 									{% endif %}
 								</td>
-								{% set totalMinutes = item.waitingTime %} 
-								{% set hours = (totalMinutes // 60) %} 
-								{% set minutes = (totalMinutes % 60) // 1 %} 
-								{% set seconds = ((totalMinutes - (hours * 60) - minutes) * 60) | round %} 
-								<td>{{ "%02d"|format(hours) ~ ':' ~ "%02d"|format(minutes) ~ ':' ~ "%02d"|format(seconds) }}</td> 
-								{% set totalMinutes = item.processingTime %} 
-								{% set hours = (totalMinutes // 60) %} 
-								{% set minutes = (totalMinutes % 60) // 1 %} 
-								{% set seconds = ((totalMinutes - (hours * 60) - minutes) * 60) | round %} 
-								<td>{{ "%02d"|format(hours) ~ ':' ~ "%02d"|format(minutes) ~ ':' ~ "%02d"|format(seconds) }}</td> 
+							{% set totalSeconds = (item.waitingTime * 60)|round(0, 'floor') %}
+							{% set hours = (totalSeconds // 3600) %}
+							{% set minutes = ((totalSeconds % 3600) // 60) %}
+							{% set seconds = (totalSeconds % 60) %}
+							<td>{{ "%02d"|format(hours) ~ ':' ~ "%02d"|format(minutes) ~ ':' ~ "%02d"|format(seconds) }}</td>
+							{% set totalSeconds = (item.processingTime * 60)|round(0, 'floor') %}
+							{% set hours = (totalSeconds // 3600) %}
+							{% set minutes = ((totalSeconds % 3600) // 60) %}
+							{% set seconds = (totalSeconds % 60) %}
+							<td>{{ "%02d"|format(hours) ~ ':' ~ "%02d"|format(minutes) ~ ':' ~ "%02d"|format(seconds) }}</td>
 							</tr>
 						{% endfor %}				
 					</table>

--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -97,7 +97,6 @@
 								{% if workstation.scope.preferences.client.customTextfield2Activated|default(0) == 1 %}
 									<th>{{workstation.scope.preferences.client.customTextfield2Label}}</th>
 								{% endif %}
-								<th>Wartezeit</th>
 								<th>Aktion</th>
 							</tr>
 						</thead>
@@ -164,13 +163,6 @@
 										{{ item.customTextfield2|decodeEntities }}
 									</td>
 								{% endif %}
-								<td class="nowrap">
-									{% if item.queue.withAppointment %}
-										Termin
-									{% else %}
-										Spontankunde
-									{% endif %}
-								</td>
 								<td>
 									<p>
                                         {% if workstation.name %}
@@ -293,7 +285,7 @@
 							{% if workstation.scope.preferences.client.customTextfield2Activated|default(0) == 1 %}
 								<th>{{workstation.scope.preferences.client.customTextfield2Label}}</th>
 							{% endif %}
-							<th>Wartezeit</th>
+						<th>Termindauer</th>
 							<th></th>
 							<th></th>
 						</tr>
@@ -432,21 +424,12 @@
 											{{ item.customTextfield2|decodeEntities }}
 										</td>
 									{% endif %}
-									<td class="nowrap">
-										{% if item.queue.withAppointment %}
-											Termin
-										{% else %}
-											Spontankunde
-										{% endif %}
-										{% if item.queue.withAppointment %}
-											{% set duration = item.appointments|first.availability.slotTimeInMinutes * item.appointments|first.slotCount %}
-											({{ duration }}
-											min)
-										{% endif %}
-										{% if (item.queue.waitingTimeEstimate != item.queue.waitingTimeOptimistic) and isToday %}
-											<p class="queue-table-amendment-time">+{{ item.queue.waitingTimeOptimistic }}&#8209;{{ item.queue.waitingTimeEstimate }}&nbsp;Min.</p>
-										{% endif %}
-									</td>
+							<td class="nowrap">
+								{% if item.queue.withAppointment %}
+									{% set duration = item.appointments|first.availability.slotTimeInMinutes * item.appointments|first.slotCount %}
+									{{ duration }}&nbsp;Min.
+								{% endif %}
+							</td>
 									{% if item.queue.status != "reserved" and item.queue.status != "preconfirmed" and item.queue.status != "deleted" %}
 										<td class="center">
 											<a data-id="{{ item.id }}" data-name="{{ item.queue.withAppointment ? item.clients|first.familyName|decodeEntities : ('Wartenummer ' ~ item.queue.number) }}" href="#" class="icon process-delete" title="Löschen">
@@ -504,7 +487,6 @@
 								{% if workstation.scope.preferences.client.customTextfield2Activated|default(0) == 1 %}
 									<th>{{workstation.scope.preferences.client.customTextfield2Label}}</th>
 								{% endif %}
-								<th>Wartezeit</th>
 								<th>Aktion</th>
 							</tr>
 						</thead>
@@ -571,13 +553,6 @@
 										{{ item.customTextfield2|decodeEntities }}
 									</td>
 								{% endif %}
-								<td class="nowrap">
-									{% if item.queue.withAppointment %}
-										Termin
-									{% else %}
-										Spontankunde
-									{% endif %}
-								</td>
 								<td>
 									<p>
                                         {% if workstation.name %}


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified per-row duration display in queue tables: for items with appointments, show calculated duration in minutes; removed multi-line Termin/Spontankunde and waiting-time amendment blocks.
  * Queued/parked rows render the duration cell only when an appointment exists.
  * Finished/missed rows now compute and display total time as hours:minutes:seconds.

* **Style**
  * Renamed column header from “Wartezeit” to “Termindauer” across relevant queue tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->