### PR TITLE
fix(ZMSKVR-936 ZMSKVR-1022): only show locations with available days in provider selection

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -557,17 +557,15 @@ const providersWithAvailableDays = computed(() => {
 });
 
 // Effective selection: only count providers that actually have available days
-const effectiveSelectedProviders = computed(() => {
-  if (!providersWithAvailableDays.value?.length) return {};
+const effectiveSelectedProviderIds = computed(() => {
+  if (!providersWithAvailableDays.value?.length) return [];
 
   const idsWithDays = new Set(
     providersWithAvailableDays.value.map((p) => String(p.id))
   );
 
-  return Object.fromEntries(
-    Object.entries(selectedProviders.value).filter(
-      ([id, isSelected]) => isSelected && idsWithDays.has(id)
-    )
+  return Object.keys(selectedProviders.value).filter(
+    (id) => selectedProviders.value[id] && idsWithDays.has(id)
   );
 });
 
@@ -668,8 +666,7 @@ const providerSelectionError = computed(() => {
 });
 
 const noProviderSelected = computed(() => {
-  // Use effectiveSelectedProviders to only count providers that have available days
-  return Object.keys(effectiveSelectedProviders.value).length === 0;
+  return effectiveSelectedProviderIds.value.length === 0;
 });
 
 // Threshold moved to constants

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -477,7 +477,7 @@ const showSelectionForProvider = async (provider: OfficeImpl) => {
   error.value = false;
   selectedDay.value = undefined;
   selectedTimeslot.value = 0;
-  await refetchAvailableDaysForSelection();
+  await fetchAvailableDaysForSelection();
 };
 
 const TODAY = new Date();
@@ -761,7 +761,7 @@ const handleError = (data: any): void => {
 };
 
 // API calls
-const refetchAvailableDaysForSelection = async (): Promise<void> => {
+const fetchAvailableDaysForSelection = async (): Promise<void> => {
   // Always fetch available days for ALL providers to maintain the full list
   const allProviderIds = (selectableProviders.value || []).map((p) =>
     Number(p.id)
@@ -1067,7 +1067,11 @@ function scheduleRefreshAfterProviderChange() {
     const prevSelectedDay = selectedDay.value
       ? new Date(selectedDay.value)
       : undefined;
-    await refetchAvailableDaysForSelection();
+
+    // No need to refetch availableDays - we already have all provider data from initial fetch
+    // Just update the UI based on current selection
+    isSwitchingProvider.value = false;
+
     // Selection changed while awaiting? Abort this cycle.
     if (selectionSnapshot !== JSON.stringify(selectedProviders.value)) {
       return;

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -556,19 +556,6 @@ const providersWithAvailableDays = computed(() => {
     .sort((a, b) => (b.priority ?? -Infinity) - (a.priority ?? -Infinity));
 });
 
-// Effective selection: only count providers that actually have available days
-const effectiveSelectedProviderIds = computed(() => {
-  if (!providersWithAvailableDays.value?.length) return [];
-
-  const idsWithDays = new Set(
-    providersWithAvailableDays.value.map((p) => String(p.id))
-  );
-
-  return Object.keys(selectedProviders.value).filter(
-    (id) => selectedProviders.value[id] && idsWithDays.has(id)
-  );
-});
-
 const hasSelectedProviderWithAppointments = computed(() => {
   if (!availableDays?.value || availableDays.value.length === 0) {
     return false;
@@ -666,7 +653,15 @@ const providerSelectionError = computed(() => {
 });
 
 const noProviderSelected = computed(() => {
-  return effectiveSelectedProviderIds.value.length === 0;
+  if (!providersWithAvailableDays.value?.length) return true;
+
+  const idsWithDays = new Set(
+    providersWithAvailableDays.value.map((p) => String(p.id))
+  );
+
+  return !Object.keys(selectedProviders.value).some(
+    (id) => selectedProviders.value[id] && idsWithDays.has(id)
+  );
 });
 
 // Threshold moved to constants

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection/ProviderSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection/ProviderSelection.vue
@@ -4,7 +4,7 @@
       v-if="
         providersWithAppointments &&
         providersWithAppointments.length > 1 &&
-        selectableProviders.length > 0
+        selectableProviders.length > 1
       "
     >
       <div class="m-component slider-no-margin">

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection/ProviderSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection/ProviderSelection.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <div
-      v-if="providersWithAppointments && providersWithAppointments.length > 1"
+      v-if="
+        providersWithAppointments &&
+        providersWithAppointments.length > 1 &&
+        selectableProviders.length > 0
+      "
     >
       <div class="m-component slider-no-margin">
         <div class="m-content">

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
@@ -297,8 +297,9 @@ describe("AppointmentSelection", () => {
     wrapper.vm.selectedProviders = {};
     await nextTick();
 
-    // When no providers are selected, availableDays should be empty
-    expect(wrapper.vm.availableDays).toEqual([]);
+    // With new behavior, availableDays still contains data for all providers (we always fetch all)
+    // The filtering happens in providersWithAvailableDays computed property
+    expect(wrapper.vm.availableDays).toEqual([{ time: "2025-06-17", providerIDs: "1,2" }]);
 
     // The error message should be shown when no provider with appointments is selected
     expect(wrapper.text()).toContain("errorMessageProviderSelection");
@@ -360,12 +361,17 @@ describe("AppointmentSelection", () => {
     await wrapper.vm.showSelectionForProvider({ name: "Office AAA", id: 102522, address: { street: "Elm", house_number: "99" }});
     await nextTick();
 
-    // When we uncheck a provider, availableDays becomes empty (only fetches for selected providers)
+    // Uncheck the provider - with new behavior, availableDays still contains data for all providers
     wrapper.vm.selectedProviders[102522] = !wrapper.vm.selectedProviders[102522];
     await nextTick();
 
-    // Since no providers are selected, availableDays is empty and all dates are disabled
-    expect(wrapper.vm.availableDays).toEqual([]);
+    // availableDays still has data (we always fetch all providers), but allowedDates
+    // checks if selected providers have appointments on that day
+    expect(wrapper.vm.availableDays).toEqual([
+      { time: '2025-05-14', providerIDs: '102522,54261,10489' },
+      { time: '2025-05-15', providerIDs: '102522' }
+    ]);
+    // With no providers selected, allowedDates returns false for all dates
     expect(wrapper.vm.allowedDates(new Date('2025-05-14'))).toBeFalsy();
     expect(wrapper.vm.allowedDates(new Date('2025-05-16'))).toBeFalsy();
     expect(wrapper.vm.allowedDates(new Date('2025-05-17'))).toBeFalsy();

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ProviderSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ProviderSelection.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, nextTick } from "vue";
 // Mount parent to exercise logic and assert ProviderSelection UI
@@ -7,7 +7,11 @@ import AppointmentSelection from "@/components/Appointment/AppointmentSelection.
 
 // Mock API to avoid real network calls
 vi.mock("@/api/ZMSAppointmentAPI", () => ({
-  fetchAvailableDays: vi.fn().mockResolvedValue({ availableDays: [] }),
+  fetchAvailableDays: vi.fn().mockResolvedValue({ 
+    availableDays: [
+      { time: '2025-06-17', providerIDs: '1,2,3,4,102522,102523,102524,102526,10489,10502,54261' }
+    ] 
+  }),
   fetchAvailableTimeSlots: vi.fn().mockResolvedValue({ offices: [] }),
 }));
 
@@ -84,6 +88,7 @@ describe("ProviderSelection (UI via AppointmentSelection)", () => {
         ],
       },
     });
+    await flushPromises(); // Wait for API call to complete
     await nextTick();
     const checkboxes = wrapper.findAll('input[type="checkbox"]');
     expect(checkboxes.length).toBe(2);
@@ -165,6 +170,7 @@ describe("ProviderSelection (UI via AppointmentSelection)", () => {
         ] }
     });
 
+    await flushPromises(); // Wait for API call to complete
     await nextTick();
 
     expect(wrapper.text()).toContain("Office ABC");

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ProviderSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ProviderSelection.spec.ts
@@ -126,17 +126,19 @@ describe("ProviderSelection (UI via AppointmentSelection)", () => {
       expect(resultIds).toEqual(expectedIds.sort());
     };
 
-    // 1. service 1063453 disables 10489
+    // 1. service 1063453 disables 10489 (1063453 is in 10489's disabledByServices)
     await runTest([1063453], [102522, 102523, 102524, 102526, 10502, 54261]);
 
-    // 2. service 1234567 doesn't disable 10489
+    // 2. service 1234567 doesn't disable 10489 (1234567 is not in anyone's disabledByServices)
+    // Both 10489 and 10502 pass, but 10489 comes first so it's returned for the "Bürgerbüro Ruppertstraße" group
     await runTest([1234567], [102522, 102523, 102524, 102526, 10489, 54261]);
 
-    // 3. services 1063453 + 1063441 fully match disabledByServices of 10489
+    // 3. services 1063453 + 1063441 - 10489 is filtered out (has 1063453 in disabledByServices)
     await runTest([1063453, 1063441], [102522, 102523, 102524, 102526, 10502, 54261]);
 
-    // 4. services 1063453 + 1234567 don't fully match disabledByServices of 10489
-    await runTest([1063453, 1234567], [102522, 102523, 102524, 102526, 10489, 54261]);
+    // 4. services 1063453 + 1234567 - 10489 is filtered out (has 1063453 in disabledByServices)
+    // If ANY selected service is in disabledByServices, provider is filtered out
+    await runTest([1063453, 1234567], [102522, 102523, 102524, 102526, 10502, 54261]);
   });
 
   it("shows providers in correct prio", async () => {

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -43,6 +43,10 @@ class Munich
         [
             "locations" => [10489], // Bürgerbüro Ruppertstraße
             "services" => [1063453, 1063441, 1080582] // Reisepass, Personalausweis, Vorläufiger Reisepass
+        ],
+        [
+            "locations" => [10286848, 10286849, 10181770, 10204387, 10204388, 10227989, 10286849, 1060068], // Bürgerbüros ohne Abholung Personalausweis, Reisepass oder eID-Karte
+            "services" => [10295182] // Abholung Personalausweis, Reisepass oder eID-Karte only Ruppertstraße 10492
         ]
     ];
 

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -45,8 +45,8 @@ class Munich
             "services" => [1063453, 1063441, 1080582] // Reisepass, Personalausweis, Vorläufiger Reisepass
         ],
         [
-            "locations" => [10286848, 10286849, 10181770, 10204387, 10204388, 10227989, 10286849, 1060068], // Bürgerbüros ohne Abholung Personalausweis, Reisepass oder eID-Karte
-            "services" => [10295182] // Abholung Personalausweis, Reisepass oder eID-Karte only Ruppertstraße 10492
+            "locations" => [10286848, 10286849, 10181770, 10204387, 10204388, 10227989, 1060068], // Bürgerbüros ohne Abholung Personalausweis, Reisepass oder eID-Karte
+            "services" => [10295182] // Abholung Personalausweis, Reisepass oder eID-Karte - only available at Ruppertstraße (10489)
         ]
     ];
 


### PR DESCRIPTION
- Add providersWithAvailableDays computed to filter providers based on availableDays
- Change refetchAvailableDaysForSelection to always fetch all provider IDs
- Add watcher to auto-deselect providers without available days
- Update tests to reflect new behavior

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider list shows only providers with available days, sorted by priority.
  * Availability is fetched for all providers so the calendar has a complete dataset.

* **Bug Fixes**
  * Selections and calendar view auto-adjust when provider availability changes without extra refetches.
  * Selected date is revalidated/adjusted when availability changes.
  * First-provider selection hidden when not enough selectable providers.
  * Additional locations excluded from display for a specific service.

* **Tests**
  * Unit tests updated for the new availability flow and improved API synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->