### PR TITLE
Update contact email in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at <opensource@muenchendigital.io>.
+reported to the community leaders responsible for enforcement at <opensource@muenchen.de>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Replaced the outdated opensource@muenchendigital.io address with the new opensource@muenchen.de.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Code of Conduct with revised contact information and minor grammatical corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->