### PR TITLE
feat(ZMSKVR-890): add indexes to improve performance of waiting statistic queries

### DIFF
--- a/zmsdb/migrations/91763967241-add-indexes-on-waitingstatistic.sql
+++ b/zmsdb/migrations/91763967241-add-indexes-on-waitingstatistic.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `wartenrstatistik` DROP INDEX `scopedate`;
+
+ALTER TABLE `wartenrstatistik`
+  ADD INDEX `idx_standort_datum` (`standortid`, `datum`),
+  ADD INDEX `idx_datum_standort` (`datum`, `standortid`),
+  ADD INDEX `idx_datum` (`datum`),
+  ADD INDEX `idx_standort` (`standortid`);


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


### Context and Observations:

Existing index `scopedate` (`standortid`, `datum`) was not always chosen by MySQL for queries with large `IN` lists on `standortid` or wide date ranges.

`EXPLAIN` on different query sizes revealed the following:

- Small queries (few `standortids`) use the composite index (`standortid`, `datum`) efficiently.
- Medium queries start using only the `standortid` index, resulting in temporary tables and filesort.
- Large queries often fall back to the `datum` index, bypassing the composite index entirely.