### PR TITLE
hotfix(ZMSKVR-1225): set new noreply-address in email and preferences tables

### DIFF
--- a/zmsdb/migrations/91769610028-set-sender-to-noreply.sql
+++ b/zmsdb/migrations/91769610028-set-sender-to-noreply.sql
@@ -1,0 +1,6 @@
+UPDATE `email`
+SET `absenderadresse` = 'noreply-terminvereinbarung@muenchen.de';
+
+UPDATE `preferences`
+SET `value` = 'noreply-terminvereinbarung@muenchen.de';
+WHERE `name` = 'emailFrom';

--- a/zmsdb/migrations/91769610028-set-sender-to-noreply.sql
+++ b/zmsdb/migrations/91769610028-set-sender-to-noreply.sql
@@ -2,5 +2,5 @@ UPDATE `email`
 SET `absenderadresse` = 'noreply-terminvereinbarung@muenchen.de';
 
 UPDATE `preferences`
-SET `value` = 'noreply-terminvereinbarung@muenchen.de';
+SET `value` = 'noreply-terminvereinbarung@muenchen.de'
 WHERE `name` = 'emailFrom';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default sender email address for outgoing notifications to noreply-terminvereinbarung@muenchen.de.
  * Synchronized the stored sender preference to use the new noreply address so configured messages and preferences now match.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->