### PR TITLE
Potential fix for code scanning alert no. 194: Unused or undefined state property

### DIFF
--- a/zmsadmin/js/page/availabilityDay/form/datepicker.js
+++ b/zmsadmin/js/page/availabilityDay/form/datepicker.js
@@ -17,12 +17,11 @@ class AvailabilityDatePicker extends Component
     constructor(props) {
         super(props);
         this.state = {
-            kind: this.props.attributes.kind,            
             availability: this.props.attributes.availability,
-            availabilityList: this.props.attributes.availabilitylist,
             minDate: moment.unix(this.props.attributes.availability.startDate).toDate(),
             minTime: setHours(setMinutes(new Date(), 1), 0),
             maxTime: setHours(setMinutes(new Date(), 59), 23),
+            excludeTimeList: [],
             datePickerIsOpen: false,
             timePickerIsOpen: false,
             timePickerInitialized: this.props.attributes.availability.kind !== "new"
@@ -77,7 +76,6 @@ class AvailabilityDatePicker extends Component
         }
         this.setState({
             availability: this.props.attributes.availability,
-            availabilityList: this.props.attributes.availabilitylist,
             selectedDate: selectedDate,
             timePickerInitialized: this.props.attributes.availability.kind !== "new" || (selectedTime && selectedTime.format("H") != 0)
         })


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/eappointment/security/code-scanning/194](https://github.com/it-at-m/eappointment/security/code-scanning/194)

General fix approach:
1. Remove unused state keys (`kind`, `availabilityList`) from state initialization and state updates.
2. Initialize `excludeTimeList` in state to a safe default (`[]`) since it is read in render and never written in shown code.

Best single fix (no behavior change):
- In `zmsadmin/js/page/availabilityDay/form/datepicker.js`:
  - In the constructor `this.state = { ... }`, delete `kind` and `availabilityList`, add `excludeTimeList: []`.
  - In `updateState`, remove `availabilityList` from `this.setState({...})`.
This keeps runtime behavior stable while resolving all 4 variants:
- 2x `availabilityList` written-never-read
- 1x `kind` written-never-read
- 1x `excludeTimeList` read-never-written

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the time picker's exclusion logic in the availability date picker to properly handle excluded times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->