### PR TITLE
fix(ZMSKVR-1256): hide spinner after response

### DIFF
--- a/zmsadmin/js/page/workstation/index.js
+++ b/zmsadmin/js/page/workstation/index.js
@@ -487,9 +487,11 @@ class View extends BaseView {
                     { 'name': 'dialog', 'value': 1 }
                 );
                 this.loadCall(`${this.includeUrl}/notification/`, 'POST', $.param(sendData)).then(
-                    (response) => this.loadMessage(response, () => {
+                    (response) => {
+                        hideSpinner($container);
+                        this.loadMessage(response, () => {
                     }, null, event.currentTarget)
-                );
+                });
             }), null, event.currentTarget)
         });
     }

--- a/zmsadmin/js/page/workstation/index.js
+++ b/zmsadmin/js/page/workstation/index.js
@@ -466,9 +466,11 @@ class View extends BaseView {
                     { 'name': 'dialog', 'value': 1 }
                 );
                 this.loadCall(`${this.includeUrl}/mail/`, 'POST', $.param(sendData), false, $container).then(
-                    (response) => this.loadMessage(response, () => {
+                    (response) => {
+                        hideSpinner($container);
+                        this.loadMessage(response, () => {
                     }, null, event.currentTarget)
-                );
+                });
             }), null, event.currentTarget)
         });
     }


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading spinner behavior when sending custom mail/notifications — the spinner now hides before the response message is displayed, preventing spinner overlap during message loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->