### PR TITLE
Revert "feat(ZMSKVR-97): Add ICS download functionality for appointment confirmation"

### DIFF
--- a/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedProcess.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedProcess.php
@@ -48,10 +48,8 @@ class ThinnedProcess extends Entity implements JsonSerializable
     public ?string $captchaToken;
 /** @var int|null */
     public ?int $slotCount;
-/** @var string|null */
-    public ?string $icsContent;
 
-    public function __construct(?int $processId = null, ?string $timestamp = null, ?string $authKey = null, ?string $familyName = null, ?string $customTextfield = null, ?string $customTextfield2 = null, ?string $email = null, ?string $telephone = null, ?string $officeName = null, ?int $officeId = null, ?ThinnedScope $scope = null, array $subRequestCounts = [], ?int $serviceId = null, ?string $serviceName = null, int $serviceCount = 0, ?string $status = null, ?string $captchaToken = null, ?int $slotCount = null, ?string $icsContent = null)
+    public function __construct(?int $processId = null, ?string $timestamp = null, ?string $authKey = null, ?string $familyName = null, ?string $customTextfield = null, ?string $customTextfield2 = null, ?string $email = null, ?string $telephone = null, ?string $officeName = null, ?int $officeId = null, ?ThinnedScope $scope = null, array $subRequestCounts = [], ?int $serviceId = null, ?string $serviceName = null, int $serviceCount = 0, ?string $status = null, ?string $captchaToken = null, ?int $slotCount = null)
     {
         $this->processId = $processId;
         $this->timestamp = $timestamp;
@@ -71,7 +69,6 @@ class ThinnedProcess extends Entity implements JsonSerializable
         $this->status = $status;
         $this->captchaToken = $captchaToken;
         $this->slotCount = $slotCount;
-        $this->icsContent = $icsContent;
         $this->ensureValid();
     }
 
@@ -100,8 +97,7 @@ class ThinnedProcess extends Entity implements JsonSerializable
             'serviceCount' => $this->serviceCount,
             'status' => $this->status ?? null,
             'captchaToken' => $this->captchaToken ?? null,
-            'slotCount' => $this->slotCount ?? null,
-            'icsContent' => $this->icsContent ?? null
+            'slotCount' => $this->slotCount ?? null
         ];
     }
 
@@ -113,16 +109,6 @@ class ThinnedProcess extends Entity implements JsonSerializable
     public function getCaptchaToken(): ?string
     {
         return $this->captchaToken;
-    }
-
-    public function setIcsContent(string $icsContent): void
-    {
-        $this->icsContent = $icsContent;
-    }
-
-    public function getIcsContent(): ?string
-    {
-        return $this->icsContent;
     }
 
     private function ensureValid()

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentByIdControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentByIdControllerTest.php
@@ -112,14 +112,10 @@ class AppointmentByIdControllerTest extends ControllerTestCase
             "serviceId" => 1063424,
             "serviceName" => "Gewerbe anmelden",
             "serviceCount" => 1,
-            "slotCount" => 1,
+            "slotCount" => 1
         ];
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertArrayHasKey('icsContent', $responseBody);
-        $this->assertStringContainsString('BEGIN:VCALENDAR', $responseBody['icsContent']);
-        unset($responseBody['icsContent']);
-        unset($expectedResponse['icsContent']);
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentCancelControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentCancelControllerTest.php
@@ -117,14 +117,10 @@ class AppointmentCancelControllerTest extends ControllerTestCase
             'serviceName' => 'Adressänderung Personalausweis, Reisepass, eAT',
             'serviceCount' => 1,
             'status' => 'deleted',
-            'slotCount' => 1,
+            'slotCount' => 1
         ];
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertArrayHasKey('icsContent', $responseBody);
-        $this->assertStringContainsString('BEGIN:VCALENDAR', $responseBody['icsContent']);
-        unset($responseBody['icsContent']);
-        unset($expectedResponse['icsContent']);
         $this->assertEquals($expectedResponse, $responseBody);
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentConfirmControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentConfirmControllerTest.php
@@ -114,14 +114,10 @@ class AppointmentConfirmControllerTest extends ControllerTestCase
             'serviceName' => 'Adressänderung Personalausweis, Reisepass, eAT',
             'serviceCount' => 1,
             'status' => 'confirmed',
