### PR TITLE
clean(ZMSKVR): rename kioskpasswortschutz to kiosk_activation, ticketPrinterActivation

### DIFF
--- a/zmsadmin/templates/block/organisation/form.twig
+++ b/zmsadmin/templates/block/organisation/form.twig
@@ -49,9 +49,9 @@
                                 "type":"checkbox",
                                 "parameter": {
                                     "label": "Kioske müssen aktiviert werden",
-                                    "name": "preferences[ticketPrinterProtectionEnabled]",
+                                    "name": "preferences[ticketPrinterActivation]",
                                     "value": 1,
-                                    "checked": organisation.preferences.ticketPrinterProtectionEnabled,
+                                    "checked": organisation.preferences.ticketPrinterActivation,
                                 }
                             }]
                         ) }}

--- a/zmsadmin/tests/Zmsadmin/OrganisationTest.php
+++ b/zmsadmin/tests/Zmsadmin/OrganisationTest.php
@@ -66,7 +66,7 @@ class OrganisationTest extends Base
                 'street' => 'Otto-Suhr-Allee 100, 10585 Berlin'
             ),
             'preferences' => array(
-                'ticketPrinterProtectionEnabled' => 1
+                'ticketPrinterActivation' => 1
             ),
             'save' => 'save'
         ], [], 'POST');

--- a/zmsadmin/tests/Zmsadmin/OwnerAddOrganisationTest.php
+++ b/zmsadmin/tests/Zmsadmin/OwnerAddOrganisationTest.php
@@ -52,7 +52,7 @@ class OwnerAddOrganisationTest extends Base
                 'street' => 'Otto-Suhr-Allee 100, 10585 Berlin'
             ),
             'preferences' => array(
-                'ticketPrinterProtectionEnabled' => 1
+                'ticketPrinterActivation' => 1
             ),
             'save' => 'save'
         ], [], 'POST');

--- a/zmsadmin/tests/Zmsadmin/fixtures/GET_organisation_71_resolved3.json
+++ b/zmsadmin/tests/Zmsadmin/fixtures/GET_organisation_71_resolved3.json
@@ -628,7 +628,7 @@
             "name": "Charlottenburg-Wilmersdorf"
         },
         "preferences": {
-            "ticketPrinterProtectionEnabled": "0"
+            "ticketPrinterActivation": "0"
         },
         "ticketprinters": [
             {

--- a/zmsadmin/tests/Zmsadmin/fixtures/GET_organisation_71_resolved5.json
+++ b/zmsadmin/tests/Zmsadmin/fixtures/GET_organisation_71_resolved5.json
@@ -638,7 +638,7 @@
             "name": "Charlottenburg-Wilmersdorf"
         },
         "preferences": {
-            "ticketPrinterProtectionEnabled": "0"
+            "ticketPrinterActivation": "0"
         },
         "ticketprinters": [
             {

--- a/zmsadmin/tests/Zmsadmin/fixtures/GET_ownerlist.json
+++ b/zmsadmin/tests/Zmsadmin/fixtures/GET_ownerlist.json
@@ -415,7 +415,7 @@
                         "name": "Pankow"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -639,7 +639,7 @@
                         "name": "Friedrichshain-Kreuzberg"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "1"
+                        "ticketPrinterActivation": "1"
                     }
                 },
                 {
@@ -940,7 +940,7 @@
                         "name": "Marzahn-Hellersdorf"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -1488,7 +1488,7 @@
                         "name": "Lichtenberg"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -2112,7 +2112,7 @@
                         "name": "Charlottenburg-Wilmersdorf"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     },
                     "ticketprinters": [
                         {
@@ -2429,7 +2429,7 @@
                         "name": "Mitte"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -2916,7 +2916,7 @@
                         "name": "Tempelhof-Schöneberg"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -3803,7 +3803,7 @@
                         "name": "Reinickendorf"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -4207,7 +4207,7 @@
                         "name": "Spandau"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -4681,7 +4681,7 @@
                         "name": "Neukölln"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -4915,7 +4915,7 @@
                         "name": "Treptow-Köpenick"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 },
                 {
@@ -4928,7 +4928,7 @@
                         "name": "Test Organisation"
                     },
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": "0"
+                        "ticketPrinterActivation": "0"
                     }
                 }
             ],

