### PR TITLE
Revert "fix(ZMSKVR-1228): keyboard usable modal"

### DIFF
--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -202,10 +202,10 @@
     </muc-button>
   </div>
   <AvailabilityInfoModal
-    v-model:open="showAvailabilityInfoModal"
+    :show="showAvailabilityInfoModal"
     :html="availabilityInfoHtmlForModal"
     :closeAriaLabel="t('closeDialog')"
-    :t="t"
+    @close="closeAvailabilityInfoModal"
   />
 </template>
 <script setup lang="ts">

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection/AvailabilityInfoModal.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection/AvailabilityInfoModal.vue
@@ -1,33 +1,117 @@
 <template>
-  <muc-modal
-    :open="open"
-    :close-aria-label="closeAriaLabel"
-    @close="emit('update:open', false)"
+  <div
+    v-if="show"
+    class="modal fade show"
+    style="display: block"
+    tabindex="-1"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="dialogAriaLabel"
+    @click.self="$emit('close')"
   >
-    <template #title>
-      {{ t("newAppointmentsInfoLink") }}
-    </template>
-
-    <template #body>
-      <div v-html="sanitizedHtml"></div>
-    </template>
-  </muc-modal>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="standard-headline">
+            {{
+              t ? t("newAppointmentsInfoLink") : "Wann gibt es neue Termine?"
+            }}
+          </h2>
+          <button
+            type="button"
+            class="modal-button-close"
+            @click="$emit('close')"
+            :aria-label="closeAriaLabel || 'Dialog schliessen'"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon"
+            >
+              <use xlink:href="#icon-close"></use>
+            </svg>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div v-html="sanitizedHtml"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    v-if="show"
+    class="modal-backdrop fade show"
+    @click="$emit('close')"
+  ></div>
 </template>
 
 <script setup lang="ts">
-import { MucModal } from "@muenchen/muc-patternlab-vue";
 import { computed } from "vue";
 
 import { sanitizeHtml } from "@/utils/sanitizeHtml";
 
 const props = defineProps<{
-  open: boolean;
+  show: boolean;
   html: string;
-  closeAriaLabel: string;
-  t: (key: string) => string;
+  closeAriaLabel?: string;
+  dialogAriaLabel?: string;
+  t?: (key: string) => string;
 }>();
 
-const emit = defineEmits<(e: "update:open", value: boolean) => void>();
-
 const sanitizedHtml = computed(() => sanitizeHtml(props.html ?? ""));
+
+defineEmits<{
+  (e: "close"): void;
+}>();
 </script>
