### PR TITLE
hotfix(ZMSKVR-1168): Add displayNumber mapping in thinnedProcessToProcess

### DIFF
--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/MapperService.php
@@ -461,6 +461,10 @@ class MapperService
             $processEntity->status = $thinnedProcess->status;
         }
 
+        if (isset($thinnedProcess->displayNumber)) {
+            $processEntity->displayNumber = $thinnedProcess->displayNumber;
+        }
+
         $processEntity->lastChange = time();
         $processEntity->createIP = ClientIpHelper::getClientIp();
         $processEntity->createTimestamp = time();


### PR DESCRIPTION
The displayNumber was not being mapped when converting ThinnedProcess back to Process, causing it to be missing in cancellation emails.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display number propagation in process handling to ensure display numbers are correctly retained across operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->