--- a/zmsapi/tests/Zmsapi/OrganisationHashTest.php
+++ b/zmsapi/tests/Zmsapi/OrganisationHashTest.php
@@ -23,7 +23,7 @@ class OrganisationHashTest extends Base
 
     public function testTicketprinterDisabled()
     {
-        $response = $this->render(['id' => 65], [], []); //Friedrichshain-Kreuzberg mit kioskpasswortschutz
+        $response = $this->render(['id' => 65], [], []); //Friedrichshain-Kreuzberg mit kiosk_activation
         $this->assertStringContainsString('ticketprinter.json', (string)$response->getBody());
         $this->assertStringContainsString('"enabled":false', (string)$response->getBody());
         $this->assertTrue(200 == $response->getStatusCode());

--- a/zmsapi/tests/Zmsapi/fixtures/GetOrganisation.json
+++ b/zmsapi/tests/Zmsapi/fixtures/GetOrganisation.json
@@ -9,7 +9,7 @@
         "name": "Pankow"
     },
     "preferences": {
-        "ticketPrinterProtectionEnabled": 0
+        "ticketPrinterActivation": 0
     },
     "departments": [
         {

--- a/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay.json
+++ b/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay.json
@@ -198,7 +198,7 @@
 			"name": "Charlottenburg-Wilmersdorf"
 		},
 		"preferences": {
-			"ticketPrinterProtectionEnabled": "0"
+			"ticketPrinterActivation": "0"
 		},
 		"departments": [{
 			"email": "test@example.com",

--- a/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay_cluster_118.json
+++ b/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay_cluster_118.json
@@ -116,7 +116,7 @@
 				"name": "Neuk\u00f6lln"
 			},
 			"preferences": {
-				"ticketPrinterProtectionEnabled": "0"
+				"ticketPrinterActivation": "0"
 			},
 			"departments": [{
 				"email": "Buergeramt@bezirksamt-neukoelln.de",

--- a/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay_department_76.json
+++ b/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay_department_76.json
@@ -97,7 +97,7 @@
 				"name": "Tempelhof-Sch\u00f6neberg"
 			},
 			"preferences": {
-				"ticketPrinterProtectionEnabled": "0"
+				"ticketPrinterActivation": "0"
 			},
 			"departments": [{
 				"email": "buergeramt@ba-ts.berlin.de",

--- a/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay_twoScopes.json
+++ b/zmscalldisplay/tests/Zmscalldisplay/fixtures/GET_calldisplay_twoScopes.json
@@ -28,7 +28,7 @@
 				"name": "Charlottenburg-Wilmersdorf"
 			},
 			"preferences": {
-				"ticketPrinterProtectionEnabled": "0"
+				"ticketPrinterActivation": "0"
 			},
 			"departments": [{
 				"email": "test@example.com",

--- a/zmsdb/migrations/91770295000-rename-kioskpasswortschutz-to-kiosk-activation.sql
+++ b/zmsdb/migrations/91770295000-rename-kioskpasswortschutz-to-kiosk-activation.sql
@@ -1,0 +1,3 @@
+-- Rename organisation column to reflect actual behaviour (kiosks must be explicitly activated)
+ALTER TABLE `organisation`
+  CHANGE COLUMN `kioskpasswortschutz` `kiosk_activation` INT(2) DEFAULT 0;

--- a/zmsdb/migrations/91770296000-drop-ipprotectzeit-from-behoerde.sql
+++ b/zmsdb/migrations/91770296000-drop-ipprotectzeit-from-behoerde.sql
@@ -1,0 +1,3 @@
+-- Remove unused column from behoerde (never read or written by application)
+ALTER TABLE `behoerde`
+  DROP COLUMN `IPProtectZeit`;

--- a/zmsdb/src/Zmsdb/Query/Organisation.php
+++ b/zmsdb/src/Zmsdb/Query/Organisation.php
@@ -31,7 +31,7 @@ class Organisation extends Base implements MappingInterface
             'contact__name' => 'organisation.Organisationsname',
             'name' => 'organisation.Organisationsname',
             'id' => 'organisation.OrganisationsID',
-            'preferences__ticketPrinterProtectionEnabled' => 'organisation.kioskpasswortschutz'
+            'preferences__ticketPrinterActivation' => 'organisation.kiosk_activation'
         ];
     }
 
@@ -86,7 +86,7 @@ class Organisation extends Base implements MappingInterface
         $data['Organisationsname'] = $entity->name;
         $data['InfoBezirkID'] = 14;
         $data['Anschrift'] = (isset($entity->contact['street'])) ? $entity->contact['street'] : '';
-        $data['kioskpasswortschutz'] = ($entity->getPreference('ticketPrinterProtectionEnabled')) ? 1 : 0;
+        $data['kiosk_activation'] = ($entity->getPreference('ticketPrinterActivation')) ? 1 : 0;
         $data = array_filter($data, function ($value) {
             return ($value !== null && $value !== false);
         });

--- a/zmsentities/schema/dereferenced/calldisplay.json
+++ b/zmsentities/schema/dereferenced/calldisplay.json
@@ -823,7 +823,7 @@
                 "id": 456,
                 "name": "Flughafen",
                 "preferences": {
-                    "ticketPrinterProtectionEnabled": false
+                    "ticketPrinterActivation": false
                 },
                 "ticketprinters": [
                     {
@@ -859,12 +859,12 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "ticketPrinterProtectionEnabled": {
+                        "ticketPrinterActivation": {
                             "type": [
                                 "boolean",
                                 "number"
                             ],
-                            "description": "true if protection for ticket printer is enabled"
+                            "description": "true if kiosks must be explicitly activated before use"
                         }
                     }
                 },

--- a/zmsentities/schema/dereferenced/organisation.json
+++ b/zmsentities/schema/dereferenced/organisation.json
@@ -21,7 +21,7 @@
         "id": 456,
         "name": "Flughafen",
         "preferences": {
-            "ticketPrinterProtectionEnabled": false
+            "ticketPrinterActivation": false
         },
         "ticketprinters": [
             {
@@ -264,12 +264,12 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "ticketPrinterProtectionEnabled": {
+                "ticketPrinterActivation": {
                     "type": [
                         "boolean",
                         "number"
                     ],
-                    "description": "true if protection for ticket printer is enabled"
+                    "description": "true if kiosks must be explicitly activated before use"
                 }
             }
         },

--- a/zmsentities/schema/dereferenced/owner.json
+++ b/zmsentities/schema/dereferenced/owner.json
@@ -132,7 +132,7 @@
                     "id": 456,
                     "name": "Flughafen",
                     "preferences": {
-                        "ticketPrinterProtectionEnabled": false
+                        "ticketPrinterActivation": false
                     },
                     "ticketprinters": [
                         {
@@ -168,12 +168,12 @@
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
-                            "ticketPrinterProtectionEnabled": {
+                            "ticketPrinterActivation": {
                                 "type": [
                                     "boolean",
                                     "number"
                                 ],
-                                "description": "true if protection for ticket printer is enabled"
+                                "description": "true if kiosks must be explicitly activated before use"
                             }
                         }
                     },

--- a/zmsentities/schema/organisation.json
+++ b/zmsentities/schema/organisation.json
@@ -21,7 +21,7 @@
         "id": 456,
         "name": "Flughafen",
         "preferences": {
-            "ticketPrinterProtectionEnabled": false
+            "ticketPrinterActivation": false
         },
         "ticketprinters": [
             {
@@ -65,7 +65,7 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "ticketPrinterProtectionEnabled": {
+                "ticketPrinterActivation": {
                     "oneOf": [
                         {
                             "type": "number"
@@ -78,7 +78,7 @@
                             "pattern": "^[01]$"
                         }
                     ],
-                    "description": "true if protection for ticket printer is enabled"
+                    "description": "true if kiosks must be explicitly activated before use"
                 }
             }
         },

--- a/zmsentities/tests/Zmsentities/OrganisationTest.php
+++ b/zmsentities/tests/Zmsentities/OrganisationTest.php
@@ -12,7 +12,7 @@ class OrganisationTest extends EntityCommonTests
     {
         $entity = (new $this->entityclass())->getExample();
         $this->assertTrue($entity->hasDepartment(123), 'department with id 123 not found');
-        $this->assertFalse($entity->getPreference('ticketPrinterProtectionEnabled'), 'get preference failed');
+        $this->assertFalse($entity->getPreference('ticketPrinterActivation'), 'get preference failed');
     }
 
     public function testCollection()

--- a/zmsstatistic/tests/Zmsstatistic/fixtures/GET_organisation_71_resolved3.json
+++ b/zmsstatistic/tests/Zmsstatistic/fixtures/GET_organisation_71_resolved3.json
@@ -616,7 +616,7 @@
             "name": "Charlottenburg-Wilmersdorf"
         },
         "preferences": {
-            "ticketPrinterProtectionEnabled": "0"
+            "ticketPrinterActivation": "0"
         },
         "ticketprinters": [
             {

--- a/zmsticketprinter/src/Zmsticketprinter/Index.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Index.php
@@ -68,7 +68,7 @@ class Index extends BaseController
                 'urlQueryString' => $queryString,
                 'currentLang' => $currentLang,
                 'enabled' => $ticketprinter->isEnabled()
-                    || !$organisation->getPreference('ticketPrinterProtectionEnabled'),
+                    || !$organisation->getPreference('ticketPrinterActivation'),
                 'title' => 'Wartennumer ziehen',
                 'ticketprinter' => $ticketprinter,
                 'organisation' => $organisation,

--- a/zmsticketprinter/src/Zmsticketprinter/TicketprinterByScope.php
+++ b/zmsticketprinter/src/Zmsticketprinter/TicketprinterByScope.php
@@ -59,7 +59,7 @@ class TicketprinterByScope extends BaseController
             array(
                 'debug' => \App::DEBUG,
                 'enabled' => $ticketprinter->isEnabled()
-                    || !$organisation->getPreference('ticketPrinterProtectionEnabled'),
+                    || !$organisation->getPreference('ticketPrinterActivation'),
                 'title' => 'Wartennumer ziehen',
                 'ticketprinter' => $ticketprinter,
                 'organisation' => $organisation,

--- a/zmsticketprinter/tests/Zmsticketprinter/fixtures/GET_organisation_70.json
+++ b/zmsticketprinter/tests/Zmsticketprinter/fixtures/GET_organisation_70.json
@@ -17,7 +17,7 @@
       "name": "Lichtenberg"
     },
     "preferences": {
-      "ticketPrinterProtectionEnabled": "0"
+      "ticketPrinterActivation": "0"
     },
     "departments": [
       {

--- a/zmsticketprinter/tests/Zmsticketprinter/fixtures/GET_organisation_71.json
+++ b/zmsticketprinter/tests/Zmsticketprinter/fixtures/GET_organisation_71.json
@@ -17,7 +17,7 @@
       "name": "Charlottenburg-Wilmersdorf"
     },
     "preferences": {
-      "ticketPrinterProtectionEnabled": "0"
+      "ticketPrinterActivation": "0"
     },
     "departments": [
       {

--- a/zmsticketprinter/tests/Zmsticketprinter/fixtures/GET_organisation_78.json
+++ b/zmsticketprinter/tests/Zmsticketprinter/fixtures/GET_organisation_78.json
@@ -17,7 +17,7 @@
     "name": "Treptow-Köpenick",
     "id": "78",
     "preferences": {
-      "ticketPrinterProtectionEnabled": "0"
+      "ticketPrinterActivation": "0"
     },
     "departments": [
       {


### PR DESCRIPTION
This is not an actual security or password setting. The old name
(kioskpasswortschutz / ticketPrinterProtectionEnabled) suggested
password protection, but the feature only controls whether kiosks
must be explicitly activated before use (operational/UI control).
Renamed for clarity:
- DB column: kioskpasswortschutz → kiosk_activation
- API preference: ticketPrinterProtectionEnabled → ticketPrinterActivation

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