-            'slotCount' => 1,
+            'slotCount' => 1
         ];
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertArrayHasKey('icsContent', $responseBody);
-        $this->assertStringContainsString('BEGIN:VCALENDAR', $responseBody['icsContent']);
-        unset($responseBody['icsContent']);
-        unset($expectedResponse['icsContent']);
         $this->assertEquals($expectedResponse, $responseBody);
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentPreconfirmControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentPreconfirmControllerTest.php
@@ -112,14 +112,10 @@ class AppointmentPreconfirmControllerTest extends ControllerTestCase
             'serviceName' => 'Adressänderung Personalausweis, Reisepass, eAT',
             'serviceCount' => 1,
             'status' => 'preconfirmed',
-            'slotCount' => 1,
+            'slotCount' => 1
         ];
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertArrayHasKey('icsContent', $responseBody);
-        $this->assertStringContainsString('BEGIN:VCALENDAR', $responseBody['icsContent']);
-        unset($responseBody['icsContent']);
-        unset($expectedResponse['icsContent']);
         $this->assertEquals($expectedResponse, $responseBody);
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentReserveControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentReserveControllerTest.php
@@ -115,14 +115,10 @@ class AppointmentReserveControllerTest extends ControllerTestCase
             "serviceId" => 0,
             "serviceName" => null,
             "serviceCount" => 0,
-            "slotCount" => 4,
+            "slotCount" => 4
         ];
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertArrayHasKey('icsContent', $responseBody);
-        $this->assertStringContainsString('BEGIN:VCALENDAR', $responseBody['icsContent']);
-        unset($responseBody['icsContent']);
-        unset($expectedResponse['icsContent']);
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentUpdateControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Appointment/AppointmentUpdateControllerTest.php
@@ -113,14 +113,10 @@ class AppointmentUpdateControllerTest extends ControllerTestCase
             "serviceId" => 10242339,
             "serviceName" => "Adressänderung Personalausweis, Reisepass, eAT",
             "serviceCount" => 1,
-            "slotCount" => 1,
+            "slotCount" => 1
         ];
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertArrayHasKey('icsContent', $responseBody);
-        $this->assertStringContainsString('BEGIN:VCALENDAR', $responseBody['icsContent']);
-        unset($responseBody['icsContent']);
-        unset($expectedResponse['icsContent']);
         $this->assertEqualsCanonicalizing($expectedResponse, $responseBody);
     }
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Core/MapperServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Core/MapperServiceTest.php
@@ -167,11 +167,9 @@ class MapperServiceTest extends TestCase
         $process = new Process();
         $process->id = 1;
         $process->authKey = 'test-key';
