### PR TITLE
Potential fix for code scanning alert no. 193: Unused or undefined state property

### DIFF
--- a/zmsadmin/js/block/ticketprinter/config/index.js
+++ b/zmsadmin/js/block/ticketprinter/config/index.js
@@ -52,7 +52,6 @@ class TicketPrinterConfigView extends Component {
                     scopes: scopes.map(readPropsScope)
                 }
             }),
-            generatedUrl: "",
             homeUrl: "",
             template: "default",
             ticketPrinterName: ""


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/eappointment/security/code-scanning/193](https://github.com/it-at-m/eappointment/security/code-scanning/193)

Remove the unused `generatedUrl` entry from `this.state` in `TicketPrinterConfigView`’s constructor.

Best fix without changing behavior:
- In `zmsadmin/js/block/ticketprinter/config/index.js`, edit the constructor state object and delete only `generatedUrl: ""`.
- Keep all other state properties unchanged (`selectedItems`, `departments`, `homeUrl`, `template`, `ticketPrinterName`).
- No new methods/imports/dependencies are needed.

This resolves the “written but never read” state property warning while preserving current runtime behavior, since URL creation already happens via `buildUrl()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
