### PR TITLE
fix(ZMSKVR): add skipArchive parameter to cluster process endpoint for zmscalldisplay and zmsticketprinter

### DIFF
--- a/zmsapi/routing.php
+++ b/zmsapi/routing.php
@@ -1009,6 +1009,11 @@ use \Psr\Http\Message\ResponseInterface;
  *                  description: "Resolve references with $ref, which might be faster on the server side. The value of the parameter is the number of iterations to resolve references"
  *                  in: query
  *                  type: integer
+ *              -   name: skipArchive
+ *                  description: "Skip querying the archive table for better performance when archived processes are not needed (e.g., for calldisplay and ticketprinter)"
+ *                  in: query
+ *                  type: integer
+ *                  default: 0
  *          responses:
  *              200:
  *                  description: "success, also if process list is empty"

--- a/zmsclient/src/Zmsclient/WorkstationRequests.php
+++ b/zmsclient/src/Zmsclient/WorkstationRequests.php
@@ -78,7 +78,8 @@ class WorkstationRequests
                     '/cluster/' . $this->readCluster()->id . '/process/' . $selectedDate->format('Y-m-d') . '/',
                     [
                         'resolveReferences' => 2,
-                        'gql' => $gql
+                        'gql' => $gql,
+                        'skipArchive' => 1
                     ]
                 )
                 ->getCollection();


### PR DESCRIPTION
- Add skipArchive parameter to ProcessListByClusterAndDate API endpoint
- Skip archive table query when skipArchive=1 for better performance
- Update WorkstationRequests to always skip archive for calldisplay/ticketprinter
- Maintain backward compatibility for zmsadmin (default behavior unchanged)
- Update Swagger documentation for new parameter

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
