### PR TITLE
Potential fix for code scanning alert no. 207: Semicolon insertion

### DIFF
--- a/zmscitizenview/tests/unit/Appointment/ServiceFinder.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/ServiceFinder.spec.ts
@@ -98,7 +98,7 @@ describe("ServiceFinder", () => {
 
   afterAll(() => {
     vi.unstubAllGlobals();
-  })
+  });
 
   const mockProvider = {
     id: "1",


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/eappointment/security/code-scanning/207](https://github.com/it-at-m/eappointment/security/code-scanning/207)

To fix this, explicitly terminate the `afterAll(...)` statement with a semicolon.

Best fix (without changing functionality):
- In `zmscitizenview/tests/unit/Appointment/ServiceFinder.spec.ts`, update the closing line of the `afterAll` call from `})` to `});`.
- No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this release.** This update contains only internal test file maintenance with no impact on end-user functionality or features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->