### PR TITLE
fix(ZMSKVR-1208): validate disabledByServices for jump-in links

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -921,7 +921,7 @@ function getAvailableProviders(
       Number
     );
     const allDisabled = selectedServices.every((s) =>
-      restrictedDisabled.includes(s.id)
+      restrictedDisabled.includes(Number(s.id))
     );
 
     return allDisabled ? (clean as OfficeImpl) : (restricted as OfficeImpl);

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -613,6 +613,20 @@ onMounted(() => {
         );
         if (!hasValidRelation) {
           emit("invalidJumpinLink");
+          return;
+        }
+
+        // Check if the service is disabled for this office via disabledByServices
+        const foundOffice = offices.value.find(
+          (office) => office.id == props.preselectedOfficeId
+        );
+        if (foundOffice) {
+          const disabledServices = (foundOffice.disabledByServices ?? []).map(
+            Number
+          );
+          if (disabledServices.includes(Number(props.preselectedServiceId))) {
+            emit("invalidJumpinLink");
+          }
         }
       }
     });


### PR DESCRIPTION
- Add check for disabledByServices when validating preselected service+office combinations
- Emit invalidJumpinLink when service is in office's disabledByServices array
-  Fix string to number typing mismatch for service id

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed appointment provider selection to correctly handle ID comparisons.
  * Improved service validation for pre-selected appointments to detect unavailable service-office combinations and display appropriate error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->