### PR TITLE
fix(ZMSKVR): for code scanning alert no. 98: Client-side cross-site scripting

### DIFF
--- a/zmscitizenview/src/components/AppointmentDetail/AppointmentDetailView.vue
+++ b/zmscitizenview/src/components/AppointmentDetail/AppointmentDetailView.vue
@@ -501,7 +501,7 @@ function setBreadcrumbAndTitle(appointmentId: string) {
     '[data-fragment-placeholder="breadcrumb-label"]'
   );
   if (element) {
-    element.innerHTML = appointmentId;
+    element.textContent = appointmentId;
   }
   const titleSeperator = "–";
   const splittedTitle = document.title.split(titleSeperator);


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/eappointment/security/code-scanning/98](https://github.com/it-at-m/eappointment/security/code-scanning/98)

To fix this safely without changing functionality, avoid HTML parsing for untrusted content. Use `textContent` instead of `innerHTML` when setting the breadcrumb label so the value is rendered as plain text. This preserves visible output while preventing script/HTML execution. The document title assignment is not an HTML sink, so it can remain as-is.

**File/region to change:**
- `zmscitizenview/src/components/AppointmentDetail/AppointmentDetailView.vue`
- In `setBreadcrumbAndTitle(...)`, replace the `innerHTML` assignment.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security handling of appointment ID display in breadcrumb navigation to prevent potential interpretation of special characters and HTML content, ensuring the appointment ID displays as plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->