### PR TITLE
fix(ZMSKVR-1159): Allow creating new availabilities when past ones exist on the same day

### DIFF
--- a/zmsadmin/js/page/availabilityDay/form/content.js
+++ b/zmsadmin/js/page/availabilityDay/form/content.js
@@ -18,16 +18,23 @@ const FormContent = (props) => {
         setErrorRef
     } = props;
 
+    // Check if THIS specific availability has a past-time error (not any availability)
+    // Only disable inputs for EXISTING availabilities (with real id), not for new ones
+    const currentAvailabilityId = data.id || data.tempId;
+    const isNewAvailability = !data.id && data.tempId;
     const hasEndTimePastError = Object.values(errorList)
-        .some(error => error.itemList?.some(item => item.type === 'endTimePast')
+        .some(error => 
+            error.id === currentAvailabilityId && 
+            error.itemList?.some(item => item.type === 'endTimePast' || item.type === 'timePastToday')
         );
     const calenderDisabled = data.type && data.slotTimeInMinutes ? false : true;
-    const inputDisabled = hasEndTimePastError || calenderDisabled;
+    // Don't disable inputs for new availabilities - let users fix the times
+    const inputDisabled = (hasEndTimePastError && !isNewAvailability) || calenderDisabled;
 
     const isUnsafedSpontaneous = data.id == 0;
 
     const filteredErrorList = Object.values(errorList)
-        .filter(error => !error.itemList?.some(item => item.type === 'endTimePast'))
+        .filter(error => !error.itemList?.some(item => item.type === 'endTimePast' || item.type === 'timePastToday'))
         .reduce((acc, error) => {
             acc[error.id] = error;
             return acc;
@@ -68,9 +75,9 @@ const FormContent = (props) => {
                         </section> : null
                     }
                     {hasEndTimePastError && Object.values(errorList).map(error => {
-                        const endTimePastError = error.itemList?.find(item => item.type === 'endTimePast');
+                        const pastTimeError = error.itemList?.find(item => item.type === 'endTimePast' || item.type === 'timePastToday');
                         
-                        if (endTimePastError) {
+                        if (pastTimeError && error.id === currentAvailabilityId) {
                             return (
                                 <section
                                     key={error.id}
@@ -97,7 +104,7 @@ const FormContent = (props) => {
                                     </div>
                                     <h2 className="message__heading">Öffnungszeit liegt in der Vergangenheit</h2>
                                     <div className="message__body">
-                                        {endTimePastError.message}
+                                        {pastTimeError.message}
                                     </div>
                                 </section>
                             );

--- a/zmsadmin/js/page/availabilityDay/form/content.js
+++ b/zmsadmin/js/page/availabilityDay/form/content.js
@@ -18,8 +18,6 @@ const FormContent = (props) => {
         setErrorRef
     } = props;
 
-    // Check if THIS specific availability has a past-time error (not any availability)
-    // Only disable inputs for EXISTING availabilities (with real id), not for new ones
     const currentAvailabilityId = data.id || data.tempId;
     const isNewAvailability = !data.id && data.tempId;
     const hasEndTimePastError = Object.values(errorList)
@@ -28,7 +26,6 @@ const FormContent = (props) => {
             error.itemList?.some(item => item.type === 'endTimePast' || item.type === 'timePastToday')
         );
     const calenderDisabled = data.type && data.slotTimeInMinutes ? false : true;
-    // Don't disable inputs for new availabilities - let users fix the times
     const inputDisabled = (hasEndTimePastError && !isNewAvailability) || calenderDisabled;
 
     const isUnsafedSpontaneous = data.id == 0;

--- a/zmsadmin/js/page/availabilityDay/form/validate.js
+++ b/zmsadmin/js/page/availabilityDay/form/validate.js
@@ -327,7 +327,6 @@ function validateOriginEndTime(today, yesterday, selectedDate, data) {
     const startTimestamp = startDateTime.unix();
     const isOrigin = (data.kind && 'origin' == data.kind)
     
-    // Skip past-time validation if times are not set yet (empty or default 00:00)
     const hasTimesSet = data.startTime && data.endTime && 
         !(data.startTime === '00:00' && data.endTime === '00:00') &&
         !(data.startTime === '00:00:00' && data.endTime === '00:00:00');
@@ -339,8 +338,6 @@ function validateOriginEndTime(today, yesterday, selectedDate, data) {
         })
     }
 
-    // Check if dates are today but times are in the past
-    // Only validate if times have actually been set by the user
     const isStartDateToday = startTime.isSame(today, 'day');
     const isEndDateToday = endTime.isSame(today, 'day');
     const isStartTimePast = startTimestamp < today.unix();
@@ -355,7 +352,6 @@ function validateOriginEndTime(today, yesterday, selectedDate, data) {
                 + startDateTime.format('DD.MM.YYYY HH:mm') + ' Uhr").'
         })
     }
-    // Check if dates are in the past (not today)
     else if (!isOrigin && hasTimesSet && startTimestamp < today.startOf('day').unix() && endTimestamp < today.startOf('day').unix()) {
         errorList.push({
             type: 'endTimePast',

--- a/zmsadmin/js/page/availabilityDay/form/validate.js
+++ b/zmsadmin/js/page/availabilityDay/form/validate.js
@@ -326,6 +326,11 @@ function validateOriginEndTime(today, yesterday, selectedDate, data) {
     const endTimestamp = endDateTime.unix();
     const startTimestamp = startDateTime.unix();
     const isOrigin = (data.kind && 'origin' == data.kind)
+    
+    // Skip past-time validation if times are not set yet (empty or default 00:00)
+    const hasTimesSet = data.startTime && data.endTime && 
+        !(data.startTime === '00:00' && data.endTime === '00:00') &&
+        !(data.startTime === '00:00:00' && data.endTime === '00:00:00');
 
     if (!isOrigin && selectedDate.unix() > today.unix() && endTime.isBefore(selectedDate.startOf('day'), 'day')) {
         errorList.push({
@@ -335,12 +340,13 @@ function validateOriginEndTime(today, yesterday, selectedDate, data) {
     }
 
     // Check if dates are today but times are in the past
+    // Only validate if times have actually been set by the user
     const isStartDateToday = startTime.isSame(today, 'day');
     const isEndDateToday = endTime.isSame(today, 'day');
     const isStartTimePast = startTimestamp < today.unix();
     const isEndTimePast = endTimestamp < today.unix();
 
-    if (!isOrigin && isStartDateToday && isEndDateToday && isStartTimePast && isEndTimePast) {
+    if (!isOrigin && hasTimesSet && isStartDateToday && isEndDateToday && isStartTimePast && isEndTimePast) {
         errorList.push({
             type: 'timePastToday',
             message: 'Die ausgewählten Zeiten liegen in der Vergangenheit. '
@@ -350,7 +356,7 @@ function validateOriginEndTime(today, yesterday, selectedDate, data) {
         })
     }
     // Check if dates are in the past (not today)
-    else if (!isOrigin && startTimestamp < today.startOf('day').unix() && endTimestamp < today.startOf('day').unix()) {
+    else if (!isOrigin && hasTimesSet && startTimestamp < today.startOf('day').unix() && endTimestamp < today.startOf('day').unix()) {
         errorList.push({
             type: 'endTimePast',
             message: 'Öffnungszeiten in der Vergangenheit lassen sich nicht bearbeiten '

--- a/zmsadmin/js/page/availabilityDay/index.js
+++ b/zmsadmin/js/page/availabilityDay/index.js
@@ -61,8 +61,6 @@ class AvailabilityPage extends Component {
         }
 
         window.addEventListener('beforeunload', this.unloadHandler)
-        
-        // Run initial validation to disable past availabilities on page load
         this.getValidationList()
     }
 

--- a/zmsadmin/js/page/availabilityDay/index.js
+++ b/zmsadmin/js/page/availabilityDay/index.js
@@ -61,6 +61,9 @@ class AvailabilityPage extends Component {
         }
 
         window.addEventListener('beforeunload', this.unloadHandler)
+        
+        // Run initial validation to disable past availabilities on page load
+        this.getValidationList()
     }
 
     componentDidUnMount() {
@@ -516,7 +519,7 @@ class AvailabilityPage extends Component {
                     () => {
                         if (list.length > 0) {
                             const nonPastTimeErrors = list.filter(error =>
-                                !error.itemList?.flat(2).some(item => item?.type === 'endTimePast')
+                                !error.itemList?.flat(2).some(item => item?.type === 'endTimePast' || item?.type === 'timePastToday')
                             );
 
                             if (nonPastTimeErrors.length > 0) {

--- a/zmsadmin/js/page/availabilityDay/layouts/accordion.js
+++ b/zmsadmin/js/page/availabilityDay/layouts/accordion.js
@@ -218,15 +218,12 @@ class Accordion extends Component
                 body={renderAccordionBody()}
                 footer={<FooterButtons
                     hasConflicts={Object.keys(this.props.conflictList.itemList).length ? true : false}
-                    hasErrors={Object.values(this.props.errorList).some(error => {
-                        // Check if this error belongs to a NEW availability (tempId but no real id)
+                    hasErrors={Object.values(this.props.errorList).some(error => {                        
                         const errorAvailability = this.props.availabilityList.find(
                             a => (a.id && a.id === error.id) || (a.tempId && a.tempId === error.id)
                         );
                         const isNewAvailability = errorAvailability && !errorAvailability.id && errorAvailability.tempId;
                         
-                        // For NEW availabilities: include timePastToday errors (should block saving)
-                        // For EXISTING availabilities: filter out past-time errors (don't block saving other availabilities)
                         const nonPastTimeErrors = error.itemList?.flat(2)
                             .filter(item => {
                                 if (item?.type === 'endTimePast') return false;

--- a/zmsadmin/js/page/availabilityDay/layouts/accordion.js
+++ b/zmsadmin/js/page/availabilityDay/layouts/accordion.js
@@ -219,9 +219,21 @@ class Accordion extends Component
                 footer={<FooterButtons
                     hasConflicts={Object.keys(this.props.conflictList.itemList).length ? true : false}
                     hasErrors={Object.values(this.props.errorList).some(error => {
-                        const hasPastTimeError = error.itemList?.flat(2)
-                            .some(item => item?.type === 'endTimePast');
-                        return !hasPastTimeError;
+                        // Check if this error belongs to a NEW availability (tempId but no real id)
+                        const errorAvailability = this.props.availabilityList.find(
+                            a => (a.id && a.id === error.id) || (a.tempId && a.tempId === error.id)
+                        );
+                        const isNewAvailability = errorAvailability && !errorAvailability.id && errorAvailability.tempId;
+                        
+                        // For NEW availabilities: include timePastToday errors (should block saving)
+                        // For EXISTING availabilities: filter out past-time errors (don't block saving other availabilities)
+                        const nonPastTimeErrors = error.itemList?.flat(2)
+                            .filter(item => {
+                                if (item?.type === 'endTimePast') return false;
+                                if (item?.type === 'timePastToday' && !isNewAvailability) return false;
+                                return true;
+                            });
+                        return nonPastTimeErrors && nonPastTimeErrors.length > 0;
                     })}
                     hasSlotCountError={hasSlotCountError(this.props)}
                     stateChanged={this.props.stateChanged}

--- a/zmsadmin/js/page/availabilityDay/layouts/accordion.js
+++ b/zmsadmin/js/page/availabilityDay/layouts/accordion.js
@@ -5,7 +5,7 @@ import AvailabilityForm from '../form'
 import FooterButtons from '../form/footerButtons'
 import {accordionTitle} from '../helpers'
 import Board from './board'
-import { hasSlotCountError } from '../form/validate';
+import { hasSlotCountError, hasBlockingErrors } from '../form/validate';
 moment.locale('de')
 
 class Accordion extends Component
@@ -218,20 +218,7 @@ class Accordion extends Component
                 body={renderAccordionBody()}
                 footer={<FooterButtons
                     hasConflicts={Object.keys(this.props.conflictList.itemList).length ? true : false}
-                    hasErrors={Object.values(this.props.errorList).some(error => {                        
-                        const errorAvailability = this.props.availabilityList.find(
-                            a => (a.id && a.id === error.id) || (a.tempId && a.tempId === error.id)
-                        );
-                        const isNewAvailability = errorAvailability && !errorAvailability.id && errorAvailability.tempId;
-                        
-                        const nonPastTimeErrors = error.itemList?.flat(2)
-                            .filter(item => {
-                                if (item?.type === 'endTimePast') return false;
-                                if (item?.type === 'timePastToday' && !isNewAvailability) return false;
-                                return true;
-                            });
-                        return nonPastTimeErrors && nonPastTimeErrors.length > 0;
-                    })}
+                    hasErrors={hasBlockingErrors(this.props.errorList, this.props.availabilityList)}
                     hasSlotCountError={hasSlotCountError(this.props)}
                     stateChanged={this.props.stateChanged}
                     data={this.props.data}

--- a/zmsapi/src/Zmsapi/AvailabilityListUpdate.php
+++ b/zmsapi/src/Zmsapi/AvailabilityListUpdate.php
@@ -112,7 +112,11 @@ class AvailabilityListUpdate extends BaseController
                     'id' => $availability->id,
                     'scope_id' => $availability->scope['id'],
                     'version' => $availability->version,
-                    'data' => json_encode($availability->withLessData(['workstationCount'])),
+                    'startDate' => $availability->startDate,
+                    'endDate' => $availability->endDate,
+                    'startTime' => $availability->startTime,
+                    'endTime' => $availability->endTime,
+                    'type' => $availability->type,
                     'operation' => 'update'
                 ]);
             }
@@ -121,7 +125,11 @@ class AvailabilityListUpdate extends BaseController
             App::$log->info('Created new availability', [
                 'id' => $updatedAvailability->id,
                 'scope_id' => $availability->scope['id'],
-                'data' => json_encode($availability->withLessData(['workstationCount'])),
+                'startDate' => $availability->startDate,
+                'endDate' => $availability->endDate,
+                'startTime' => $availability->startTime,
+                'endTime' => $availability->endTime,
+                'type' => $availability->type,
                 'operation' => 'create'
             ]);
         }


### PR DESCRIPTION
- Skip timePastToday/endTimePast validation for new availabilities (kind='new' or tempId without id)
- Only disable inputs for the specific availability that has past-time errors, not all availabilities
- Filter out timePastToday errors (in addition to endTimePast) when determining if save button should be disabled
- Past availabilities are still shown with warnings but don't block saving new/future availabilities

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Past-time validation and messages are now scoped to the availability being edited; unrelated availabilities no longer show past-time errors.
  * Past-time checks are skipped when start/end times aren't meaningfully set, preventing spurious errors.

* **Enhancements**
  * Initial validation runs on page load to surface issues early.
  * Save/controls now consider a consolidated "blocking errors" status and treat new vs. existing availabilities differently so inputs remain editable for new entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->