### PR TITLE
fix(ZMSKVR): Show provider selection error when all visible providers

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -625,22 +625,18 @@ const handleDaySelection = async (day: any) => {
 };
 
 const providerSelectionError = computed(() => {
-  // If available days is empty (no data fetched), don't show error yet
   if (!availableDays?.value || availableDays.value.length === 0) {
     return "";
   }
 
-  // Only consider providers that actually have available days (shown as checkboxes)
   const selectableIds = new Set(
     providersWithAvailableDays.value.map((p) => String(p.id))
   );
 
-  // Check if any selectable provider is selected
   const hasSelection = Object.entries(selectedProviders.value).some(
     ([id, isSelected]) => isSelected && selectableIds.has(id)
   );
 
-  // Show error if there are selectable providers but none are selected
   return !hasSelection && selectableIds.size > 0
     ? props.t("errorMessageProviderSelection")
     : "";

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -625,31 +625,25 @@ const handleDaySelection = async (day: any) => {
 };
 
 const providerSelectionError = computed(() => {
-  // Check if any providers are selected
-  const selectedProviderIds = Object.keys(selectedProviders.value).filter(
-    (id) => selectedProviders.value[id]
-  );
-
-  // If no providers are selected at all, show error
-  if (
-    selectedProviderIds.length === 0 &&
-    providersWithAppointments.value.length > 0
-  ) {
-    return props.t("errorMessageProviderSelection");
-  }
-
   // If available days is empty (no data fetched), don't show error yet
   if (!availableDays?.value || availableDays.value.length === 0) {
     return "";
   }
 
-  const hasSelection = Object.entries(selectedProviders.value).some(
-    ([id, isSelected]) =>
-      isSelected &&
-      providersWithAppointments.value.some((p) => p.id.toString() === id)
+  // Only consider providers that actually have available days (shown as checkboxes)
+  const selectableIds = new Set(
+    providersWithAvailableDays.value.map((p) => String(p.id))
   );
 
-  return hasSelection ? "" : props.t("errorMessageProviderSelection");
+  // Check if any selectable provider is selected
+  const hasSelection = Object.entries(selectedProviders.value).some(
+    ([id, isSelected]) => isSelected && selectableIds.has(id)
+  );
+
+  // Show error if there are selectable providers but none are selected
+  return !hasSelection && selectableIds.size > 0
+    ? props.t("errorMessageProviderSelection")
+    : "";
 });
 
 const noProviderSelected = computed(() => {


### PR DESCRIPTION
… unchecked

The error message was not appearing when unchecking all providers because the check used providersWithAppointments (all providers) instead of providersWithAvailableDays (only providers with visible checkboxes).

Providers without available days have no checkbox but were still counted as "selected" in the background, preventing the error from showing.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appointment provider selection validation to more accurately check against providers with available slots, ensuring error messages display only when applicable based on real-time availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->