### PR TITLE
fix(ZMSKVR-1242): enlarge calendar when displaying six weeks 

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentSelection/CalendarView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection/CalendarView.vue
@@ -482,7 +482,10 @@ function onLater(type: "hour" | "dayPart") {
     .container-wrapper:has(
         .muc-calendar-view-full-size
           > .muc-calendar-container:nth-of-type(2)
-          > :nth-child(36)
+          > :nth-child(36) 
+          /* :nth-child(36) checks whether the day grid has at least 36 direct children.
+          With 7 columns, 35 items fit into 5 rows; the 36th item means a 6th row is needed,
+          so we increase the calendar height only for 6-week months. */
       )
       .container-view-size
   ) {

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection/CalendarView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection/CalendarView.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Calendar Component -->
-    <div class="m-component">
+    <div class="m-component calendar-root">
       <muc-calendar
         :key="calendarKey"
         :model-value="selectedDay"
@@ -475,5 +475,19 @@ function onLater(type: "hour" | "dayPart") {
 .no-top-margin,
 .no-top-margin h3 {
   margin-top: 0 !important;
+}
+
+.calendar-root
+  :deep(
+    .container-wrapper:has(
+        .muc-calendar-view-full-size
+          > .muc-calendar-container:nth-of-type(2)
+          > :nth-child(36)
+      )
+      .container-view-size
+  ) {
+  --cal-container-view-height: 336px !important;
+  height: var(--cal-container-view-height) !important;
+  min-height: var(--cal-container-view-height) !important;
 }
 </style>


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Scoped calendar styling added to the appointment selection view; sets a consistent container height (336px) for certain six-week month layouts to improve layout stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->