-        $appointment = new class {
-            public $date = '1724907600';
-            public function hasTime() { return true; }
-        };
-        $process->appointments = [$appointment];
+        $process->appointments = [
+            (object) ['date' => '1724907600']
+        ];
         $process->clients = [
             (object) [
                 'familyName' => 'Doe',

--- a/zmscitizenview/resources/loader-test/index.html
+++ b/zmscitizenview/resources/loader-test/index.html
@@ -14,9 +14,7 @@
 
 <h1>zms-appointment</h1>
 
-<zms-appointment
-        appointment-detail-url="appointment-detail.html"
-></zms-appointment>
+<zms-appointment></zms-appointment>
 
 <h1>zms-appointment-slider overview page</h1>
 

--- a/zmscitizenview/src/api/models/AppointmentDTO.ts
+++ b/zmscitizenview/src/api/models/AppointmentDTO.ts
@@ -91,10 +91,4 @@ export interface AppointmentDTO {
    * @memberof AppointmentDTO
    */
   serviceCount: number;
-  /**
-   *
-   * @type {string}
-   * @memberof AppointmentDTO
-   */
-  icsContent?: string;
 }

--- a/zmscitizenview/src/components/Appointment/CustomerInfo.vue
+++ b/zmscitizenview/src/components/Appointment/CustomerInfo.vue
@@ -106,7 +106,10 @@
 </template>
 
 <script setup lang="ts">
-import type { SelectedTimeslotProvider } from "@/types/ProvideInjectTypes";
+import type {
+  SelectedAppointmentProvider,
+  SelectedTimeslotProvider,
+} from "@/types/ProvideInjectTypes";
 import type { Ref } from "vue";
 
 import {

--- a/zmscitizenview/src/types/AppointmentImpl.ts
+++ b/zmscitizenview/src/types/AppointmentImpl.ts
@@ -33,8 +33,6 @@ export class AppointmentImpl implements AppointmentDTO {
 
   serviceCount: number;
 
-  icsContent?: string;
-
   constructor(
     processId: string,
     timestamp: number,
@@ -50,8 +48,7 @@ export class AppointmentImpl implements AppointmentDTO {
     subRequestCounts: any[],
     serviceId: string,
     serviceName: string,
-    serviceCount: number,
-    icsContent?: string
+    serviceCount: number
   ) {
     this.processId = processId;
     this.timestamp = timestamp;
@@ -68,6 +65,5 @@ export class AppointmentImpl implements AppointmentDTO {
     this.serviceId = serviceId;
     this.serviceName = serviceName;
     this.serviceCount = serviceCount;
-    this.icsContent = icsContent;
   }
 }

--- a/zmscitizenview/src/types/ProvideInjectTypes.ts
+++ b/zmscitizenview/src/types/ProvideInjectTypes.ts
@@ -1,6 +1,6 @@
 import { Ref } from "vue";
 
-import { AppointmentDTO } from "@/api/models/AppointmentDTO";
+import { AppointmentImpl } from "@/types/AppointmentImpl";
 import { CustomerData } from "@/types/CustomerData";
 import { OfficeImpl } from "@/types/OfficeImpl";
 import { ServiceImpl } from "@/types/ServiceImpl";
@@ -20,5 +20,5 @@ export interface CustomerDataProvider {
 }
 
 export interface SelectedAppointmentProvider {
-  appointment: Ref<AppointmentDTO | undefined>;
+  appointment: Ref<AppointmentImpl | undefined>;
 }

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -176,7 +176,6 @@
   "contactDetails": "Kontaktdaten",
   "detailTimeHint": "Kommen Sie bitte pünktlich zu Ihrem Termin. In seltenen Fällen kann es vorkommen, dass Sie trotz Termin kurz warten müssen. Bitte haben Sie dafür Verständnis.",
   "downloadAppointment": "Termin herunterladen (ics)",
-  "viewAppointment": "Termin ansehen",
   "earlier": "Früher",
   "errorMessageCustomTextfield": "Bitte geben Sie die notwendigen Informationen ein.",
   "errorMessageCustomTextfield2": "Bitte geben Sie die notwendigen Informationen ein.",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -164,7 +164,6 @@
   "contact": "Contact us",
   "contactDetails": "Contact details",
   "downloadAppointment": "Download Appointment (ics)",
-  "viewAppointment": "View Appointment",
   "earlier": "Earlier",
   "errorMessageCustomTextfield": "Please enter the required information.",
   "errorMessageCustomTextfield2": "Please enter the required information.",

--- a/zmscitizenview/src/zms-appointment.ce.vue
+++ b/zmscitizenview/src/zms-appointment.ce.vue
@@ -14,7 +14,6 @@
         :exclusive-location="exclusiveLocation"
         :appointment-hash="appointmentHash"
         :confirm-appointment-hash="confirmAppointmentHash"
-        :appointment-detail-url="appointmentDetailUrl"
         :t="t"
       />
     </div>
@@ -80,11 +79,6 @@ defineProps({
     type: String,
     required: false,
     default: fallbackConfirmAppointmentHash,
-  },
-  appointmentDetailUrl: {
-    type: String,
-    required: false,
-    default: "appointment-detail.html",
   },
 });
 

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -7,16 +7,9 @@ import * as ZMSAppointmentAPI from "@/api/ZMSAppointmentAPI";
 import de from '@/utils/de-DE.json';
 // @ts-expect-error: Vue SFC import for test
 import AppointmentView from "@/components/Appointment/AppointmentView.vue";
-// @ts-expect-error: Vue SFC import for test
-import { isAuthenticated } from "@/utils/auth";
 // beforeEach is already imported from vitest on line 2
 
 globalThis.scrollTo = vi.fn();
-
-// Mock the auth utility
-vi.mock('@/utils/auth', () => ({
-  isAuthenticated: vi.fn()
-}));
 
 describe("AppointmentView", () => {
 
@@ -1275,120 +1268,6 @@ describe("AppointmentView", () => {
       expect(window.location.href).toBe("http://localhost:8082/");
 
       (window as any).location = originalLocation;
-    });
-  });
-
-  describe("ICS Download Feature", () => {
-    const mockConfirmAppointment = vi.mocked(ZMSAppointmentAPI.confirmAppointment);
-
-    beforeEach(() => {
-      vi.mocked(isAuthenticated).mockReturnValue(false);
-      mockConfirmAppointment.mockClear();
-    });
-
-    describe("Button Rendering", () => {
-      it("should render download button with correct attributes", async () => {
-        const wrapper = createWrapper();
-        // Simulate success state by setting the internal state directly
-        wrapper.vm.confirmAppointmentSuccess = true;
-        await nextTick();
-        
-        // The button should not be visible without appointment data
-        const buttons = wrapper.findAll('button');
-        const downloadButton = buttons.find(button => button.text().includes(de.downloadAppointment));
-        expect(downloadButton).toBeUndefined();
-      });
-
-      it("should render view button when user is authenticated", async () => {
-        vi.mocked(isAuthenticated).mockReturnValue(true);
-        const wrapper = createWrapper();
-        wrapper.vm.confirmAppointmentSuccess = true;
-        await nextTick();
-        
-        const buttons = wrapper.findAll('button');
-        const viewButton = buttons.find(button => button.text().includes(de.viewAppointment));
-        expect(viewButton).toBeDefined();
-        expect(viewButton?.attributes('icon')).toBe('arrow-right');
-        expect(viewButton?.text()).toContain(de.viewAppointment);
-      });
-
-      it("should hide view button when user is not authenticated", async () => {
-        vi.mocked(isAuthenticated).mockReturnValue(false);
-        const wrapper = createWrapper();
-        wrapper.vm.confirmAppointmentSuccess = true;
-        await nextTick();
-        
-        const buttons = wrapper.findAll('button');
-        const viewButton = buttons.find(button => button.text().includes(de.viewAppointment));
-        expect(viewButton).toBeUndefined();
-      });
-    });
-
-    describe("Download Functionality", () => {
-      it("should have downloadIcsAppointment function", async () => {
-        const wrapper = createWrapper();
-        const component = wrapper.vm as any;
-        
-        // Check that the function exists
-        expect(typeof component.downloadIcsAppointment).toBe('function');
-      });
-    });
-
-    describe("View Functionality", () => {
-      it("should have viewAppointment function", async () => {
-        const wrapper = createWrapper();
-        const component = wrapper.vm as any;
-        
-        // Check that the function exists
-        expect(typeof component.viewAppointment).toBe('function');
-      });
-    });
-
-    describe("ICS Content Integration", () => {
-      it("should handle appointment confirmation with ICS content", async () => {
-        const mockConfirmResponse = {
-          processId: "12345",
-          timestamp: 1640995200,
-          authKey: "abc123",
-          familyName: "Test User",
-          email: "test@example.com",
-          icsContent: "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:ZMS-München\r\nEND:VCALENDAR",
-          officeId: "456",
-          scope: {},
-          subRequestCounts: [],
-          serviceId: "789",
-          serviceName: "Test Service",
-          serviceCount: 1,
-          status: "confirmed"
-        };
-        mockConfirmAppointment.mockResolvedValueOnce(mockConfirmResponse);
-
-        const appointmentData = {
-          id: "12345",
-          authKey: "abc123",
-          scope: {}
-        };
-        const validHash = btoa(JSON.stringify(appointmentData));
-
-        const wrapper = createWrapper({
-          confirmAppointmentHash: validHash
-        });
-
-        await nextTick();
-        await vi.waitFor(() => {
-          expect(mockConfirmAppointment).toHaveBeenCalled();
-        });
-
-        // Check that the API was called with correct parameters
-        expect(mockConfirmAppointment).toHaveBeenCalledWith(
-          {
-            id: "12345",
-            authKey: "abc123",
-            scope: {}
-          },
-          "https://www.muenchen.de"
-        );
-      });
     });
   });
 });

--- a/zmsentities/schema/citizenapi/thinnedProcess.json
+++ b/zmsentities/schema/citizenapi/thinnedProcess.json
@@ -152,13 +152,6 @@
         "null"
       ],
       "description": "Count of slots in the process"
-    },
-    "icsContent": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "description": "ICS calendar file content for the appointment"
     }
   },
   "required": [

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -318,9 +318,7 @@ class Messaging
         // Get the ICS template for the process status dynamically
         $template = self::getTemplate('ics', $status);
         if (!$template) {
-            $exception = new \BO\Zmsentities\Exception\TemplateNotFound("ICS template for status $status not found");
-            $exception->data = $status;
-            throw $exception;
+            throw new \Exception("ICS template for status $status not found");
         }
 
         $baseParameters = self::generateMailParameters(new ProcessList([$process]), $config, null, $status);


### PR DESCRIPTION
Reverts it-at-m/eappointment#1545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed ICS calendar generation and delivery; API responses and schemas no longer include icsContent.
  - Simplified appointment flow by removing ICS download/view actions from the UI.
  - Removed appointmentDetailUrl prop from components/web component; related navigation functionality eliminated.

- Chores
  - Cleaned up unused dependencies and translation keys related to the removed features.

- Tests
  - Updated tests to reflect the removal of ICS content and related UI actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->