### PR TITLE
hotfix(zmskvr): fix dispaly number prefix typo

### DIFF
--- a/zmsadmin/templates/block/scope/form.twig
+++ b/zmsadmin/templates/block/scope/form.twig
@@ -923,7 +923,7 @@
                     ) }}
 
 					{{ formgroup(
-						{"label": "Terminnummmern-Präfix:", "description": "Bitte geben Sie ein bis zwei Großbuchstaben ein, die vor die vierstelligen Terminnummer gesetzt werden. Bleibt das Feld leer, wird eine sechsstellige Terminnummer vergeben"},
+						{"label": "Terminnummern-Präfix:", "description": "Bitte geben Sie ein bis zwei Großbuchstaben ein, die vor die vierstelligen Terminnummer gesetzt werden. Bleibt das Feld leer, wird eine sechsstellige Terminnummer vergeben"},
 						[{
 							"type":"input",
 							"parameter": {


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the scope form: the label now reads “Terminnummern-Präfix” (previously “Terminnummmern-Präfix”) in the Wartenummernkontingent section.
  * Improves readability and localization consistency for German-speaking users, reducing potential confusion when configuring prefixes.
  * No changes to functionality, data, or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->