### PR TITLE
fix(ZMSKVR-1058): invalidate cache keys when saving scopes, departments, and clusters

### DIFF
--- a/zmsdb/src/Zmsdb/Cluster.php
+++ b/zmsdb/src/Zmsdb/Cluster.php
@@ -441,18 +441,18 @@ class Cluster extends Base
 
         $invalidatedKeys = [];
 
-        // Invalidate cluster entity cache
-        for ($i = 0; $i <= 2; $i++) {
-            $key = "cluster-{$cluster->id}-{$i}";
+        // Invalidate cluster entity cache for all resolveReferences levels (0, 1, 2)
+        for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+            $key = "cluster-{$cluster->id}-{$resolveReferences}";
             if (App::$cache->has($key)) {
                 App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }
 
-        // Invalidate scopeReadByClusterId cache (scopes associated with this cluster)
-        for ($i = 0; $i <= 2; $i++) {
-            $key = "scopeReadByClusterId-{$cluster->id}-{$i}";
+        // Invalidate scopeReadByClusterId cache for all resolveReferences levels (0, 1, 2)
+        for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+            $key = "scopeReadByClusterId-{$cluster->id}-{$resolveReferences}";
             if (App::$cache->has($key)) {
                 App::$cache->delete($key);
                 $invalidatedKeys[] = $key;

--- a/zmsdb/src/Zmsdb/Cluster.php
+++ b/zmsdb/src/Zmsdb/Cluster.php
@@ -43,12 +43,12 @@ class Cluster extends Base
             if (! $cluster->hasId()) {
                 return null;
             }
-        }
 
-        if (App::$cache) {
-            App::$cache->set($cacheKey, $cluster);
-            if (\App::$log) {
-                \App::$log->info('Cluster cache set', ['cache_key' => $cacheKey]);
+            if (App::$cache) {
+                App::$cache->set($cacheKey, $cluster);
+                if (\App::$log) {
+                    \App::$log->info('Cluster cache set', ['cache_key' => $cacheKey]);
+                }
             }
         }
 

--- a/zmsdb/src/Zmsdb/Cluster.php
+++ b/zmsdb/src/Zmsdb/Cluster.php
@@ -459,7 +459,6 @@ class Cluster extends Base
             }
         }
 
-        // Log invalidated cache keys
         if (!empty($invalidatedKeys) && \App::$log) {
             \App::$log->info('Cluster cache invalidated', [
                 'cluster_id' => $cluster->id,

--- a/zmsdb/src/Zmsdb/Cluster.php
+++ b/zmsdb/src/Zmsdb/Cluster.php
@@ -2,7 +2,6 @@
 
 namespace BO\Zmsdb;
 
-use BO\Zmsdb\Application as App;
 use BO\Zmsentities\Cluster as Entity;
 use BO\Zmsentities\Collection\ClusterList as Collection;
 
@@ -20,8 +19,8 @@ class Cluster extends Base
         $cacheKey = "cluster-$itemId-$resolveReferences";
 
         $cluster = null;
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $cluster = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $cluster = \App::$cache->get($cacheKey);
         }
 
         if (empty($cluster)) {
@@ -35,8 +34,8 @@ class Cluster extends Base
                 return null;
             }
 
-            if (App::$cache) {
-                App::$cache->set($cacheKey, $cluster);
+            if (\App::$cache) {
+                \App::$cache->set($cacheKey, $cluster);
                 if (\App::$log) {
                     \App::$log->info('Cluster cache set', ['cache_key' => $cacheKey]);
                 }
@@ -324,7 +323,7 @@ class Cluster extends Base
 
     public function removeCache($cluster)
     {
-        if (!App::$cache || !isset($cluster->id)) {
+        if (!\App::$cache || !isset($cluster->id)) {
             return;
         }
 
@@ -333,8 +332,8 @@ class Cluster extends Base
         // Invalidate cluster entity cache for all resolveReferences levels (0, 1, 2)
         for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
             $key = "cluster-{$cluster->id}-{$resolveReferences}";
-            if (App::$cache->has($key)) {
-                App::$cache->delete($key);
+            if (\App::$cache->has($key)) {
+                \App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }
@@ -342,8 +341,8 @@ class Cluster extends Base
         // Invalidate scopeReadByClusterId cache for all resolveReferences levels (0, 1, 2)
         for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
             $key = "scopeReadByClusterId-{$cluster->id}-{$resolveReferences}";
-            if (App::$cache->has($key)) {
-                App::$cache->delete($key);
+            if (\App::$cache->has($key)) {
+                \App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }

--- a/zmsdb/src/Zmsdb/Cluster.php
+++ b/zmsdb/src/Zmsdb/Cluster.php
@@ -15,15 +15,6 @@ use BO\Zmsentities\Collection\ClusterList as Collection;
  */
 class Cluster extends Base
 {
-    /**
-    * read entity
-    *
-    * @param
-    * itemId
-    * resolveReferences
-    *
-    * @return Resource Entity
-    */
     public function readEntity($itemId, $resolveReferences = 0, $disableCache = false)
     {
         $cacheKey = "cluster-$itemId-$resolveReferences";
@@ -74,14 +65,6 @@ class Cluster extends Base
         return $entity;
     }
 
-    /**
-    * read list of clusters
-    *
-    * @param
-    * resolveReferences
-    *
-    * @return Resource Collection
-    */
     public function readList($resolveReferences = 0)
     {
         $clusterList = new Collection();
@@ -136,15 +119,6 @@ class Cluster extends Base
         return $clusterList;
     }
 
-    /**
-     * get a queueList by cluster id and dateTime
-     *
-     ** @param
-     *            clusterId
-     *            now
-     *
-     * @return Bool
-     */
     public function readQueueList(
         $clusterId,
         \DateTimeInterface $dateTime,
@@ -158,15 +132,6 @@ class Cluster extends Base
             ->withSortedWaitingTime();
     }
 
-    /**
-     * get a scopeList with opened scopes
-     *
-     ** @param
-     *            clusterId
-     *            now
-     *
-     * @return Bool
-     */
     public function readOpenedScopeList($clusterId, \DateTimeInterface $dateTime)
     {
         $scopeList = new \BO\Zmsentities\Collection\ScopeList();
@@ -194,15 +159,6 @@ class Cluster extends Base
         return $scopeList;
     }
 
-    /**
-     * get the scope with shortest estimated waitingtime
-     *
-     ** @param
-     *            clusterId
-     *            now
-     *
-     * @return Bool
-     */
     public function readScopeWithShortestWaitingTime($clusterId, \DateTimeInterface $dateTime)
     {
         $scopeList = $this->readOpenedScopeList($clusterId, $dateTime)->getArrayCopy();
@@ -229,15 +185,6 @@ class Cluster extends Base
         return $preferedScope;
     }
 
-    /**
-     * get cluster with scopes workstation count
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return number
-     */
     public function readWithScopeWorkstationCount($clusterId, $dateTime, $resolveReferences = 0)
     {
         $scopeQuery = new Scope();
@@ -255,15 +202,6 @@ class Cluster extends Base
         return $cluster;
     }
 
-    /**
-     * update image data for call display image
-     *
-     * @param
-     *         clusterId
-     *         Mimepart entity
-     *
-     * @return Mimepart entity
-     */
     public function writeImageData($clusterId, \BO\Zmsentities\Mimepart $entity)
     {
         if ($entity->mime && $entity->content) {
@@ -285,14 +223,6 @@ class Cluster extends Base
         return $entity;
     }
 
-    /**
-     * read image data
-     *
-     * @param
-     *         clusterId
-     *
-     * @return Mimepart entity
-     */
     public function readImageData($clusterId)
     {
         $imageName = 'c_' . $clusterId . '_bild';
@@ -308,14 +238,6 @@ class Cluster extends Base
         return $imageData;
     }
 
-    /**
-     * delete image data for calldisplay image
-     *
-     * @param
-     *         clusterId
-     *
-     * @return Status
-     */
     public function deleteImage($clusterId)
     {
         $imageName = 'c_' . $clusterId . '_bild';
@@ -328,14 +250,6 @@ class Cluster extends Base
         return $result;
     }
 
-    /**
-    * remove an cluster
-    *
-    * @param
-    * itemId
-    *
-    * @return Resource Status
-    */
     public function deleteEntity($itemId)
     {
         $result = false;
@@ -354,14 +268,6 @@ class Cluster extends Base
         return $result;
     }
 
-    /**
-     * write an cluster
-     *
-     * @param
-     * entity
-     *
-     * @return Entity
-     */
     public function writeEntity(\BO\Zmsentities\Cluster $entity)
     {
         $query = new Query\Cluster(Query\Base::INSERT);
@@ -378,14 +284,6 @@ class Cluster extends Base
         return $this->readEntity($lastInsertId, 1, true);
     }
 
-    /**
-     * update an cluster
-     *
-     * @param
-     * clusterId, entity
-     *
-     * @return Entity
-     */
     public function updateEntity($clusterId, \BO\Zmsentities\Cluster $entity)
     {
         $query = new Query\Cluster(Query\Base::UPDATE);
@@ -402,15 +300,6 @@ class Cluster extends Base
         return $this->readEntity($clusterId, 1, true);
     }
 
-    /**
-     * create links preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            links
-     *
-     * @return Boolean
-     */
     protected function writeAssignedScopes($clusterId, $scopeList)
     {
         $cluster = $this->readEntity($clusterId);

--- a/zmsdb/src/Zmsdb/Department.php
+++ b/zmsdb/src/Zmsdb/Department.php
@@ -13,10 +13,6 @@ use BO\Zmsentities\Collection\DepartmentList as Collection;
  */
 class Department extends Base
 {
-    /**
-     *
-     * @var Array \BO\Zmsentities\Department
-     */
     public static $departmentCache = array();
 
     public function readEntity($departmentId, $resolveReferences = 0, $disableCache = false)
@@ -145,14 +141,6 @@ class Department extends Base
         return $departmentList;
     }
 
-    /**
-     * remove a department
-     *
-     * @param
-     *            departmentId
-     *
-     * @return Resource Status
-     */
     public function deleteEntity($departmentId)
     {
         $entity = $this->readEntity($departmentId, 1);
@@ -181,13 +169,6 @@ class Department extends Base
         return ($entity && $entityDelete && $emailDelete && $notificationsDelete) ? $entity : null;
     }
 
-    /**
-     * write a department
-     *
-     * @param Department $entity
-     *
-     * @return Entity
-     */
     public function writeEntity(\BO\Zmsentities\Department $entity, $parentId)
     {
         self::$departmentCache = [];
@@ -223,14 +204,6 @@ class Department extends Base
         return $this->readEntity($lastInsertId);
     }
 
-    /**
-     * update a department
-     *
-     * @param
-     *            departmentId
-     *
-     * @return Entity
-     */
     public function updateEntity($departmentId, \BO\Zmsentities\Department $entity)
     {
         self::$departmentCache = [];
@@ -258,15 +231,6 @@ class Department extends Base
         return $this->readEntity($departmentId, 0, true);
     }
 
-    /**
-     * create dayoff preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            dayoffs
-     *
-     * @return Boolean
-     */
     protected function writeDepartmentDayoffs($departmentId, $dayoffList)
     {
         if (!$departmentId) {
@@ -293,15 +257,6 @@ class Department extends Base
         }
     }
 
-    /**
-     * create links preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            links
-     *
-     * @return Boolean
-     */
     protected function writeDepartmentLinks($departmentId, $links)
     {
         if (!$departmentId) {
@@ -322,15 +277,6 @@ class Department extends Base
         }
     }
 
-    /**
-     * create mail preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            email
-     *
-     * @return Boolean
-     */
     protected function writeDepartmentMail(
         $departmentId,
         $email,
@@ -347,15 +293,6 @@ class Department extends Base
         return $result;
     }
 
-    /**
-     * create notification preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            preferences
-     *
-     * @return Boolean
-     */
     protected function writeDepartmentNotifications($departmentId, $preferences)
     {
         self::$departmentCache = [];
@@ -373,15 +310,6 @@ class Department extends Base
         return $result;
     }
 
-    /**
-     * update mail preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            email
-     *
-     * @return Boolean
-     */
     protected function updateDepartmentMail(
         $departmentId,
         $email,
@@ -398,15 +326,6 @@ class Department extends Base
         ));
     }
 
-    /**
-     * update notification preferences of a department
-     *
-     * @param
-     *            departmentId,
-     *            preferences
-     *
-     * @return Boolean
-     */
     protected function updateDepartmentNotifications($departmentId, $preferences)
     {
         self::$departmentCache = [];

--- a/zmsdb/src/Zmsdb/Department.php
+++ b/zmsdb/src/Zmsdb/Department.php
@@ -2,7 +2,6 @@
 
 namespace BO\Zmsdb;
 
-use BO\Zmsdb\Application as App;
 use BO\Zmsentities\Department as Entity;
 use BO\Zmsentities\Collection\DepartmentList as Collection;
 
@@ -19,8 +18,8 @@ class Department extends Base
     {
         $cacheKey = "department-$departmentId-$resolveReferences";
 
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $department = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $department = \App::$cache->get($cacheKey);
         }
 
         if (empty($department)) {
@@ -30,8 +29,8 @@ class Department extends Base
                 ->addConditionDepartmentId($departmentId);
             $department = $this->fetchOne($query, new Entity());
 
-            if (App::$cache) {
-                App::$cache->set($cacheKey, $department);
+            if (\App::$cache) {
+                \App::$cache->set($cacheKey, $department);
                 if (\App::$log) {
                     \App::$log->info('Department cache set', ['cache_key' => $cacheKey]);
                 }
@@ -367,7 +366,7 @@ class Department extends Base
 
     public function removeCache($department)
     {
-        if (!App::$cache || !isset($department->id)) {
+        if (!\App::$cache || !isset($department->id)) {
             return;
         }
 
@@ -376,8 +375,8 @@ class Department extends Base
         // Invalidate department entity cache for all resolveReferences levels (0, 1, 2)
         for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
             $key = "department-{$department->id}-{$resolveReferences}";
-            if (App::$cache->has($key)) {
-                App::$cache->delete($key);
+            if (\App::$cache->has($key)) {
+                \App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }
@@ -385,8 +384,8 @@ class Department extends Base
         // Invalidate scopeReadByDepartmentId cache for all resolveReferences levels (0, 1, 2)
         for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
             $key = "scopeReadByDepartmentId-{$department->id}-{$resolveReferences}";
-            if (App::$cache->has($key)) {
-                App::$cache->delete($key);
+            if (\App::$cache->has($key)) {
+                \App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }

--- a/zmsdb/src/Zmsdb/Department.php
+++ b/zmsdb/src/Zmsdb/Department.php
@@ -454,18 +454,18 @@ class Department extends Base
 
         $invalidatedKeys = [];
 
-        // Invalidate department entity cache
-        for ($i = 0; $i <= 2; $i++) {
-            $key = "department-{$department->id}-{$i}";
+        // Invalidate department entity cache for all resolveReferences levels (0, 1, 2)
+        for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+            $key = "department-{$department->id}-{$resolveReferences}";
             if (App::$cache->has($key)) {
                 App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }
 
-        // Invalidate scopeReadByDepartmentId cache (scopes associated with this department)
-        for ($i = 0; $i <= 2; $i++) {
-            $key = "scopeReadByDepartmentId-{$department->id}-{$i}";
+        // Invalidate scopeReadByDepartmentId cache for all resolveReferences levels (0, 1, 2)
+        for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+            $key = "scopeReadByDepartmentId-{$department->id}-{$resolveReferences}";
             if (App::$cache->has($key)) {
                 App::$cache->delete($key);
                 $invalidatedKeys[] = $key;

--- a/zmsdb/src/Zmsdb/Department.php
+++ b/zmsdb/src/Zmsdb/Department.php
@@ -472,7 +472,6 @@ class Department extends Base
             }
         }
 
-        // Log invalidated cache keys
         if (!empty($invalidatedKeys) && \App::$log) {
             \App::$log->info('Department cache invalidated', [
                 'department_id' => $department->id,

--- a/zmsdb/src/Zmsdb/Organisation.php
+++ b/zmsdb/src/Zmsdb/Organisation.php
@@ -85,14 +85,6 @@ class Organisation extends Base
         return $organisationList;
     }
 
-    /**
-     * read Organisation by Ticketprinter Hash
-     *
-     * @param
-     * hash
-     *
-     * @return Resource Entity
-     */
     public function readByHash($hash)
     {
         $organisationId = $this->getReader()
@@ -121,14 +113,6 @@ class Organisation extends Base
         return $organisationList;
     }
 
-    /**
-     * remove an organisation
-     *
-     * @param
-     *            itemId
-     *
-     * @return Resource Status
-     */
     public function deleteEntity($itemId)
     {
         $entity = $this->readEntity($itemId, 1);
@@ -140,14 +124,6 @@ class Organisation extends Base
         return ($this->deleteItem($query)) ? $entity : null;
     }
 
-    /**
-     * write a organisation
-     *
-     * @param
-     *            organisationId
-     *
-     * @return Entity
-     */
     public function writeEntity(\BO\Zmsentities\Organisation $entity, $parentId)
     {
         $query = new Query\Organisation(Query\Base::INSERT);
@@ -162,14 +138,6 @@ class Organisation extends Base
         return $this->readEntity($lastInsertId);
     }
 
-    /**
-     * update a organisation
-     *
-     * @param
-     *            organisationId
-     *
-     * @return Entity
-     */
     public function updateEntity($organisationId, \BO\Zmsentities\Organisation $entity)
     {
         $query = new Query\Organisation(Query\Base::UPDATE);
@@ -183,15 +151,6 @@ class Organisation extends Base
         return $this->readEntity($organisationId, 1, true);
     }
 
-    /**
-     * create ticketprinters of an organisation
-     *
-     * @param
-     *            organisationID,
-     *            ticketprinterList
-     *
-     * @return Boolean
-     */
     protected function writeOrganisationTicketprinters($organisationId, $ticketprinterList)
     {
         $deleteQuery = new Query\Ticketprinter(Query\Base::DELETE);
@@ -205,15 +164,6 @@ class Organisation extends Base
         }
     }
 
-    /**
-     * update ticketprinters of an organisation
-     *
-     * @param
-     *            organisationID,
-     *            ticketprinterList
-     *
-     * @return Boolean
-     */
     protected function updateOrganisationTicketprinters($ticketprinterList, $organisationId)
     {
         foreach ($ticketprinterList as $item) {

--- a/zmsdb/src/Zmsdb/Query/Scope.php
+++ b/zmsdb/src/Zmsdb/Query/Scope.php
@@ -73,6 +73,16 @@ class Scope extends Base implements MappingInterface
         ';
     }
 
+    public function getQueryDepartmentIdByScopeId()
+    {
+        return 'SELECT BehoerdenID FROM standort WHERE StandortID = ?';
+    }
+
+    public function getQueryClusterIdsByScopeId()
+    {
+        return 'SELECT clusterID FROM clusterzuordnung WHERE standortID = ?';
+    }
+
     public function getQueryReadImageData()
     {
         return '

--- a/zmsdb/src/Zmsdb/Scope.php
+++ b/zmsdb/src/Zmsdb/Scope.php
@@ -345,15 +345,6 @@ class Scope extends Base
         return $scopeList;
     }
 
-    /**
-     * get a scope and return true if it is opened
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return Bool
-     */
     public function readIsOpened($scopeId, $now)
     {
         $isOpened = false;
@@ -378,15 +369,6 @@ class Scope extends Base
         );
     }
 
-    /**
-     * get last given waitingnumer and return updated (+1) waitingnumber
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return Bool
-     */
     public function readWaitingNumberUpdated($scopeId, $dateTime, $respectContingent = true)
     {
         if (! $this->readIsGivenNumberInContingent($scopeId) && $respectContingent) {
@@ -412,15 +394,6 @@ class Scope extends Base
         return $scope->getStatus('queue', 'lastDisplayNumber');
     }
 
-    /**
-     * get last given waitingnumer and return updated (+1) waitingnumber
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return Bool
-     */
     public function readIsGivenNumberInContingent($scopeId)
     {
         $isInContingent = $this->getReader()
@@ -429,15 +402,6 @@ class Scope extends Base
         return ($isInContingent) ? true : false;
     }
 
-    /**
-     * get list of queues on scope by daytime
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return number
-     */
     public function readQueueList($scopeIds, $dateTime, $resolveReferences = 0, $withEntities = [])
     {
         if ($resolveReferences > 0) {
@@ -457,15 +421,6 @@ class Scope extends Base
         return $queueList->withSortedArrival();
     }
 
-    /**
-     * get waitingtime of scope
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return \BO\Zmsentities\Scope
-     */
     public function readWithWorkstationCount($scopeId, $dateTime, $resolveReferences = 0, $withEntities = [])
     {
         $query = new Query\Scope(Query\Base::SELECT, '', false, null, $withEntities);
@@ -505,15 +460,6 @@ class Scope extends Base
         return $queueList->withEstimatedWaitingTime($timeAverage, $workstationCount, $dateTime);
     }
 
-    /**
-     * get list of scopes with admin
-     *
-     * * @param
-     * scopeId
-     * now
-     *
-     * @return number
-     */
     public function readListWithScopeAdminEmail($resolveReferences = 0)
     {
         $scopeList = new Collection();
@@ -534,11 +480,6 @@ class Scope extends Base
         return $scopeList;
     }
 
-    /**
-     * write a scope
-     *
-     * @return Entity
-     */
     public function writeEntity(\BO\Zmsentities\Scope $entity, $parentId)
     {
         self::$cache = [];
@@ -555,14 +496,6 @@ class Scope extends Base
         return $this->readEntity($lastInsertId);
     }
 
-    /**
-     * update a scope
-     *
-     * @param
-     *            scopeId
-     *
-     * @return Entity
-     */
     public function updateEntity($scopeId, \BO\Zmsentities\Scope $entity, $resolveReferences = 0)
     {
         self::$cache = [];
@@ -595,16 +528,6 @@ class Scope extends Base
         }
     }
 
-    /**
-     * update ghostWorkstationCount
-     *
-     * @param
-     *         scopeId
-     *         entity
-     *         dateTime (now)
-     *
-     * @return Entity
-     */
     public function updateGhostWorkstationCount(\BO\Zmsentities\Scope $entity, \DateTimeInterface $dateTime)
     {
         $departmentId = $this->readDepartmentIdByScopeId($entity->id);
@@ -620,15 +543,6 @@ class Scope extends Base
         return $entity;
     }
 
-    /**
-     * update emergency
-     *
-     * @param
-     *         scopeId
-     *         entity
-     *
-     * @return Entity
-     */
     public function updateEmergency($scopeId, \BO\Zmsentities\Scope $entity)
     {
         self::$cache = [];
@@ -645,15 +559,6 @@ class Scope extends Base
         return $this->readEntity($scopeId, 0, true);
     }
 
-    /**
-     * update image data for call display image
-     *
-     * @param
-     *         scopeId
-     *         Mimepart entity
-     *
-     * @return Mimepart entity
-     */
     public function writeImageData($scopeId, \BO\Zmsentities\Mimepart $entity)
     {
         if ($entity->mime && $entity->content) {
@@ -675,14 +580,6 @@ class Scope extends Base
         return $entity;
     }
 
-    /**
-     * read image data
-     *
-     * @param
-     *         scopeId
-     *
-     * @return Mimepart entity
-     */
     public function readImageData($scopeId)
     {
         $imageName = 's_' . $scopeId . '_bild';
@@ -698,14 +595,6 @@ class Scope extends Base
         return $imageData;
     }
 
-    /**
-     * delete image data for call display image
-     *
-     * @param
-     *         scopeId
-     *
-     * @return Status
-     */
     public function deleteImage($scopeId)
     {
         $imageName = 's_' . $scopeId . '_bild';
@@ -714,14 +603,6 @@ class Scope extends Base
         ));
     }
 
-    /**
-     * remove a scope
-     *
-     * @param
-     *            scopeId
-     *
-     * @return Resource Status
-     */
     public function deleteEntity($scopeId)
     {
         $processListCount = (new Process())->readProcessListCountByScope($scopeId);
@@ -754,24 +635,12 @@ class Scope extends Base
         }
     }
 
-    /**
-     * Read department ID for a scope
-     *
-     * @param int $scopeId
-     * @return int|null
-     */
     public function readDepartmentIdByScopeId($scopeId)
     {
         $query = new Query\Scope(Query\Base::SELECT);
         return $this->getReader()->fetchValue($query->getQueryDepartmentIdByScopeId(), [$scopeId]);
     }
 
-    /**
-     * Read cluster IDs that contain this scope
-     *
-     * @param int $scopeId
-     * @return array
-     */
     public function readClusterIdsByScopeId($scopeId)
     {
         $query = new Query\Scope(Query\Base::SELECT);
@@ -779,12 +648,6 @@ class Scope extends Base
         return array_column($result, 'clusterID');
     }
 
-    /**
-     * Remove cache entries with context information (department ID, cluster IDs)
-     *
-     * @param \BO\Zmsentities\Scope $scope
-     * @param int|null $departmentId
-     */
     public function removeCacheByContext($scope, $departmentId = null)
     {
         if (!App::$cache) {

--- a/zmsdb/src/Zmsdb/Scope.php
+++ b/zmsdb/src/Zmsdb/Scope.php
@@ -799,10 +799,10 @@ class Scope extends Base
 
         $invalidatedKeys = [];
 
-        // Invalidate scope entity cache
+        // Invalidate scope entity cache for all resolveReferences levels (0, 1, 2)
         if (isset($scope->id)) {
-            for ($i = 0; $i <= 2; $i++) {
-                $key = "scope-{$scope->id}-{$i}";
+            for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+                $key = "scope-{$scope->id}-{$resolveReferences}";
                 if (App::$cache->has($key)) {
                     App::$cache->delete($key);
                     $invalidatedKeys[] = $key;
@@ -810,19 +810,19 @@ class Scope extends Base
             }
         }
 
-        // Invalidate scope list cache
-        for ($i = 0; $i <= 2; $i++) {
-            $key = "scopeReadList-{$i}";
+        // Invalidate scope list cache for all resolveReferences levels (0, 1, 2)
+        for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+            $key = "scopeReadList-{$resolveReferences}";
             if (App::$cache->has($key)) {
                 App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }
 
-        // Invalidate scopeReadByDepartmentId cache
+        // Invalidate scopeReadByDepartmentId cache for all resolveReferences levels (0, 1, 2)
         if ($departmentId) {
-            for ($i = 0; $i <= 2; $i++) {
-                $key = "scopeReadByDepartmentId-{$departmentId}-{$i}";
+            for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+                $key = "scopeReadByDepartmentId-{$departmentId}-{$resolveReferences}";
                 if (App::$cache->has($key)) {
                     App::$cache->delete($key);
                     $invalidatedKeys[] = $key;
@@ -834,8 +834,8 @@ class Scope extends Base
         if (isset($scope->id)) {
             $clusterIds = $this->readClusterIdsByScopeId($scope->id);
             foreach ($clusterIds as $clusterId) {
-                for ($i = 0; $i <= 2; $i++) {
-                    $key = "scopeReadByClusterId-{$clusterId}-{$i}";
+                for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+                    $key = "scopeReadByClusterId-{$clusterId}-{$resolveReferences}";
                     if (App::$cache->has($key)) {
                         App::$cache->delete($key);
                         $invalidatedKeys[] = $key;
@@ -844,11 +844,11 @@ class Scope extends Base
             }
         }
 
-        // Invalidate scopeReadByProviderId cache
+        // Invalidate scopeReadByProviderId cache for all resolveReferences levels (0, 1, 2)
         if (isset($scope->provider) && isset($scope->provider['id']) && $scope->provider['id']) {
             $providerId = $scope->provider['id'];
-            for ($i = 0; $i <= 2; $i++) {
-                $key = "scopeReadByProviderId-{$providerId}-{$i}";
+            for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
+                $key = "scopeReadByProviderId-{$providerId}-{$resolveReferences}";
                 if (App::$cache->has($key)) {
                     App::$cache->delete($key);
                     $invalidatedKeys[] = $key;

--- a/zmsdb/src/Zmsdb/Scope.php
+++ b/zmsdb/src/Zmsdb/Scope.php
@@ -4,7 +4,6 @@ namespace BO\Zmsdb;
 
 use BO\Zmsentities\Scope as Entity;
 use BO\Zmsentities\Collection\ScopeList as Collection;
-use BO\Zmsdb\Application as App;
 
 /**
  *
@@ -22,8 +21,8 @@ class Scope extends Base
     {
         $cacheKey = "scope-$scopeId-$resolveReferences";
 
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $scope = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $scope = \App::$cache->get($cacheKey);
         }
 
         if (empty($scope)) {
@@ -36,8 +35,8 @@ class Scope extends Base
                 return null;
             }
 
-            if (App::$cache) {
-                App::$cache->set($cacheKey, $scope);
+            if (\App::$cache) {
+                \App::$cache->set($cacheKey, $scope);
                 if (\App::$log) {
                     \App::$log->info('Scope cache set', ['cache_key' => $cacheKey]);
                 }
@@ -112,8 +111,8 @@ class Scope extends Base
     ) {
         $cacheKey = "scopeReadByClusterId-$clusterId-$resolveReferences";
 
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $result = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $result = \App::$cache->get($cacheKey);
         }
 
         if (empty($result)) {
@@ -130,8 +129,8 @@ class Scope extends Base
                 );
             }
 
-            if (App::$cache && !($result instanceof \PDOStatement)) {
-                App::$cache->set($cacheKey, $result);
+            if (\App::$cache && !($result instanceof \PDOStatement)) {
+                \App::$cache->set($cacheKey, $result);
                 if (\App::$log) {
                     \App::$log->info('Scope cache set', ['cache_key' => $cacheKey]);
                 }
@@ -168,8 +167,8 @@ class Scope extends Base
     {
         $cacheKey = "scopeReadByProviderId-$providerId-$resolveReferences";
 
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $result = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $result = \App::$cache->get($cacheKey);
         }
 
         if (empty($result)) {
@@ -179,8 +178,8 @@ class Scope extends Base
                 ->addConditionProviderId($providerId);
             $result = $this->fetchList($query, new Entity());
 
-            if (App::$cache) {
-                App::$cache->set($cacheKey, $result);
+            if (\App::$cache) {
+                \App::$cache->set($cacheKey, $result);
                 if (\App::$log) {
                     \App::$log->info('Scope cache set', ['cache_key' => $cacheKey]);
                 }
@@ -232,8 +231,8 @@ class Scope extends Base
     {
         $cacheKey = "scopeReadByDepartmentId-$departmentId-$resolveReferences";
 
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $result = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $result = \App::$cache->get($cacheKey);
         }
 
         $scopeList = new Collection();
@@ -246,8 +245,8 @@ class Scope extends Base
                     ->addConditionDepartmentId($departmentId);
                 $result = $this->fetchList($query, new Entity());
 
-                if (App::$cache) {
-                    App::$cache->set($cacheKey, $result);
+                if (\App::$cache) {
+                    \App::$cache->set($cacheKey, $result);
                     if (\App::$log) {
                         \App::$log->info('Scope cache set', ['cache_key' => $cacheKey]);
                     }
@@ -315,8 +314,8 @@ class Scope extends Base
     {
         $cacheKey = "scopeReadList-$resolveReferences";
 
-        if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
-            $result = App::$cache->get($cacheKey);
+        if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
+            $result = \App::$cache->get($cacheKey);
         }
 
         if (empty($result)) {
@@ -325,8 +324,8 @@ class Scope extends Base
                 ->addResolvedReferences($resolveReferences);
             $result = $this->fetchList($query, new Entity());
 
-            if (App::$cache) {
-                App::$cache->set($cacheKey, $result);
+            if (\App::$cache) {
+                \App::$cache->set($cacheKey, $result);
                 if (\App::$log) {
                     \App::$log->info('Scope cache set', ['cache_key' => $cacheKey]);
                 }
@@ -650,7 +649,7 @@ class Scope extends Base
 
     public function removeCacheByContext($scope, $departmentId = null)
     {
-        if (!App::$cache) {
+        if (!\App::$cache) {
             return;
         }
 
@@ -660,8 +659,8 @@ class Scope extends Base
         if (isset($scope->id)) {
             for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
                 $key = "scope-{$scope->id}-{$resolveReferences}";
-                if (App::$cache->has($key)) {
-                    App::$cache->delete($key);
+                if (\App::$cache->has($key)) {
+                    \App::$cache->delete($key);
                     $invalidatedKeys[] = $key;
                 }
             }
@@ -670,8 +669,8 @@ class Scope extends Base
         // Invalidate scope list cache for all resolveReferences levels (0, 1, 2)
         for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
             $key = "scopeReadList-{$resolveReferences}";
-            if (App::$cache->has($key)) {
-                App::$cache->delete($key);
+            if (\App::$cache->has($key)) {
+                \App::$cache->delete($key);
                 $invalidatedKeys[] = $key;
             }
         }
@@ -680,8 +679,8 @@ class Scope extends Base
         if ($departmentId) {
             for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
                 $key = "scopeReadByDepartmentId-{$departmentId}-{$resolveReferences}";
-                if (App::$cache->has($key)) {
-                    App::$cache->delete($key);
+                if (\App::$cache->has($key)) {
+                    \App::$cache->delete($key);
                     $invalidatedKeys[] = $key;
                 }
             }
@@ -693,8 +692,8 @@ class Scope extends Base
             foreach ($clusterIds as $clusterId) {
                 for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
                     $key = "scopeReadByClusterId-{$clusterId}-{$resolveReferences}";
-                    if (App::$cache->has($key)) {
-                        App::$cache->delete($key);
+                    if (\App::$cache->has($key)) {
+                        \App::$cache->delete($key);
                         $invalidatedKeys[] = $key;
                     }
                 }
@@ -706,8 +705,8 @@ class Scope extends Base
             $providerId = $scope->provider['id'];
             for ($resolveReferences = 0; $resolveReferences <= 2; $resolveReferences++) {
                 $key = "scopeReadByProviderId-{$providerId}-{$resolveReferences}";
-                if (App::$cache->has($key)) {
-                    App::$cache->delete($key);
+                if (\App::$cache->has($key)) {
+                    \App::$cache->delete($key);
                     $invalidatedKeys[] = $key;
                 }
             }

--- a/zmsdb/src/Zmsdb/Scope.php
+++ b/zmsdb/src/Zmsdb/Scope.php
@@ -845,8 +845,8 @@ class Scope extends Base
         }
 
         // Invalidate scopeReadByProviderId cache
-        if (isset($scope->provider) && isset($scope->provider['id'])) {
-            $providerId = $scope->getProviderId();
+        if (isset($scope->provider) && isset($scope->provider['id']) && $scope->provider['id']) {
+            $providerId = $scope->provider['id'];
             for ($i = 0; $i <= 2; $i++) {
                 $key = "scopeReadByProviderId-{$providerId}-{$i}";
                 if (App::$cache->has($key)) {

--- a/zmsdb/src/Zmsdb/Scope.php
+++ b/zmsdb/src/Zmsdb/Scope.php
@@ -567,7 +567,6 @@ class Scope extends Base
     {
         self::$cache = [];
 
-        // Get department ID before updating for cache invalidation
         $departmentId = $this->readDepartmentIdByScopeId($scopeId);
 
         $query = new Query\Scope(Query\Base::UPDATE);
@@ -593,8 +592,6 @@ class Scope extends Base
                     $preferenceQuery->replaceProperty($entityName, $entityId, $groupName, $name, $value);
                 }
             }
-
-            // Cache is already invalidated by the calling write/update method
         }
     }
 
@@ -733,7 +730,6 @@ class Scope extends Base
         }
         self::$cache = [];
 
-        // Get department ID before deleting for cache invalidation
         $departmentId = $this->readDepartmentIdByScopeId($scopeId);
 
         $entity = $this->readEntity($scopeId);
@@ -756,8 +752,6 @@ class Scope extends Base
                 $preferenceQuery->deleteProperty($entityName, $entityId, $groupName, $name);
             }
         }
-
-        // Cache is already invalidated by the calling delete method
     }
 
     /**
@@ -856,7 +850,6 @@ class Scope extends Base
             }
         }
 
-        // Log invalidated cache keys
         if (!empty($invalidatedKeys) && \App::$log) {
             \App::$log->info('Scope cache invalidated', [
                 'scope_id' => isset($scope->id) ? $scope->id : 'unknown',
@@ -865,9 +858,6 @@ class Scope extends Base
         }
     }
 
-    /**
-     * @deprecated Use removeCacheByContext instead
-     */
     public function removeCache($scope)
     {
         $departmentId = isset($scope->id) ? $this->readDepartmentIdByScopeId($scope->id) : null;

--- a/zmsdb/src/Zmsdb/Scope.php
+++ b/zmsdb/src/Zmsdb/Scope.php
@@ -762,8 +762,8 @@ class Scope extends Base
      */
     public function readDepartmentIdByScopeId($scopeId)
     {
-        $sql = 'SELECT BehoerdenID FROM standort WHERE StandortID = :scopeId';
-        return $this->getReader()->fetchValue($sql, ['scopeId' => $scopeId]);
+        $query = new Query\Scope(Query\Base::SELECT);
+        return $this->getReader()->fetchValue($query->getQueryDepartmentIdByScopeId(), [$scopeId]);
     }
 
     /**
@@ -774,8 +774,8 @@ class Scope extends Base
      */
     public function readClusterIdsByScopeId($scopeId)
     {
-        $sql = 'SELECT clusterID FROM clusterzuordnung WHERE standortID = :scopeId';
-        $result = $this->getReader()->fetchAll($sql, ['scopeId' => $scopeId]);
+        $query = new Query\Scope(Query\Base::SELECT);
+        $result = $this->getReader()->fetchAll($query->getQueryClusterIdsByScopeId(), [$scopeId]);
         return array_column($result, 'clusterID');
     }
 


### PR DESCRIPTION
- Add comprehensive cache invalidation for Scope entities including:
  - scopeReadByDepartmentId cache keys
  - scopeReadByClusterId cache keys
  - scopeReadList cache keys
  - scopeReadByProviderId cache keys
- Add scopeReadByClusterId cache invalidation to Cluster.removeCache()
- Add scopeReadByDepartmentId cache invalidation to Department.removeCache()
- Add Monolog info logging for cache set and invalidation operations
- Add helper methods readDepartmentIdByScopeId() and readClusterIdsByScopeId()

This ensures newly created or modified scopes appear immediately in the location and department lists without waiting for cache expiration.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded, context-aware cache invalidation to more reliably clear related cluster, department, provider, and scope entries, reducing stale data and improving consistency.

* **Chores**
  * Added informational logging when cache entries are set or cleared, reporting which keys were affected for better observability.

* **New Features**
  * Exposed new public APIs to support targeted, context-aware cache invalidation (deprecated wrapper retained).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->