### PR TITLE
fix(ZMSKVR-1083): Enforce maxSlotsPerAppointment and maxQuantity limits in booking flow

### DIFF
--- a/zmsapi/src/Zmsapi/Exception/Process/MoreThanAllowedQuantityPerService.php
+++ b/zmsapi/src/Zmsapi/Exception/Process/MoreThanAllowedQuantityPerService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BO\Zmsapi\Exception\Process;
+
+class MoreThanAllowedQuantityPerService extends \Exception
+{
+    protected $code = 400;
+
+    protected $message = 'The quantity of a service exceeds the maximum allowed quantity';
+}

--- a/zmsapi/src/Zmsapi/Exception/Process/MoreThanAllowedSlotsPerAppointment.php
+++ b/zmsapi/src/Zmsapi/Exception/Process/MoreThanAllowedSlotsPerAppointment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BO\Zmsapi\Exception\Process;
+
+class MoreThanAllowedSlotsPerAppointment extends \Exception
+{
+    protected $code = 400;
+
+    protected $message = 'The number of slots exceeds the maximum allowed slots per appointment';
+}

--- a/zmsapi/src/Zmsapi/ProcessConfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirm.php
@@ -112,5 +112,9 @@ class ProcessConfirm extends BaseController
         if (! (new Process())->isAppointmentSlotCountAllowed($entity)) {
             throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
         }
+
+        if (! (new Process())->isServiceQuantityAllowed($entity)) {
+            throw new Exception\Process\MoreThanAllowedQuantityPerService();
+        }
     }
 }

--- a/zmsapi/src/Zmsapi/ProcessConfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirm.php
@@ -37,7 +37,7 @@ class ProcessConfirm extends BaseController
 
         $userAccount = (new Helper\User($request))->readWorkstation()->getUseraccount();
         $process = (new Process())->readEntity($entity->id, $entity->authKey, 2);
-        
+
         // Validate limits against persisted process (not client payload) to prevent bypass
         $this->validateProcessLimits($process);
         if ('preconfirmed' != $process->status && 'reserved' != $process->status) {

--- a/zmsapi/src/Zmsapi/ProcessConfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirm.php
@@ -108,5 +108,9 @@ class ProcessConfirm extends BaseController
         } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
+
+        if (! (new Process())->isAppointmentSlotCountAllowed($entity)) {
+            throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
+        }
     }
 }

--- a/zmsapi/src/Zmsapi/ProcessConfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirm.php
@@ -38,7 +38,6 @@ class ProcessConfirm extends BaseController
         $userAccount = (new Helper\User($request))->readWorkstation()->getUseraccount();
         $process = (new Process())->readEntity($entity->id, $entity->authKey, 2);
 
-        // Validate limits against persisted process (not client payload) to prevent bypass
         $this->validateProcessLimits($process);
         if ('preconfirmed' != $process->status && 'reserved' != $process->status) {
             throw new Exception\Process\ProcessNotPreconfirmedAnymore();
@@ -113,10 +112,6 @@ class ProcessConfirm extends BaseController
         }
     }
 
-    /**
-     * Validate limits against persisted process from DB (not client payload)
-     * to prevent bypass by omitting scope/requests from request.
-     */
     protected function validateProcessLimits(\BO\Zmsentities\Process $process)
     {
         if (! (new Process())->isAppointmentSlotCountAllowed($process)) {

--- a/zmsapi/src/Zmsapi/ProcessPreconfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirm.php
@@ -36,7 +36,6 @@ class ProcessPreconfirm extends BaseController
         $userAccount = (new Helper\User($request))->readWorkstation()->getUseraccount();
         $process = (new Process())->readEntity($entity->id, $entity->authKey, 2);
 
-        // Validate limits against persisted process (not client payload) to prevent bypass
         $this->validateProcessLimits($process);
         if ('reserved' != $process->status) {
             throw new Exception\Process\ProcessNotReservedAnymore();
@@ -72,10 +71,6 @@ class ProcessPreconfirm extends BaseController
         }
     }
 
-    /**
-     * Validate limits against persisted process from DB (not client payload)
-     * to prevent bypass by omitting scope/requests from request.
-     */
     protected function validateProcessLimits(\BO\Zmsentities\Process $process)
     {
         if (! (new Process())->isAppointmentSlotCountAllowed($process)) {

--- a/zmsapi/src/Zmsapi/ProcessPreconfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirm.php
@@ -66,6 +66,10 @@ class ProcessPreconfirm extends BaseController
             throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
         }
 
+        if (! (new Process())->isServiceQuantityAllowed($entity)) {
+            throw new Exception\Process\MoreThanAllowedQuantityPerService();
+        }
+
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
         } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {

--- a/zmsapi/src/Zmsapi/ProcessPreconfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirm.php
@@ -62,6 +62,10 @@ class ProcessPreconfirm extends BaseController
             throw new Exception\Process\MoreThanAllowedAppointmentsPerMail();
         }
 
+        if (! (new Process())->isAppointmentSlotCountAllowed($entity)) {
+            throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
+        }
+
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
         } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {

--- a/zmsapi/src/Zmsapi/ProcessPreconfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirm.php
@@ -35,7 +35,7 @@ class ProcessPreconfirm extends BaseController
 
         $userAccount = (new Helper\User($request))->readWorkstation()->getUseraccount();
         $process = (new Process())->readEntity($entity->id, $entity->authKey, 2);
-        
+
         // Validate limits against persisted process (not client payload) to prevent bypass
         $this->validateProcessLimits($process);
         if ('reserved' != $process->status) {

--- a/zmsapi/src/Zmsapi/ProcessUpdate.php
+++ b/zmsapi/src/Zmsapi/ProcessUpdate.php
@@ -113,9 +113,8 @@ class ProcessUpdate extends BaseController
             throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
         }
 
-        if (! (new Process())->isServiceQuantityAllowed($entity)) {
-            throw new Exception\Process\MoreThanAllowedQuantityPerService();
-        }
+        // Note: isServiceQuantityAllowed is only checked in ProcessPreconfirm/ProcessConfirm
+        // to reduce DB queries on this frequently-called endpoint
 
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();

--- a/zmsapi/src/Zmsapi/ProcessUpdate.php
+++ b/zmsapi/src/Zmsapi/ProcessUpdate.php
@@ -109,6 +109,10 @@ class ProcessUpdate extends BaseController
             throw new Exception\Process\MoreThanAllowedAppointmentsPerMail();
         }
 
+        if (! (new Process())->isAppointmentSlotCountAllowed($entity)) {
+            throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
+        }
+
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
         } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {

--- a/zmsapi/src/Zmsapi/ProcessUpdate.php
+++ b/zmsapi/src/Zmsapi/ProcessUpdate.php
@@ -113,6 +113,10 @@ class ProcessUpdate extends BaseController
             throw new Exception\Process\MoreThanAllowedSlotsPerAppointment();
         }
 