+
+<style>
+.modal-header {
+  padding: 1rem 1.5rem 0 1.5rem !important;
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+.modal-header h2 {
+  font-size: 1.75rem !important;
+}
+
+.modal-body {
+  padding: 0 1.5rem 1.5rem 1.5rem !important;
+}
+
+.modal-body h3 {
+  margin-top: 1.5rem !important;
+  margin-bottom: 0.5rem !important;
+  color: var(--color-neutrals-blue-dark);
+  font-weight: 600;
+}
+
+.modal-body div {
+  margin-bottom: 1rem;
+}
+
+.modal-body div:last-child {
+  margin-bottom: 0;
+}
+
+.modal-header .standard-headline {
+  margin: 0 0 1.5rem 0 !important;
+  color: var(--color-neutrals-blue-dark);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.2;
+  flex: 1;
+}
+
+.modal-button-close {
+  font-size: 1.75rem !important;
+  margin: 0 0 0 0 !important;
+  z-index: 10;
+  background: none;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+</style>

--- a/zmscitizenview/tests/setup/localStorageMock.ts
+++ b/zmscitizenview/tests/setup/localStorageMock.ts
@@ -2,8 +2,6 @@
  * Ensures tests always have a browser-like localStorage even when
  * NODE_OPTIONS or custom loaders replace jsdom's default implementation.
  */
-import { vi } from 'vitest';
-
 class LocalStorageMock implements Storage {
   private store = new Map<string, string>();
 
@@ -37,19 +35,8 @@ const isValidLocalStorage =
   typeof globalThis.localStorage?.getItem === "function";
 
 if (!isValidLocalStorage) {
-  globalThis.localStorage = new LocalStorageMock();
+  const mock = new LocalStorageMock();
+  globalThis.localStorage = mock;
 }
 
-if (typeof window !== 'undefined') {
-  Object.defineProperty(HTMLElement.prototype, 'showModal', {
-    configurable: true,
-    writable: true,
-    value: vi.fn(),
-  });
 
-  Object.defineProperty(HTMLElement.prototype, 'close', {
-    configurable: true,
-    writable: true,
-    value: vi.fn(),
-  });
-}

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
@@ -1813,7 +1813,7 @@ describe("AppointmentSelection", () => {
 
         // Programmatically set modal HTML and open
         (wrapper.vm as any).availabilityInfoHtmlOverride = 'Same info message';
-        wrapper.vm.showAvailabilityInfoModal = true;
+        (wrapper.vm as any).showAvailabilityInfoModal = true;
         await nextTick();
 
         // Modal should open and show the aggregated info
@@ -1857,7 +1857,7 @@ describe("AppointmentSelection", () => {
 
         // Programmatically set modal HTML and open (use computed grouped html)
         (wrapper.vm as any).availabilityInfoHtmlOverride = (wrapper.vm as any).noneSelectedAvailabilityInfoHtml;
-        wrapper.vm.showAvailabilityInfoModal = true;
+        (wrapper.vm as any).showAvailabilityInfoModal = true;
         await nextTick();
 
         // Modal should open and show the grouped info
@@ -1889,7 +1889,7 @@ describe("AppointmentSelection", () => {
         expect(callout.html()).not.toContain('newAppointmentsInfoLink');
         expect(callout.find('.m-button.m-button--ghost').exists()).toBe(false);
         // No modal should open from warning callout
-        expect(wrapper.find('.modal-body').isVisible()).toBe(false);
+        expect(wrapper.find('.modal-body').exists()).toBe(false);
       });
 
       it('should fallback to translation key when infoForAllAppointments is null', async () => {
@@ -2064,7 +2064,7 @@ describe("AppointmentSelection", () => {
         const trigger = callout.find('.m-button.m-button--ghost');
         // Warning callout no longer has a trigger; modal cannot be opened here
         expect(trigger.exists()).toBe(false);
-        expect(wrapper.find('.modal-body').isVisible()).toBe(false);
+        expect(wrapper.find('.modal-body').exists()).toBe(false);
       });
 
       it('should maintain existing functionality when infoForAllAppointments is not set', async () => {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/AvailabilityInfoModal.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/AvailabilityInfoModal.spec.ts
@@ -1,78 +1,201 @@
-import { mount } from "@vue/test-utils";
-import { describe, it, expect } from "vitest";
-import AvailabilityInfoModal from "@/components/Appointment/AppointmentSelection/AvailabilityInfoModal.vue";
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach } from 'vitest';
+// @ts-expect-error: Vue SFC import for test
+import AvailabilityInfoModal from '@/components/Appointment/AppointmentSelection/AvailabilityInfoModal.vue';
 
-const createWrapper = (props = {}) =>
-  mount(AvailabilityInfoModal, {
-    props: {
-      open: false,
-      html: "",
-      t: (key: string) => key,
-      ...props,
-    },
-    global: {
-      stubs: {
-        MucModal: {
-          props: ["open"],
-          emits: ["close"],
-          template: `
-            <div v-if="open" class="muc-modal">
-              <slot name="title"/>
-              <slot name="body"/>
-              <slot name="footer"/>
-              <button class="close" @click="$emit('close')" />
-            </div>
-          `,
-        },
+describe('AvailabilityInfoModal', () => {
+  let wrapper: ReturnType<typeof mount>;
+
+  const createWrapper = (props = {}) => {
+    return mount(AvailabilityInfoModal, {
+      props: {
+        show: false,
+        html: '',
+        t: (key: string) => key,
+        ...props,
       },
-    },
+    });
+  };
+
+  describe('Props', () => {
+    it('renders when show is true', () => {
+      wrapper = createWrapper({ show: true, html: 'Test content' });
+      expect(wrapper.find('.modal').exists()).toBe(true);
+      expect(wrapper.find('.modal-backdrop').exists()).toBe(true);
+    });
+
+    it('does not render when show is false', () => {
+      wrapper = createWrapper({ show: false, html: 'Test content' });
+      expect(wrapper.find('.modal').exists()).toBe(false);
+      expect(wrapper.find('.modal-backdrop').exists()).toBe(false);
+    });
+
+    it('displays html content correctly', () => {
+      const testHtml = '<p>Test <strong>content</strong></p>';
+      wrapper = createWrapper({ show: true, html: testHtml });
+      expect(wrapper.find('.modal-body').html()).toContain(testHtml);
+    });
+
+    it('handles empty html content', () => {
+      wrapper = createWrapper({ show: true, html: '' });
+      expect(wrapper.find('.modal-header .standard-headline').text()).toBe('newAppointmentsInfoLink');
+    });
+
+    it('handles HTML with special characters', () => {
+      const testHtml = '<p>Test &amp; content &lt;script&gt;alert("xss")&lt;/script&gt;</p>';
+      wrapper = createWrapper({ show: true, html: testHtml });
+      expect(wrapper.find('.modal-body').html()).toContain(testHtml);
+    });
   });
 
-describe("AvailabilityInfoModal", () => {
-  it("renders when open", () => {
-    const wrapper = createWrapper({ open: true });
+  describe('Modal Structure', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ show: true, html: 'Test content' });
+    });
 
-    expect(wrapper.find(".muc-modal").exists()).toBe(true);
+    it('has correct modal classes and attributes', () => {
+      const modal = wrapper.find('.modal');
+      expect(modal.classes()).toEqual(expect.arrayContaining(['fade', 'show']));
+      expect(modal.attributes('role')).toBe('dialog');
+      expect(modal.attributes('aria-modal')).toBe('true');
+    });
+
+    it('has modal-dialog with centered class', () => {
+      expect(wrapper.find('.modal-dialog').classes()).toContain('modal-dialog-centered');
+    });
+
+    it('has modal-header with close button', () => {
+      const header = wrapper.find('.modal-header');
+      expect(header.exists()).toBe(true);
+      
+      const closeButton = header.find('.modal-button-close');
+      expect(closeButton.exists()).toBe(true);
+      expect(closeButton.attributes('aria-label')).toBe('Dialog schliessen');
+    });
+
+    it('has modal-body with content', () => {
+      const body = wrapper.find('.modal-body');
+      expect(body.exists()).toBe(true);
+      expect(body.text()).toBe('Test content');
+    });
+
+    it('has standard headline H2 header', () => {
+      const header = wrapper.find('.modal-header .standard-headline');
+      expect(header.exists()).toBe(true);
+      expect(header.text()).toBe('newAppointmentsInfoLink');
+      expect(header.element.tagName).toBe('H2');
+    });
+
+    it('does not have modal-footer', () => {
+      expect(wrapper.find('.modal-footer').exists()).toBe(false);
+    });
+
+    it('has modal-backdrop', () => {
+      expect(wrapper.find('.modal-backdrop').exists()).toBe(true);
+      expect(wrapper.find('.modal-backdrop').classes()).toEqual(expect.arrayContaining(['fade', 'show']));
+    });
   });
 
-  it("does not render when closed", () => {
-    const wrapper = createWrapper({ open: false });
+  describe('Events', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ show: true, html: 'Test content' });
+    });
 
-    expect(wrapper.find(".muc-modal").exists()).toBe(false);
+    it('emits close event when close button is clicked', async () => {
+      const closeButton = wrapper.find('.modal-button-close');
+      await closeButton.trigger('click');
+      
+      expect(wrapper.emitted('close')).toBeTruthy();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('emits close event when clicking outside modal content', async () => {
+      const modal = wrapper.find('.modal');
+      await modal.trigger('click');
+      
+      expect(wrapper.emitted('close')).toBeTruthy();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('emits close event when clicking on backdrop', async () => {
+      const backdrop = wrapper.find('.modal-backdrop');
+      await backdrop.trigger('click');
+      
+      expect(wrapper.emitted('close')).toBeTruthy();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('does not emit close when clicking inside modal content', async () => {
+      const modalBody = wrapper.find('.modal-body');
+      await modalBody.trigger('click');
+      
+      expect(wrapper.emitted('close')).toBeFalsy();
+    });
   });
 
-  it("renders translated title", () => {
-    const wrapper = createWrapper({ open: true });
+  describe('Styling', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ show: true, html: 'Test content' });
+    });
 
-    expect(wrapper.text()).toContain("newAppointmentsInfoLink");
+    it('renders modal-body element', () => {
+      expect(wrapper.find('.modal-body').exists()).toBe(true);
+    });
+
+    it('has correct modal display style when shown', () => {
+      const modal = wrapper.find('.modal');
+      expect(modal.attributes('style')).toContain('display: block');
+    });
   });
 
-  it("renders provided HTML", () => {
-    const html = "<p>Test <strong>content</strong></p>";
-    const wrapper = createWrapper({ open: true, html });
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ show: true, html: 'Test content' });
+    });
 
-    expect(wrapper.html()).toContain(html);
+    it('has proper ARIA attributes', () => {
+      const modal = wrapper.find('.modal');
+      expect(modal.attributes('role')).toBe('dialog');
+      expect(modal.attributes('aria-modal')).toBe('true');
+    });
+
+    it('has close button with proper aria-label', () => {
+      const closeButton = wrapper.find('.modal-button-close');
+      expect(closeButton.attributes('aria-label')).toBe('Dialog schliessen');
+    });
+
+    it('close button has proper type attribute', () => {
+      const closeButton = wrapper.find('.modal-button-close');
+      expect(closeButton.attributes('type')).toBe('button');
+    });
   });
 
-  it("emits update:open false when modal emits close", async () => {
-    const wrapper = createWrapper({ open: true });
+  describe('Edge Cases', () => {
+    it('handles very long HTML content', () => {
+      const longHtml = '<p>' + 'A'.repeat(1000) + '</p>';
+      wrapper = createWrapper({ show: true, html: longHtml });
+      
+      expect(wrapper.find('.modal-body').html()).toContain(longHtml);
+    });
 
-    await wrapper.find(".close").trigger("click");
+    it('handles HTML with nested elements', () => {
+      const nestedHtml = '<div><p><span><strong>Nested</strong> content</span></p></div>';
+      wrapper = createWrapper({ show: true, html: nestedHtml });
+      
+      // Vue wraps the content in additional divs, so we check for the content within
+      expect(wrapper.find('.modal-body').text()).toContain('Nested content');
+      expect(wrapper.find('.modal-body strong').text()).toBe('Nested');
+    });
 
-    expect(wrapper.emitted("update:open")).toEqual([[false]]);
-  });
-
-  it("handles nested HTML content", () => {
-    const html = "<div><p><strong>Nested</strong> content</p></div>";
-    const wrapper = createWrapper({ open: true, html });
-
-    expect(wrapper.text()).toContain("Nested content");
-  });
-
-  it("handles long HTML content", () => {
-    const html = `<p>${"A".repeat(1000)}</p>`;
-    const wrapper = createWrapper({ open: true, html });
-
-    expect(wrapper.text()).toContain("A".repeat(10));
+    it('handles HTML with self-closing tags', () => {
+      const selfClosingHtml = '<p>Content</p><br><hr>';
+      wrapper = createWrapper({ show: true, html: selfClosingHtml });
+      
+      // Vue wraps the content in additional divs, so we check for the content within
+      expect(wrapper.find('.modal-body').text()).toContain('Content');
+      expect(wrapper.find('.modal-body p').exists()).toBe(true);
+      expect(wrapper.find('.modal-body br').exists()).toBe(true);
+      expect(wrapper.find('.modal-body hr').exists()).toBe(true);
+    });
   });
 });

--- a/zmscitizenview/vitest.config.ts
+++ b/zmscitizenview/vitest.config.ts
@@ -21,3 +21,5 @@ export default defineConfig({
     setupFiles: ["./tests/setup/localStorageMock.ts"]
   }
 })
+
+


### PR DESCRIPTION
Reverts it-at-m/eappointment#1933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced modal with improved close functionality, including close button and backdrop interaction support.
  * Added better accessibility features with ARIA labels and improved keyboard navigation support.

* **Tests**
  * Expanded test coverage for modal functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->