### PR TITLE
fix(ZMSKVR-1209): Handle Safari iOS URL encoding in appointment links

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -1016,7 +1016,10 @@ const getProviders = (serviceId: string, providers: string[] | null) => {
 
 const parseAppointmentHash = (hash: string): AppointmentHash | null => {
   try {
-    const appointmentData = JSON.parse(window.atob(hash));
+    // Add missing base64 padding if needed (padding may be stripped from URL)
+    const padding = (4 - (hash.length % 4)) % 4;
+    const paddedHash = padding > 0 ? hash + "=".repeat(padding) : hash;
+    const appointmentData = JSON.parse(window.atob(paddedHash));
     if (
       appointmentData.id == undefined ||
       appointmentData.authKey == undefined


### PR DESCRIPTION
Safari iOS encodes hash fragments when opening links from email apps, converting `/` to `%2F` and adding trailing `=` characters. This broke appointment cancel/confirm links for citizens.

Changes:
- Add iterative URL decoding to handle double/triple encoding
- Restore base64 padding in parseAppointmentHash() since trailing `=` may be stripped from URLs

Note: The decoding is unambiguous because `%` is not a valid base64 character (base64 only uses A-Z, a-z, 0-9, +, /, =). So `%2F` can only be a URL-encoded `/`, never part of the appointment hash data.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
