### PR TITLE
Revert "chore(deps-dev): bump svgo from 4.0.0 to 4.0.1 in /zmscalldisplay"

### DIFF
--- a/zmscalldisplay/package-lock.json
+++ b/zmscalldisplay/package-lock.json
@@ -20,7 +20,7 @@
         "postcss": "^8.5.8",
         "qrcode-generator": "2.0.4",
         "sass": "^1.98.0",
-        "svgo": "^4.0.1"
+        "svgo": "^4.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6181,14 +6181,11 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -6492,9 +6489,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6504,7 +6501,7 @@
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "^1.4.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"

--- a/zmscalldisplay/package.json
+++ b/zmscalldisplay/package.json
@@ -45,6 +45,6 @@
     "postcss": "^8.5.8",
     "qrcode-generator": "2.0.4",
     "sass": "^1.98.0",
-    "svgo": "^4.0.1"
+    "svgo": "^4.0.0"
   }
 }


### PR DESCRIPTION
Reverts it-at-m/eappointment#2053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build-time dependency for SVG optimization.

**Note:** This is a maintenance update with no impact to end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->