+        if (! (new Process())->isServiceQuantityAllowed($entity)) {
+            throw new Exception\Process\MoreThanAllowedQuantityPerService();
+        }
+
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
         } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {

--- a/zmsapiautomation/src/test/java/dto/zmscitizenapi/Office.java
+++ b/zmsapiautomation/src/test/java/dto/zmscitizenapi/Office.java
@@ -49,8 +49,8 @@ public class Office {
     @JsonProperty("disabledByServices")
     private List<Integer> disabledByServices;
 
-    @JsonProperty("maxSlotsPerAppointment")
-    private String maxSlotsPerAppointment;
+    @JsonProperty("slotsPerAppointment")
+    private String slotsPerAppointment;
 
     public Integer getId() {
         return id;
@@ -156,12 +156,12 @@ public class Office {
         this.disabledByServices = disabledByServices;
     }
 
-    public String getMaxSlotsPerAppointment() {
-        return maxSlotsPerAppointment;
+    public String getSlotsPerAppointment() {
+        return slotsPerAppointment;
     }
 
-    public void setMaxSlotsPerAppointment(String maxSlotsPerAppointment) {
-        this.maxSlotsPerAppointment = maxSlotsPerAppointment;
+    public void setSlotsPerAppointment(String slotsPerAppointment) {
+        this.slotsPerAppointment = slotsPerAppointment;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
@@ -24,7 +24,7 @@ class Office extends Entity implements JsonSerializable
     public ?array $disabledByServices = [];
     public int $priority = 1;
     public ?ThinnedScope $scope = null;
-    public ?string $maxSlotsPerAppointment = null;
+    public ?string $slotsPerAppointment = null;
     public ?int $parentId = null;
 
     public function __construct(
@@ -40,7 +40,7 @@ class Office extends Entity implements JsonSerializable
         ?array $disabledByServices = [],
         int $priority = 1,
         ?ThinnedScope $scope = null,
-        ?string $maxSlotsPerAppointment = null,
+        ?string $slotsPerAppointment = null,
         ?int $parentId = null
     ) {
         $this->id = $id;
@@ -55,7 +55,7 @@ class Office extends Entity implements JsonSerializable
         $this->scope = $scope;
         $this->priority = $priority;
         $this->disabledByServices = $disabledByServices;
-        $this->maxSlotsPerAppointment = $maxSlotsPerAppointment;
+        $this->slotsPerAppointment = $slotsPerAppointment;
         $this->parentId = $parentId;
         $this->ensureValid();
     }
@@ -87,7 +87,7 @@ class Office extends Entity implements JsonSerializable
             'disabledByServices' => $this->disabledByServices,
             'priority' => $this->priority,
             'scope' => $this->scope?->toArray(),
-            'maxSlotsPerAppointment' => $this->maxSlotsPerAppointment,
+            'slotsPerAppointment' => $this->slotsPerAppointment,
             'parentId' => $this->parentId
         ];
     }

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -107,6 +107,10 @@ class ExceptionService
                 $error = self::getError('tooManySlotsPerAppointment');
 
                 break;
+            case 'BO\\Zmsapi\\Exception\\Process\\MoreThanAllowedQuantityPerService':
+                $error = self::getError('tooManyServicesPerAppointment');
+
+                break;
             case 'BO\\Zmsapi\\Exception\\Process\\PreconfirmationExpired':
                 $error = self::getError('preconfirmationExpired');
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -103,6 +103,10 @@ class ExceptionService
                 $error = self::getError('tooManyAppointmentsWithSameMail');
 
                 break;
+            case 'BO\\Zmsapi\\Exception\\Process\\MoreThanAllowedSlotsPerAppointment':
+                $error = self::getError('tooManySlotsPerAppointment');
+
+                break;
             case 'BO\\Zmsapi\\Exception\\Process\\PreconfirmationExpired':
                 $error = self::getError('preconfirmationExpired');
 

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -172,7 +172,7 @@ class MapperService
                     activationDuration: self::extractActivationDuration($providerScope),
                     hint: isset($providerScope->hint) ? (trim((string) $providerScope->hint) === '' ? null : (string) $providerScope->hint) : null
                 ) : null,
-                maxSlotsPerAppointment: isset($providerScope) && !isset($providerScope['errors']) && isset($providerScope->slotsPerAppointment) ? ((string) $providerScope->slotsPerAppointment === '' ? null : (string) $providerScope->slotsPerAppointment) : null,
+                slotsPerAppointment: isset($providerScope) && !isset($providerScope['errors']) && isset($providerScope->slotsPerAppointment) ? ((string) $providerScope->slotsPerAppointment === '' ? null : (string) $providerScope->slotsPerAppointment) : null,
                 parentId: isset($provider->parent_id) ? (int) $provider->parent_id : null
             );
         }

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -166,6 +166,7 @@ class MapperService
                         ? ((string) $providerScope->infoForAllAppointments === '' ? null : (string) $providerScope->infoForAllAppointments)
                         : null,
                     appointmentsPerMail: isset($providerScope->appointmentsPerMail) ? ((string) $providerScope->appointmentsPerMail === '' ? null : (string) $providerScope->appointmentsPerMail) : null,
+                    slotsPerAppointment: isset($providerScope->slotsPerAppointment) ? ((string) $providerScope->slotsPerAppointment === '' ? null : (string) $providerScope->slotsPerAppointment) : null,
                     whitelistedMails: isset($providerScope->whitelistedMails) ? ((string) $providerScope->whitelistedMails === '' ? null : (string) $providerScope->whitelistedMails) : null,
                     reservationDuration: (int) self::extractReservationDuration($providerScope),
                     activationDuration: self::extractActivationDuration($providerScope),
@@ -479,6 +480,7 @@ class MapperService
             $scope->preferences = [
                 'client' => [
                     'appointmentsPerMail' => $thinnedProcess->scope->getAppointmentsPerMail() ?? null,
+                    'slotsPerAppointment' => $thinnedProcess->scope->getSlotsPerAppointment() ?? null,
                     "whitelistedMails" => $thinnedProcess->scope->getWhitelistedMails() ?? null,
                     'emailFrom' => $thinnedProcess->scope->getEmailFrom() ?? null,
                     'emailRequired' => $thinnedProcess->scope->getEmailRequired() ?? false,

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -126,7 +126,7 @@ class ZmsApiFacadeService
                     reservationDuration: (int) MapperService::extractReservationDuration($matchingScope),
                     hint: ($matchingScope && trim((string) $matchingScope->getScopeHint()) !== '')  ? (string) $matchingScope->getScopeHint() : null
                 ) : null,
-                maxSlotsPerAppointment: $matchingScope ? ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment()) : null
+                slotsPerAppointment: $matchingScope ? ((string) $matchingScope->getSlotsPerAppointment() === '' ? null : (string) $matchingScope->getSlotsPerAppointment()) : null
             );
         }
 
@@ -409,7 +409,7 @@ class ZmsApiFacadeService
                     address: $provider->address ?? null,
                     geo: $provider->geo ?? null,
                     scope: $scope,
-                    maxSlotsPerAppointment: $scope ? ((string) $scope->getSlotsPerAppointment() === '' ? null : (string) $scope->getSlotsPerAppointment()) : null
+                    slotsPerAppointment: $scope ? ((string) $scope->getSlotsPerAppointment() === '' ? null : (string) $scope->getSlotsPerAppointment()) : null
                 );
             }
         }

--- a/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
@@ -348,6 +348,12 @@ class ErrorMessages
             'statusCode' => self::HTTP_NOT_ACCEPTABLE,
             'errorType' => 'error'
         ],
+        'tooManySlotsPerAppointment' => [
+            'errorCode' => 'tooManySlotsPerAppointment',
+            'errorMessage' => 'The number of slots exceeds the maximum allowed slots per appointment.',
+            'statusCode' => self::HTTP_BAD_REQUEST,
+            'errorType' => 'error'
+        ],
         'scopesNotFound' => [
             'errorCode' => 'scopesNotFound',
             'errorMessage' => 'No scopes found.',

--- a/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
@@ -354,6 +354,12 @@ class ErrorMessages
             'statusCode' => self::HTTP_BAD_REQUEST,
             'errorType' => 'error'
         ],
+        'tooManyServicesPerAppointment' => [
+            'errorCode' => 'tooManyServicesPerAppointment',
+            'errorMessage' => 'The quantity of a service exceeds the maximum allowed quantity.',
+            'statusCode' => self::HTTP_BAD_REQUEST,
+            'errorType' => 'error'
+        ],
         'scopesNotFound' => [
             'errorCode' => 'scopesNotFound',
             'errorMessage' => 'No scopes found.',

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficeListByServiceControllerTest.php
@@ -90,7 +90,7 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ]
             ]
@@ -168,7 +168,7 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ],
                 [
@@ -223,7 +223,7 @@ class OfficeListByServiceControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ]
             ]

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesListControllerTest.php
@@ -92,7 +92,7 @@ class OfficesListControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ],
                 [
@@ -150,7 +150,7 @@ class OfficesListControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ]
             ]

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Office/OfficesServicesRelationsControllerTest.php
@@ -92,7 +92,7 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ],
                 [
@@ -150,7 +150,7 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ]
             ],
@@ -267,7 +267,7 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ],
                 [
@@ -325,7 +325,7 @@ class OfficesServicesRelationsControllerTest extends ControllerTestCase
                         "activationDuration" => null,
                         "hint" => null
                     ],
-                    "maxSlotsPerAppointment" => null,
+                    "slotsPerAppointment" => null,
                     "parentId" => null
                 ]
             ],

--- a/zmscitizenview/src/api/models/Office.ts
+++ b/zmscitizenview/src/api/models/Office.ts
@@ -72,7 +72,7 @@ export interface Office {
    * @type {string}
    * @memberof Office
    */
-  maxSlotsPerAppointment?: string;
+  slotsPerAppointment?: string;
   /**
    *
    * @type {number}

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -998,7 +998,7 @@ const getProviders = (serviceId: string, providers: string[] | null) => {
           office.slotTimeInMinutes,
           office.disabledByServices,
           office.scope,
-          office.maxSlotsPerAppointment,
+          office.slotsPerAppointment,
           office.slots,
           office.priority || 1
         );
@@ -1209,7 +1209,7 @@ onMounted(() => {
                 foundOffice.slotTimeInMinutes,
                 undefined, // disabledByServices
                 foundOffice.scope,
-                foundOffice.maxSlotsPerAppointment,
+                foundOffice.slotsPerAppointment,
                 undefined, // slots
                 foundOffice.priority || 1
               );

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -754,19 +754,6 @@ onMounted(() => {
           ? Math.min(minSlotsOfProvider, MAX_SLOTS)
           : MAX_SLOTS;
       minSlotsPerAppointment.value = nextMaxSlotsPerAppointment;
-
-      console.log("[ServiceFinder] onMounted - minSlotsPerAppointment", {
-        selectedServiceId: service.value.id,
-        providerMinSlots: minSlotsOfProvider,
-        effectiveMinSlotsPerAppointment: nextMaxSlotsPerAppointment,
-        usingFallbackMAX_SLOTS: minSlotsOfProvider <= 0,
-        MAX_SLOTS,
-        providersCount: service.value.providers.length,
-        providers: service.value.providers.map((p) => ({
-          id: p.id,
-          slotsPerAppointment: p.slotsPerAppointment,
-        })),
-      });
     }
     if (services.value.length === 0) {
       fetchServicesAndProviders(

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -315,9 +315,11 @@ watch(service, (newService) => {
 
 /**
  * Calculation of the currently required slots by changing the count of the selected service.
+ * Uses a flag to prevent double-execution when clamping the value.
  */
+let isAdjustingCount = false;
 watch(countOfService, (newCountOfService) => {
-  if (!service.value) return;
+  if (!service.value || isAdjustingCount) return;
 
   const subServiceSlots = calculateSubserviceSlots(service.value.subServices);
   const { adjustedCount, totalSlots } = adjustMainServiceCount(
@@ -328,7 +330,9 @@ watch(countOfService, (newCountOfService) => {
   );
 
   if (adjustedCount !== newCountOfService) {
+    isAdjustingCount = true;
     countOfService.value = adjustedCount;
+    isAdjustingCount = false;
   }
   service.value.count = adjustedCount;
   currentSlots.value = totalSlots;

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -323,22 +323,6 @@ watch(
           ? Math.min(minSlotsOfProvider, MAX_SLOTS)
           : MAX_SLOTS;
       minSlotsPerAppointment.value = nextMaxSlotsPerAppointment;
-
-      console.debug(
-        "[ServiceFinder] watch([offices, relations]) - minSlotsPerAppointment",
-        {
-          selectedServiceId: service.value.id,
-          providerMinSlots: minSlotsOfProvider,
-          effectiveMinSlotsPerAppointment: nextMaxSlotsPerAppointment,
-          usingFallbackMAX_SLOTS: minSlotsOfProvider <= 0,
-          MAX_SLOTS,
-          providersCount: service.value.providers?.length || 0,
-          providers: (service.value.providers || []).map((p) => ({
-            id: p.id,
-            slotsPerAppointment: p.slotsPerAppointment,
-          })),
-        }
-      );
     }
   },
   { immediate: false }
@@ -400,19 +384,6 @@ const setServiceData = (selectedService: ServiceImpl) => {
       ? Math.min(minSlotsOfProvider, MAX_SLOTS)
       : MAX_SLOTS;
   minSlotsPerAppointment.value = nextMaxSlotsPerAppointment;
-
-  console.debug("[ServiceFinder] setServiceData - minSlotsPerAppointment", {
-    selectedServiceId: selectedService.id,
-    providerMinSlots: minSlotsOfProvider,
-    effectiveMinSlotsPerAppointment: nextMaxSlotsPerAppointment,
-    usingFallbackMAX_SLOTS: minSlotsOfProvider <= 0,
-    MAX_SLOTS,
-    providersCount: service.value!.providers.length,
-    providers: service.value!.providers.map((p) => ({
-      id: p.id,
-      slotsPerAppointment: p.slotsPerAppointment,
-    })),
-  });
 
   if (selectedService.combinable) {
     const combinable = selectedService.combinable;
@@ -825,22 +796,6 @@ onMounted(() => {
               ? Math.min(minSlotsOfProvider, MAX_SLOTS)
               : MAX_SLOTS;
           minSlotsPerAppointment.value = nextMaxSlotsPerAppointment;
-
-          console.debug(
-            "[ServiceFinder] fetchServicesAndProviders (back navigation) - minSlotsPerAppointment",
-            {
-              selectedServiceId: service.value.id,
-              providerMinSlots: minSlotsOfProvider,
-              effectiveMinSlotsPerAppointment: nextMaxSlotsPerAppointment,
-              usingFallbackMAX_SLOTS: minSlotsOfProvider <= 0,
-              MAX_SLOTS,
-              providersCount: service.value.providers?.length || 0,
-              providers: (service.value.providers || []).map((p) => ({
-                id: p.id,
-                slotsPerAppointment: p.slotsPerAppointment,
-              })),
-            }
-          );
         }
       });
     }

--- a/zmscitizenview/src/components/Appointment/ServiceFinder.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder.vue
@@ -304,30 +304,6 @@ watch(service, (newService) => {
   countOfService.value = newService.count ?? 1;
 });
 
-// Watch for when offices/relations are loaded to recalculate minSlotsPerAppointment
-watch(
-  [offices, relations],
-  () => {
-    if (
-      service.value &&
-      offices.value.length > 0 &&
-      relations.value.length > 0
-    ) {
-      // Recalculate providers and minSlotsPerAppointment
-      service.value.providers = getProviders(service.value.id, null);
-      const minSlotsOfProvider = getMinSlotsPerAppointmentOfProvider(
-        service.value.providers || []
-      );
-      const nextMaxSlotsPerAppointment =
-        minSlotsOfProvider > 0
-          ? Math.min(minSlotsOfProvider, MAX_SLOTS)
-          : MAX_SLOTS;
-      minSlotsPerAppointment.value = nextMaxSlotsPerAppointment;
-    }
-  },
-  { immediate: false }
-);
-
 /**
  * Calculation of the currently required slots by changing the count of the selected service.
  */

--- a/zmscitizenview/src/components/Appointment/ServiceFinder/SubserviceListItem.vue
+++ b/zmscitizenview/src/components/Appointment/ServiceFinder/SubserviceListItem.vue
@@ -23,7 +23,7 @@ import { getServiceBaseURL, MAX_SLOTS } from "@/utils/Constants";
 const props = defineProps<{
   subService: SubService;
   currentSlots: number;
-  maxSlotsPerAppointment: number;
+  minSlotsPerAppointment: number;
 }>();
 
 const emit = defineEmits<(e: "change", id: string, count: number) => void>();
@@ -37,7 +37,7 @@ watch(count, (newCount) => {
 /**
  * Calculates the maximum count for this subservice, considering both:
  * - maxQuantity: the subservice's own limit
- * - maxSlotsPerAppointment: remaining slots after accounting for main service and other subservices
+ * - minSlotsPerAppointment: remaining slots after accounting for main service and other subservices
  */
 const maxValue = computed(() => {
   const subServiceSlots = getMaxSlotOfProvider(props.subService.providers);
@@ -46,9 +46,9 @@ const maxValue = computed(() => {
   // Calculate slots currently used by this subservice
   const thisSlotsUsed = subServiceSlots * count.value;
 
-  // Available slots = maxSlotsPerAppointment - (currentSlots - this subservice's contribution)
+  // Available slots = minSlotsPerAppointment - (currentSlots - this subservice's contribution)
   const slotsUsedByOthers = props.currentSlots - thisSlotsUsed;
-  const availableSlots = props.maxSlotsPerAppointment - slotsUsedByOthers;
+  const availableSlots = props.minSlotsPerAppointment - slotsUsedByOthers;
 
   // Calculate max count based on available slots
   const maxCountBySlots = Math.floor(availableSlots / subServiceSlots);

--- a/zmscitizenview/src/types/OfficeImpl.ts
+++ b/zmscitizenview/src/types/OfficeImpl.ts
@@ -23,7 +23,7 @@ export class OfficeImpl implements Office {
 
   scope?: Scope;
 
-  maxSlotsPerAppointment?: string;
+  slotsPerAppointment?: string;
 
   slots?: number;
 
@@ -40,7 +40,7 @@ export class OfficeImpl implements Office {
     slotTimeInMinutes: number,
     disabledByServices: string[] | undefined,
     scope: Scope | undefined,
-    maxSlotsPerAppointment: string | undefined,
+    slotsPerAppointment: string | undefined,
     slots: number | undefined,
     priority: number = 1
   ) {
@@ -54,7 +54,7 @@ export class OfficeImpl implements Office {
     this.slotTimeInMinutes = slotTimeInMinutes;
     this.disabledByServices = disabledByServices;
     this.scope = scope;
-    this.maxSlotsPerAppointment = maxSlotsPerAppointment;
+    this.slotsPerAppointment = slotsPerAppointment;
     this.slots = slots;
     this.priority = priority;
   }

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -139,6 +139,8 @@
   "apiErrorTelephoneIsRequiredText": "Bitte geben Sie Ihre Telefonnummer an.",
   "apiErrorTooManyAppointmentsWithSameMailHeader": "Sie haben bereits zu viele Termine gebucht.",
   "apiErrorTooManyAppointmentsWithSameMailText": "Sie können mit Ihrer E-Mail-Adresse nur eine begrenzte Anzahl an Terminen vereinbaren. Bitte sagen Sie einen anderen Termin ab, bevor Sie einen neuen Termin buchen.",
+  "apiErrorTooManyServicesPerAppointmentHeader": "Zu viele gleiche Leistungen ausgewählt.",
+  "apiErrorTooManyServicesPerAppointmentText": "Sie haben mehr von einer Leistung ausgewählt als erlaubt. Bitte reduzieren Sie die Anzahl und versuchen Sie es erneut.",
   "apiErrorTooManySlotsPerAppointmentHeader": "Zu viele Leistungen ausgewählt.",
   "apiErrorTooManySlotsPerAppointmentText": "Sie können pro Termin nur eine begrenzte Anzahl an Leistungen buchen. Bitte reduzieren Sie Ihre Auswahl und versuchen Sie es erneut.",
   "apiErrorUnknownErrorHeader": "Ein unbekannter Fehler ist aufgetreten.",

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -139,6 +139,8 @@
   "apiErrorTelephoneIsRequiredText": "Bitte geben Sie Ihre Telefonnummer an.",
   "apiErrorTooManyAppointmentsWithSameMailHeader": "Sie haben bereits zu viele Termine gebucht.",
   "apiErrorTooManyAppointmentsWithSameMailText": "Sie können mit Ihrer E-Mail-Adresse nur eine begrenzte Anzahl an Terminen vereinbaren. Bitte sagen Sie einen anderen Termin ab, bevor Sie einen neuen Termin buchen.",
+  "apiErrorTooManySlotsPerAppointmentHeader": "Zu viele Leistungen ausgewählt.",
+  "apiErrorTooManySlotsPerAppointmentText": "Sie können pro Termin nur eine begrenzte Anzahl an Leistungen buchen. Bitte reduzieren Sie Ihre Auswahl und versuchen Sie es erneut.",
   "apiErrorUnknownErrorHeader": "Ein unbekannter Fehler ist aufgetreten.",
   "apiErrorUnknownErrorText": "Bitte versuchen Sie es später erneut.",
   "apiErrorZmsClientCommunicationErrorHeader": "Der Service ist vorübergehend nicht verfügbar.",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -135,6 +135,8 @@
   "apiErrorTelephoneIsRequiredText": "Please enter your telephone number.",
   "apiErrorTooManyAppointmentsWithSameMailHeader": "You have already booked too many appointments.",
   "apiErrorTooManyAppointmentsWithSameMailText": "You can only book a limited number of appointments with your e-mail address. Please cancel another appointment before you book a new one.",
+  "apiErrorTooManySlotsPerAppointmentHeader": "Too many services selected.",
+  "apiErrorTooManySlotsPerAppointmentText": "You can only book a limited number of services in one appointment. Please reduce your selection and try again.",
   "apiErrorUnknownErrorHeader": "An unknown error occurred.",
   "apiErrorUnknownErrorText": "Please try again later or contact support.",
   "apiErrorZmsClientCommunicationErrorHeader": "Service is temporarily unavailable.",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -135,6 +135,8 @@
   "apiErrorTelephoneIsRequiredText": "Please enter your telephone number.",
   "apiErrorTooManyAppointmentsWithSameMailHeader": "You have already booked too many appointments.",
   "apiErrorTooManyAppointmentsWithSameMailText": "You can only book a limited number of appointments with your e-mail address. Please cancel another appointment before you book a new one.",
+  "apiErrorTooManyServicesPerAppointmentHeader": "Too many of the same service selected.",
+  "apiErrorTooManyServicesPerAppointmentText": "You have selected more of a service than allowed. Please reduce the quantity and try again.",
   "apiErrorTooManySlotsPerAppointmentHeader": "Too many services selected.",
   "apiErrorTooManySlotsPerAppointmentText": "You can only book a limited number of services in one appointment. Please reduce your selection and try again.",
   "apiErrorUnknownErrorHeader": "An unknown error occurred.",

--- a/zmscitizenview/src/utils/errorHandler.ts
+++ b/zmscitizenview/src/utils/errorHandler.ts
@@ -70,6 +70,7 @@ export function createErrorStateMap(): ErrorStateMap {
     "apiErrorSourceNotFound",
     "apiErrorTelephoneIsRequired",
     "apiErrorTooManyAppointmentsWithSameMail",
+    "apiErrorTooManySlotsPerAppointment",
     "apiErrorUnknownError",
     "apiErrorZmsClientCommunicationError",
     "apiErrorInvalidJumpinLink",

--- a/zmscitizenview/src/utils/errorHandler.ts
+++ b/zmscitizenview/src/utils/errorHandler.ts
@@ -70,6 +70,7 @@ export function createErrorStateMap(): ErrorStateMap {
     "apiErrorSourceNotFound",
     "apiErrorTelephoneIsRequired",
     "apiErrorTooManyAppointmentsWithSameMail",
+    "apiErrorTooManyServicesPerAppointment",
     "apiErrorTooManySlotsPerAppointment",
     "apiErrorUnknownError",
     "apiErrorZmsClientCommunicationError",

--- a/zmscitizenview/src/utils/getProviders.ts
+++ b/zmscitizenview/src/utils/getProviders.ts
@@ -32,7 +32,7 @@ export function getProviders(
           office.slotTimeInMinutes,
           office.disabledByServices,
           office.scope,
-          office.maxSlotsPerAppointment,
+          office.slotsPerAppointment,
           office.slots,
           office.priority || 1
         );

--- a/zmscitizenview/src/utils/slotCalculations.ts
+++ b/zmscitizenview/src/utils/slotCalculations.ts
@@ -1,0 +1,94 @@
+import { OfficeImpl } from "@/types/OfficeImpl";
+import { MAX_SLOTS } from "@/utils/Constants";
+
+/**
+ * Gets the maximum slots required for a service across all providers.
+ * We use MAX (not min) because we need to ensure the booking works at
+ * providers with higher slot requirements. If a service takes 3 slots
+ * at most providers but 1 slot at one provider, we count 3 slots to be
+ * conservative with the slot limit.
+ */
+export const getMaxSlotOfProvider = (providers: OfficeImpl[]): number => {
+  let maxSlot = 1; // Default to 1 slot minimum
+  providers.forEach((provider) => {
+    if (provider.slots && provider.slots > maxSlot) {
+      maxSlot = provider.slots;
+    }
+  });
+  return maxSlot;
+};
+
+/**
+ * Gets the minimum slotsPerAppointment across all providers.
+ * We use MIN (not max) because we need to ensure the booking works at
+ * ALL providers that offer this service. If Provider A allows 10 slots
+ * and Provider B allows 3 slots, we must limit to 3 to work everywhere.
+ */
+export const getMinSlotsPerAppointmentOfProvider = (
+  providers: OfficeImpl[]
+): number => {
+  let minSlot = 0;
+  providers.forEach((provider) => {
+    if (
+      provider.slotsPerAppointment &&
+      parseInt(provider.slotsPerAppointment) > 0
+    ) {
+      const providerSlots = parseInt(provider.slotsPerAppointment);
+      if (minSlot === 0 || providerSlots < minSlot) {
+        minSlot = providerSlots;
+      }
+    }
+  });
+  return minSlot;
+};
+
+/**
+ * Calculates the effective minSlotsPerAppointment, applying MAX_SLOTS as fallback.
+ */
+export const getEffectiveMinSlotsPerAppointment = (
+  providers: OfficeImpl[]
+): number => {
+  const minSlotsOfProvider = getMinSlotsPerAppointmentOfProvider(providers);
+  return minSlotsOfProvider > 0
+    ? Math.min(minSlotsOfProvider, MAX_SLOTS)
+    : MAX_SLOTS;
+};
+
+/**
+ * Calculates the total slots used by a list of subservices.
+ */
+export const calculateSubserviceSlots = (
+  subServices: Array<{ count: number; providers: OfficeImpl[] }> | undefined
+): number => {
+  if (!subServices) return 0;
+  let slots = 0;
+  subServices.forEach((subservice) => {
+    if (subservice.count > 0) {
+      slots += getMaxSlotOfProvider(subservice.providers) * subservice.count;
+    }
+  });
+  return slots;
+};
+
+/**
+ * Calculates the maximum allowed count for a service based on slot constraints.
+ *
+ * @param serviceSlots - Slots required per unit of this service
+ * @param maxQuantity - The service's own quantity limit
+ * @param minSlotsPerAppointment - Total slots allowed for the appointment
+ * @param otherSlotsUsed - Slots already used by other services
+ * @returns The maximum count allowed (at least 0)
+ */
+export const calculateMaxCountBySlots = (
+  serviceSlots: number,
+  maxQuantity: number,
+  minSlotsPerAppointment: number,
+  otherSlotsUsed: number
+): number => {
+  if (serviceSlots <= 0) return maxQuantity;
+
+  const availableSlots = minSlotsPerAppointment - otherSlotsUsed;
+  const maxCountBySlots = Math.floor(availableSlots / serviceSlots);
+
+  return Math.max(0, Math.min(maxQuantity, maxCountBySlots));
+};

--- a/zmscitizenview/tests/unit/Appointment/ServiceFinder/SubserviceListItem.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/ServiceFinder/SubserviceListItem.spec.ts
@@ -46,75 +46,104 @@ describe("SubserviceListItem", () => {
   });
 
   describe("Computed Properties", () => {
-    it("computes maxValue correctly", () => {
+    it("computes maxValue correctly based on slots", () => {
+      // slots: 3, maxSlotsPerAppointment: 10, currentSlots: 0
+      // availableSlots = 10 - 0 = 10
+      // maxCountBySlots = floor(10 / 3) = 3
+      // maxValue = min(maxQuantity=5, maxCountBySlots=3) = 3
       const wrapper = createWrapper();
+      expect(wrapper.vm.maxValue).toBe(3);
+    });
+
+    it("computes maxValue as maxQuantity when slots allow more", () => {
+      // slots: 2, maxSlotsPerAppointment: 20, currentSlots: 0, maxQuantity: 5
+      // availableSlots = 20 - 0 = 20
+      // maxCountBySlots = floor(20 / 2) = 10
+      // maxValue = min(maxQuantity=5, maxCountBySlots=10) = 5
+      const wrapper = createWrapper({
+        subService: { ...mockSubService, providers: [{ slots: 2 }] },
+        maxSlotsPerAppointment: 20,
+      });
       expect(wrapper.vm.maxValue).toBe(mockSubService.maxQuantity);
     });
 
-    it("computes disabled correctly", () => {
+    it("computes disabled correctly when maxValue > 0", () => {
       const wrapper = createWrapper();
       expect(wrapper.vm.disabled).toBe(false);
+    });
+
+    it("computes disabled correctly when maxValue = 0 and count = 0", () => {
+      // currentSlots: 10, maxSlotsPerAppointment: 10
+      // availableSlots = 10 - 10 = 0
+      // maxCountBySlots = floor(0 / 3) = 0
+      // maxValue = 0, count = 0 -> disabled = true
+      const wrapper = createWrapper({
+        currentSlots: 10,
+        maxSlotsPerAppointment: 10,
+      });
+      expect(wrapper.vm.disabled).toBe(true);
     });
   });
 
   describe("Business Logic", () => {
-    it("maxValue equals count when checkPlusEndabled is false", () => {
+    it("maxValue is limited by remaining available slots", () => {
+      // currentSlots: 8, maxSlotsPerAppointment: 10, slots: 3
+      // availableSlots = 10 - 8 = 2
+      // maxCountBySlots = floor(2 / 3) = 0
+      // maxValue = max(0, min(5, 0)) = 0
       const wrapper = createWrapper({
-        currentSlots: 10, // will make checkPlusEndabled false
-        maxSlotsPerAppointment: 5,
+        currentSlots: 8,
+        maxSlotsPerAppointment: 10,
       });
-      wrapper.vm.count = 2;
+      expect(wrapper.vm.maxValue).toBe(0);
+    });
+
+    it("maxValue considers slots already used by this subservice", async () => {
+      // currentSlots: 6 (includes 3 from this subservice with count=1)
+      // maxSlotsPerAppointment: 10, slots: 3, count: 1
+      // thisSlotsUsed = 3 * 1 = 3
+      // slotsUsedByOthers = 6 - 3 = 3
+      // availableSlots = 10 - 3 = 7
+      // maxCountBySlots = floor(7 / 3) = 2
+      // maxValue = min(5, 2) = 2
+      const wrapper = createWrapper({
+        subService: { ...mockSubService, count: 1 },
+        currentSlots: 6,
+        maxSlotsPerAppointment: 10,
+      });
+      wrapper.vm.count = 1;
+      await nextTick();
       expect(wrapper.vm.maxValue).toBe(2);
     });
 
-    it("maxValue equals subService.maxQuantity when checkPlusEndabled is true", () => {
+    it("disabled is true when maxValue is 0 and count is 0", () => {
       const wrapper = createWrapper({
-        currentSlots: 0, // will make checkPlusEndabled true
+        currentSlots: 10,
         maxSlotsPerAppointment: 10,
-      });
-      expect(wrapper.vm.maxValue).toBe(mockSubService.maxQuantity);
-    });
-
-    it("disabled is true when checkPlusEndabled is false and count is 0", () => {
-      const wrapper = createWrapper({
-        currentSlots: 10, // will make checkPlusEndabled false
-        maxSlotsPerAppointment: 5,
       });
       wrapper.vm.count = 0;
       expect(wrapper.vm.disabled).toBe(true);
     });
 
-    it("disabled is false when checkPlusEndabled is true", () => {
+    it("disabled is false when maxValue > 0", () => {
       const wrapper = createWrapper({
-        currentSlots: 0, // will make checkPlusEndabled true
+        currentSlots: 0,
         maxSlotsPerAppointment: 10,
       });
       expect(wrapper.vm.disabled).toBe(false);
     });
 
-    it("checkPlusEndabled is true when currentSlots + minProviderSlots <= maxSlotsPerAppointment", () => {
-      const wrapper = createWrapper({
-        currentSlots: 0,
-        maxSlotsPerAppointment: 10,
-        subService: { ...mockSubService, providers: [{ slots: 3 }, { slots: 2 }] },
-      });
-      expect(wrapper.vm.checkPlusEndabled).toBe(true);
-    });
-
-    it("checkPlusEndabled is false when currentSlots + minProviderSlots > maxSlotsPerAppointment", () => {
-      const wrapper = createWrapper({
-        currentSlots: 9,
-        maxSlotsPerAppointment: 10,
-        subService: { ...mockSubService, providers: [{ slots: 3 }, { slots: 2 }] },
-      });
-      expect(wrapper.vm.checkPlusEndabled).toBe(false);
-    });
-
-    it("getMinSlotOfProvider returns the minimum slot value", () => {
+    it("uses maximum slot value from providers (not minimum)", () => {
+      // With providers having slots [5, 2, 8], getMaxSlotOfProvider returns 8
+      // availableSlots = 10 - 0 = 10
+      // maxCountBySlots = floor(10 / 8) = 1
+      // maxValue = min(5, 1) = 1
       const wrapper = createWrapper({
         subService: { ...mockSubService, providers: [{ slots: 5 }, { slots: 2 }, { slots: 8 }] },
+        currentSlots: 0,
+        maxSlotsPerAppointment: 10,
       });
-      expect(wrapper.vm.getMinSlotOfProvider(wrapper.vm.$props.subService.providers)).toBe(2);
+      expect(wrapper.vm.maxValue).toBe(1);
     });
 
     it("emits correct id and count when count changes", async () => {
@@ -129,35 +158,39 @@ describe("SubserviceListItem", () => {
     });
 
     it("disables subservice when adding it would exceed maxSlotsPerAppointment", () => {
-      // Simulate a scenario where current slots + subservice slots > maxSlotsPerAppointment
+      // currentSlots: 8, maxSlotsPerAppointment: 10, slots: 3
+      // availableSlots = 10 - 8 = 2
+      // maxCountBySlots = floor(2 / 3) = 0
+      // maxValue = 0, count = 0 -> disabled = true
       const wrapper = createWrapper({
-        currentSlots: 8, // Current slots used
-        maxSlotsPerAppointment: 10, // Maximum allowed
+        currentSlots: 8,
+        maxSlotsPerAppointment: 10,
         subService: { 
           ...mockSubService, 
-          providers: [{ slots: 3 }] // This subservice needs 3 slots
+          providers: [{ slots: 3 }]
         },
       });
       
-      // 8 + 3 = 11, which exceeds maxSlotsPerAppointment of 10
-      expect(wrapper.vm.checkPlusEndabled).toBe(false);
-      expect(wrapper.vm.disabled).toBe(true); // Should be disabled when count is 0
+      expect(wrapper.vm.maxValue).toBe(0);
+      expect(wrapper.vm.disabled).toBe(true);
     });
 
     it("enables subservice when adding it would not exceed maxSlotsPerAppointment", () => {
-      // Simulate a scenario where current slots + subservice slots <= maxSlotsPerAppointment
+      // currentSlots: 7, maxSlotsPerAppointment: 10, slots: 3
+      // availableSlots = 10 - 7 = 3
+      // maxCountBySlots = floor(3 / 3) = 1
+      // maxValue = min(5, 1) = 1, count = 0 -> disabled = false
       const wrapper = createWrapper({
-        currentSlots: 7, // Current slots used
-        maxSlotsPerAppointment: 10, // Maximum allowed
+        currentSlots: 7,
+        maxSlotsPerAppointment: 10,
         subService: { 
           ...mockSubService, 
-          providers: [{ slots: 3 }] // This subservice needs 3 slots
+          providers: [{ slots: 3 }]
         },
       });
       
-      // 7 + 3 = 10, which equals maxSlotsPerAppointment of 10
-      expect(wrapper.vm.checkPlusEndabled).toBe(true);
-      expect(wrapper.vm.disabled).toBe(false); // Should be enabled when count is 0
+      expect(wrapper.vm.maxValue).toBe(1);
+      expect(wrapper.vm.disabled).toBe(false);
     });
   });
-}); 
+});

--- a/zmscitizenview/tests/unit/Appointment/ServiceFinder/SubserviceListItem.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/ServiceFinder/SubserviceListItem.spec.ts
@@ -19,7 +19,7 @@ describe("SubserviceListItem", () => {
       props: {
         subService: mockSubService,
         currentSlots: 0,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
         ...props,
       },
     });
@@ -47,7 +47,7 @@ describe("SubserviceListItem", () => {
 
   describe("Computed Properties", () => {
     it("computes maxValue correctly based on slots", () => {
-      // slots: 3, maxSlotsPerAppointment: 10, currentSlots: 0
+      // slots: 3, minSlotsPerAppointment: 10, currentSlots: 0
       // availableSlots = 10 - 0 = 10
       // maxCountBySlots = floor(10 / 3) = 3
       // maxValue = min(maxQuantity=5, maxCountBySlots=3) = 3
@@ -56,13 +56,13 @@ describe("SubserviceListItem", () => {
     });
 
     it("computes maxValue as maxQuantity when slots allow more", () => {
-      // slots: 2, maxSlotsPerAppointment: 20, currentSlots: 0, maxQuantity: 5
+      // slots: 2, minSlotsPerAppointment: 20, currentSlots: 0, maxQuantity: 5
       // availableSlots = 20 - 0 = 20
       // maxCountBySlots = floor(20 / 2) = 10
       // maxValue = min(maxQuantity=5, maxCountBySlots=10) = 5
       const wrapper = createWrapper({
         subService: { ...mockSubService, providers: [{ slots: 2 }] },
-        maxSlotsPerAppointment: 20,
+        minSlotsPerAppointment: 20,
       });
       expect(wrapper.vm.maxValue).toBe(mockSubService.maxQuantity);
     });
@@ -73,13 +73,13 @@ describe("SubserviceListItem", () => {
     });
 
     it("computes disabled correctly when maxValue = 0 and count = 0", () => {
-      // currentSlots: 10, maxSlotsPerAppointment: 10
+      // currentSlots: 10, minSlotsPerAppointment: 10
       // availableSlots = 10 - 10 = 0
       // maxCountBySlots = floor(0 / 3) = 0
       // maxValue = 0, count = 0 -> disabled = true
       const wrapper = createWrapper({
         currentSlots: 10,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
       });
       expect(wrapper.vm.disabled).toBe(true);
     });
@@ -87,20 +87,20 @@ describe("SubserviceListItem", () => {
 
   describe("Business Logic", () => {
     it("maxValue is limited by remaining available slots", () => {
-      // currentSlots: 8, maxSlotsPerAppointment: 10, slots: 3
+      // currentSlots: 8, minSlotsPerAppointment: 10, slots: 3
       // availableSlots = 10 - 8 = 2
       // maxCountBySlots = floor(2 / 3) = 0
       // maxValue = max(0, min(5, 0)) = 0
       const wrapper = createWrapper({
         currentSlots: 8,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
       });
       expect(wrapper.vm.maxValue).toBe(0);
     });
 
     it("maxValue considers slots already used by this subservice", async () => {
       // currentSlots: 6 (includes 3 from this subservice with count=1)
-      // maxSlotsPerAppointment: 10, slots: 3, count: 1
+      // minSlotsPerAppointment: 10, slots: 3, count: 1
       // thisSlotsUsed = 3 * 1 = 3
       // slotsUsedByOthers = 6 - 3 = 3
       // availableSlots = 10 - 3 = 7
@@ -109,7 +109,7 @@ describe("SubserviceListItem", () => {
       const wrapper = createWrapper({
         subService: { ...mockSubService, count: 1 },
         currentSlots: 6,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
       });
       wrapper.vm.count = 1;
       await nextTick();
@@ -119,7 +119,7 @@ describe("SubserviceListItem", () => {
     it("disabled is true when maxValue is 0 and count is 0", () => {
       const wrapper = createWrapper({
         currentSlots: 10,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
       });
       wrapper.vm.count = 0;
       expect(wrapper.vm.disabled).toBe(true);
@@ -128,7 +128,7 @@ describe("SubserviceListItem", () => {
     it("disabled is false when maxValue > 0", () => {
       const wrapper = createWrapper({
         currentSlots: 0,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
       });
       expect(wrapper.vm.disabled).toBe(false);
     });
@@ -141,7 +141,7 @@ describe("SubserviceListItem", () => {
       const wrapper = createWrapper({
         subService: { ...mockSubService, providers: [{ slots: 5 }, { slots: 2 }, { slots: 8 }] },
         currentSlots: 0,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
       });
       expect(wrapper.vm.maxValue).toBe(1);
     });
@@ -157,14 +157,14 @@ describe("SubserviceListItem", () => {
       }
     });
 
-    it("disables subservice when adding it would exceed maxSlotsPerAppointment", () => {
-      // currentSlots: 8, maxSlotsPerAppointment: 10, slots: 3
+    it("disables subservice when adding it would exceed minSlotsPerAppointment", () => {
+      // currentSlots: 8, minSlotsPerAppointment: 10, slots: 3
       // availableSlots = 10 - 8 = 2
       // maxCountBySlots = floor(2 / 3) = 0
       // maxValue = 0, count = 0 -> disabled = true
       const wrapper = createWrapper({
         currentSlots: 8,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
         subService: { 
           ...mockSubService, 
           providers: [{ slots: 3 }]
@@ -175,14 +175,14 @@ describe("SubserviceListItem", () => {
       expect(wrapper.vm.disabled).toBe(true);
     });
 
-    it("enables subservice when adding it would not exceed maxSlotsPerAppointment", () => {
-      // currentSlots: 7, maxSlotsPerAppointment: 10, slots: 3
+    it("enables subservice when adding it would not exceed minSlotsPerAppointment", () => {
+      // currentSlots: 7, minSlotsPerAppointment: 10, slots: 3
       // availableSlots = 10 - 7 = 3
       // maxCountBySlots = floor(3 / 3) = 1
       // maxValue = min(5, 1) = 1, count = 0 -> disabled = false
       const wrapper = createWrapper({
         currentSlots: 7,
-        maxSlotsPerAppointment: 10,
+        minSlotsPerAppointment: 10,
         subService: { 
           ...mockSubService, 
           providers: [{ slots: 3 }]

--- a/zmscitizenview/tests/unit/api/ZMSAppointmentAPI.spec.ts
+++ b/zmscitizenview/tests/unit/api/ZMSAppointmentAPI.spec.ts
@@ -54,7 +54,7 @@ describe("ZMSAppointmentAPI", () => {
               slotTimeInMinutes: 30,
               disabledByServices: [],
               scope: { captchaActivatedRequired: false },
-              maxSlotsPerAppointment: "10",
+              slotsPerAppointment: "10",
               slots: 5,
               priority: 1
             },
@@ -69,7 +69,7 @@ describe("ZMSAppointmentAPI", () => {
               slotTimeInMinutes: 45,
               disabledByServices: ["1"],
               scope: { captchaActivatedRequired: true },
-              maxSlotsPerAppointment: "8",
+              slotsPerAppointment: "8",
               slots: 3,
               priority: 2
             }

--- a/zmscitizenview/tests/unit/utils/slotCalculations.spec.ts
+++ b/zmscitizenview/tests/unit/utils/slotCalculations.spec.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateMaxCountBySlots,
+  calculateSubserviceSlots,
+  getEffectiveMinSlotsPerAppointment,
+  getMaxSlotOfProvider,
+  getMinSlotsPerAppointmentOfProvider,
+} from "@/utils/slotCalculations";
+
+describe("slotCalculations", () => {
+  describe("getMaxSlotOfProvider", () => {
+    it("returns 1 for empty providers array", () => {
+      expect(getMaxSlotOfProvider([])).toBe(1);
+    });
+
+    it("returns max slots from multiple providers", () => {
+      const providers = [
+        { slots: 2 },
+        { slots: 5 },
+        { slots: 3 },
+      ] as any[];
+      expect(getMaxSlotOfProvider(providers)).toBe(5);
+    });
+
+    it("returns 1 when all providers have no slots defined", () => {
+      const providers = [{ id: "1" }, { id: "2" }] as any[];
+      expect(getMaxSlotOfProvider(providers)).toBe(1);
+    });
+
+    it("ignores providers with 0 slots", () => {
+      const providers = [
+        { slots: 0 },
+        { slots: 3 },
+      ] as any[];
+      expect(getMaxSlotOfProvider(providers)).toBe(3);
+    });
+  });
+
+  describe("getMinSlotsPerAppointmentOfProvider", () => {
+    it("returns 0 for empty providers array", () => {
+      expect(getMinSlotsPerAppointmentOfProvider([])).toBe(0);
+    });
+
+    it("returns minimum slotsPerAppointment from multiple providers", () => {
+      const providers = [
+        { slotsPerAppointment: "10" },
+        { slotsPerAppointment: "3" },
+        { slotsPerAppointment: "7" },
+      ] as any[];
+      expect(getMinSlotsPerAppointmentOfProvider(providers)).toBe(3);
+    });
+
+    it("ignores providers with no slotsPerAppointment", () => {
+      const providers = [
+        { id: "1" },
+        { slotsPerAppointment: "5" },
+      ] as any[];
+      expect(getMinSlotsPerAppointmentOfProvider(providers)).toBe(5);
+    });
+
+    it("ignores providers with 0 or negative slotsPerAppointment", () => {
+      const providers = [
+        { slotsPerAppointment: "0" },
+        { slotsPerAppointment: "-1" },
+        { slotsPerAppointment: "4" },
+      ] as any[];
+      expect(getMinSlotsPerAppointmentOfProvider(providers)).toBe(4);
+    });
+  });
+
+  describe("getEffectiveMinSlotsPerAppointment", () => {
+    it("returns MAX_SLOTS (25) for empty providers", () => {
+      expect(getEffectiveMinSlotsPerAppointment([])).toBe(25);
+    });
+
+    it("returns minimum from providers when less than MAX_SLOTS", () => {
+      const providers = [
+        { slotsPerAppointment: "10" },
+        { slotsPerAppointment: "5" },
+      ] as any[];
+      expect(getEffectiveMinSlotsPerAppointment(providers)).toBe(5);
+    });
+
+    it("caps at MAX_SLOTS when provider value exceeds it", () => {
+      const providers = [
+        { slotsPerAppointment: "30" },
+        { slotsPerAppointment: "50" },
+      ] as any[];
+      expect(getEffectiveMinSlotsPerAppointment(providers)).toBe(25);
+    });
+
+    it("returns MAX_SLOTS when no provider has valid slotsPerAppointment", () => {
+      const providers = [
+        { slotsPerAppointment: "0" },
+        { id: "2" },
+      ] as any[];
+      expect(getEffectiveMinSlotsPerAppointment(providers)).toBe(25);
+    });
+  });
+
+  describe("calculateSubserviceSlots", () => {
+    it("returns 0 for undefined subservices", () => {
+      expect(calculateSubserviceSlots(undefined)).toBe(0);
+    });
+
+    it("returns 0 for empty subservices array", () => {
+      expect(calculateSubserviceSlots([])).toBe(0);
+    });
+
+    it("calculates total slots from subservices", () => {
+      const subservices = [
+        { count: 2, providers: [{ slots: 3 }] },
+        { count: 1, providers: [{ slots: 5 }] },
+      ] as any[];
+      // 2*3 + 1*5 = 11
+      expect(calculateSubserviceSlots(subservices)).toBe(11);
+    });
+
+    it("ignores subservices with count 0", () => {
+      const subservices = [
+        { count: 0, providers: [{ slots: 3 }] },
+        { count: 2, providers: [{ slots: 2 }] },
+      ] as any[];
+      // 0*3 + 2*2 = 4
+      expect(calculateSubserviceSlots(subservices)).toBe(4);
+    });
+
+    it("uses max slots from multiple providers", () => {
+      const subservices = [
+        { count: 1, providers: [{ slots: 2 }, { slots: 5 }, { slots: 3 }] },
+      ] as any[];
+      // 1*5 = 5 (uses max slot of 5)
+      expect(calculateSubserviceSlots(subservices)).toBe(5);
+    });
+  });
+
+  describe("calculateMaxCountBySlots", () => {
+    it("returns maxQuantity when serviceSlots is 0", () => {
+      expect(calculateMaxCountBySlots(0, 5, 10, 0)).toBe(5);
+    });
+
+    it("returns maxQuantity when slots allow more", () => {
+      // serviceSlots: 2, maxQuantity: 3, minSlotsPerAppointment: 20, otherSlotsUsed: 0
+      // availableSlots = 20 - 0 = 20
+      // maxCountBySlots = floor(20 / 2) = 10
+      // min(3, 10) = 3
+      expect(calculateMaxCountBySlots(2, 3, 20, 0)).toBe(3);
+    });
+
+    it("returns slot-based limit when slots constrain more", () => {
+      // serviceSlots: 3, maxQuantity: 5, minSlotsPerAppointment: 10, otherSlotsUsed: 0
+      // availableSlots = 10 - 0 = 10
+      // maxCountBySlots = floor(10 / 3) = 3
+      // min(5, 3) = 3
+      expect(calculateMaxCountBySlots(3, 5, 10, 0)).toBe(3);
+    });
+
+    it("accounts for slots used by other services", () => {
+      // serviceSlots: 3, maxQuantity: 5, minSlotsPerAppointment: 10, otherSlotsUsed: 7
+      // availableSlots = 10 - 7 = 3
+      // maxCountBySlots = floor(3 / 3) = 1
+      // min(5, 1) = 1
+      expect(calculateMaxCountBySlots(3, 5, 10, 7)).toBe(1);
+    });
+
+    it("returns 0 when no slots available", () => {
+      // serviceSlots: 3, maxQuantity: 5, minSlotsPerAppointment: 10, otherSlotsUsed: 10
+      // availableSlots = 10 - 10 = 0
+      // maxCountBySlots = floor(0 / 3) = 0
+      // max(0, min(5, 0)) = 0
+      expect(calculateMaxCountBySlots(3, 5, 10, 10)).toBe(0);
+    });
+
+    it("returns 0 when slots are overused", () => {
+      // serviceSlots: 3, maxQuantity: 5, minSlotsPerAppointment: 10, otherSlotsUsed: 15
+      // availableSlots = 10 - 15 = -5
+      // maxCountBySlots = floor(-5 / 3) = -2
+      // max(0, min(5, -2)) = 0
+      expect(calculateMaxCountBySlots(3, 5, 10, 15)).toBe(0);
+    });
+  });
+});

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -892,6 +892,7 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         $maxSlotsPerAppointment = $entity->scope->getSlotsPerAppointment();
+        error_log('entity->scope: ' . json_encode($entity->scope));
         error_log('maxSlotsPerAppointment: ' . $maxSlotsPerAppointment);
         if ($maxSlotsPerAppointment === null || $maxSlotsPerAppointment < 1) {
             return true;

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -892,13 +892,10 @@ class Process extends Base implements Interfaces\ResolveReferences
 
         $maxSlotsPerAppointment = $entity->scope->getSlotsPerAppointment();
 
-        // Use MAX_SLOTS (25) as default limit if slotsPerAppointment is not configured
         if ($maxSlotsPerAppointment === null || $maxSlotsPerAppointment < 1) {
             $maxSlotsPerAppointment = Slot::MAX_SLOTS;
         }
 
-        // Use getAppointments()->getFirst() to avoid side effects
-        // (getFirstAppointment() creates an appointment if none exists)
         $appointment = $entity->getAppointments()->getFirst();
         if (!$appointment) {
             return true;
@@ -912,17 +909,12 @@ class Process extends Base implements Interfaces\ResolveReferences
         return $slotCount <= (int) $maxSlotsPerAppointment;
     }
 
-    /**
-     * Check if service quantities in the appointment exceed maxQuantity limits.
-     * maxQuantity is defined per request-provider relation.
-     */
     public function isServiceQuantityAllowed(Entity $entity): bool
     {
         if (empty($entity->scope) || empty($entity->requests)) {
             return true;
         }
 
-        // Get provider ID from scope - return true if no provider available
         try {
             $providerId = $entity->scope->getProviderId();
         } catch (\Exception $e) {
@@ -932,7 +924,6 @@ class Process extends Base implements Interfaces\ResolveReferences
             return true;
         }
 
-        // Count occurrences of each request (service) in the process
         $requestCounts = [];
         foreach ($entity->requests as $request) {
             $requestId = $request->getId();
@@ -942,13 +933,11 @@ class Process extends Base implements Interfaces\ResolveReferences
             $requestCounts[$requestId]++;
         }
 
-        // Validate each request count against its maxQuantity
         $requestRelationDb = new RequestRelation();
         foreach ($requestCounts as $requestId => $count) {
             $requestRelation = $requestRelationDb->readEntity($requestId, $providerId, 0);
             if ($requestRelation) {
                 $maxQuantity = $requestRelation->getMaxQuantity();
-                // maxQuantity of null means unlimited
                 if ($maxQuantity !== null && $maxQuantity > 0 && $count > (int) $maxQuantity) {
                     return false;
                 }
@@ -994,11 +983,6 @@ class Process extends Base implements Interfaces\ResolveReferences
         return $this->readResolvedReferences($process, 1);
     }
 
-    /**
-     * Read processList by external user id
-     *
-     * @return Collection processList
-     */
     public function readProcessListByExternalUserId(string $externalUserId, ?int $filterId = null, ?string $status = null, $resolveReferences = 0, $limit = 1000): Collection
     {
         $query = new Query\Process(Query\Base::SELECT);

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -891,7 +891,7 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         $maxSlotsPerAppointment = $entity->scope->getSlotsPerAppointment();
-        
+
         // Use MAX_SLOTS (25) as default limit if slotsPerAppointment is not configured
         if ($maxSlotsPerAppointment === null || $maxSlotsPerAppointment < 1) {
             $maxSlotsPerAppointment = Slot::MAX_SLOTS;

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -891,8 +891,10 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         $maxSlotsPerAppointment = $entity->scope->getSlotsPerAppointment();
+        
+        // Use MAX_SLOTS (25) as default limit if slotsPerAppointment is not configured
         if ($maxSlotsPerAppointment === null || $maxSlotsPerAppointment < 1) {
-            return true;
+            $maxSlotsPerAppointment = Slot::MAX_SLOTS;
         }
 
         $appointment = $entity->getFirstAppointment();

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -857,7 +857,6 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         $maxAppointmentsPerMail = $entity->scope->getAppointmentsPerMail();
-        error_log('maxAppointmentsPerMail: ' . $maxAppointmentsPerMail);
         $emailToCheck = $entity->getClients()->getFirst()->email;
         if ($maxAppointmentsPerMail < 1 || empty($emailToCheck)) {
             return true;
@@ -892,8 +891,6 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         $maxSlotsPerAppointment = $entity->scope->getSlotsPerAppointment();
-        error_log('entity->scope: ' . json_encode($entity->scope));
-        error_log('maxSlotsPerAppointment: ' . $maxSlotsPerAppointment);
         if ($maxSlotsPerAppointment === null || $maxSlotsPerAppointment < 1) {
             return true;
         }

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -920,8 +920,12 @@ class Process extends Base implements Interfaces\ResolveReferences
             return true;
         }
 
-        // Get provider ID from scope
-        $providerId = $entity->scope->getProviderId();
+        // Get provider ID from scope - return true if no provider available
+        try {
+            $providerId = $entity->scope->getProviderId();
+        } catch (\Exception $e) {
+            return true;
+        }
         if (!$providerId) {
             return true;
         }

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -897,7 +897,9 @@ class Process extends Base implements Interfaces\ResolveReferences
             $maxSlotsPerAppointment = Slot::MAX_SLOTS;
         }
 
-        $appointment = $entity->getFirstAppointment();
+        // Use getAppointments()->getFirst() to avoid side effects
+        // (getFirstAppointment() creates an appointment if none exists)
+        $appointment = $entity->getAppointments()->getFirst();
         if (!$appointment) {
             return true;
         }

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -857,6 +857,7 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         $maxAppointmentsPerMail = $entity->scope->getAppointmentsPerMail();
+        error_log('maxAppointmentsPerMail: ' . $maxAppointmentsPerMail);
         $emailToCheck = $entity->getClients()->getFirst()->email;
         if ($maxAppointmentsPerMail < 1 || empty($emailToCheck)) {
             return true;
@@ -882,6 +883,31 @@ class Process extends Base implements Interfaces\ResolveReferences
         }
 
         return true;
+    }
+
+    public function isAppointmentSlotCountAllowed(Entity $entity): bool
+    {
+        if (empty($entity->scope)) {
+            return true;
+        }
+
+        $maxSlotsPerAppointment = $entity->scope->getSlotsPerAppointment();
+        error_log('maxSlotsPerAppointment: ' . $maxSlotsPerAppointment);
+        if ($maxSlotsPerAppointment === null || $maxSlotsPerAppointment < 1) {
+            return true;
+        }
+
+        $appointment = $entity->getFirstAppointment();
+        if (!$appointment) {
+            return true;
+        }
+
+        $slotCount = (int) ($appointment->slotCount ?? 0);
+        if ($slotCount <= 0) {
+            return true;
+        }
+
+        return $slotCount <= (int) $maxSlotsPerAppointment;
     }
 
     protected function isMailWhitelisted(string $email, ScopeEntity $scope): bool

--- a/zmsentities/schema/citizenapi/office.json
+++ b/zmsentities/schema/citizenapi/office.json
@@ -132,12 +132,12 @@
             ],
             "description": "Array of service-IDs for which a provider is unavailable"
         },
-        "maxSlotsPerAppointment": {
+        "slotsPerAppointment": {
             "type": [
                 "string",
                 "null"
             ],
-            "description": "Maximum number of slots that can be booked per appointment"
+            "description": "Number of slots that can be booked per appointment at this office"
         }
     },
     "required": [

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -102,12 +102,6 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->getPreference('appointment', 'infoForAllAppointments', null);
     }
 
-    public function getSlotsPerAppointment()
-    {
-        $slotsPerAppointment = $this->toProperty()->preferences->client->slotsPerAppointment->get();
-
-        return ($slotsPerAppointment) ? $slotsPerAppointment : null;
-    }
 
     public function getProvider()
     {
@@ -226,6 +220,13 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         $appointmentsPerMail = $this->toProperty()->preferences->client->appointmentsPerMail->get();
 
         return ($appointmentsPerMail) ? $appointmentsPerMail : null;
+    }
+
+    public function getSlotsPerAppointment()
+    {
+        $slotsPerAppointment = $this->toProperty()->preferences->client->slotsPerAppointment->get();
+
+        return ($slotsPerAppointment) ? $slotsPerAppointment : null;
     }
 
     public function getWhitelistedMails()

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -104,7 +104,9 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
 
     public function getSlotsPerAppointment()
     {
-        return $this->getPreference('client', 'slotsPerAppointment', null);
+        $slotsPerAppointment = $this->toProperty()->preferences->client->slotsPerAppointment->get();
+
+        return ($slotsPerAppointment) ? $slotsPerAppointment : null;
     }
 
     public function getProvider()


### PR DESCRIPTION
## Summary

This PR fixes ZMSKVR-1083 where users could bypass slot and service quantity limits by navigating back in the booking flow and manipulating the UI or the API.

## Key Variables Explained

| Variable | Description | Example |
|----------|-------------|---------|
| **slotTimeInMinutes** | Base duration of one slot at a provider | 5 minutes |
| **slots** | Number of slotTimeInMinutes units a service requires | A 15-min service = 3 slots (if slotTimeInMinutes=5) |
| **slotsPerAppointment** | Total slots allowed per appointment at an office (from scope) | 6 slots = 30 minutes max |
| **maxQuantity** | Maximum times a specific service can be selected | 2 = max 2 passport applications |

## Changes

### Frontend (zmscitizenview)

- **Correct slot counting**: Changed `getMinSlotOfProvider` → `getMaxSlotOfProvider` to use the maximum slots across providers (conservative approach)
- **Use minimum slotsPerAppointment**: Changed to use minimum across all providers so bookings work everywhere
- **Renamed variables for clarity**:
  - `maxSlotsPerAppointment` → `slotsPerAppointment` (raw value per office)
  - `maxSlotsPerAppointment` → `minSlotsPerAppointment` (calculated minimum)
- **Dynamic maxValue calculation**: `muc-counter` now correctly limits based on remaining available slots

### Backend (zmsapi/zmsdb)

- **Backend validation for slotsPerAppointment**: Added `isAppointmentSlotCountAllowed()` validation in ProcessUpdate, ProcessPreconfirm, ProcessConfirm
- **Backend validation for maxQuantity**: Added `isServiceQuantityAllowed()` validation in ProcessPreconfirm, ProcessConfirm only (not ProcessUpdate for performance)
- **New exceptions**: `MoreThanAllowedSlotsPerAppointment`, `MoreThanAllowedQuantityPerService`

### API/Schema (zmscitizenapi, zmsentities)

- Renamed `maxSlotsPerAppointment` → `slotsPerAppointment` in Office model
- Added error messages and exception mappings for new validation errors
- Updated translations (en-US, de-DE)

## Performance Considerations

- `isServiceQuantityAllowed` executes 1 DB query per unique service and kept only in `ProcessPreconfirm` and `ProcessConfirm` (final gates)
- `isAppointmentSlotCountAllowed` uses in-memory data only (no DB queries) in `ProcessUpdate` (frequently called) `ProcessPreconfirm` and `ProcessConfirm`

## Test Updates

- Updated `SubserviceListItem.spec.ts` to match new calculation logic
- All 419 frontend tests pass

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces per-appointment slot limits and per-service quantity limits with explicit API errors and new client-side slot calculation helpers.
  * Unified field renamed to slotsPerAppointment across API and UI payloads and models.

* **Bug Fixes**
  * UI slot accounting and controls updated to align with server-side limit validation and surface appropriate errors.

* **Tests**
  * Expanded unit and integration tests covering slot calculations and renamed field.

* **Documentation**
  * Added localized user-facing messages for new limit errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->