### PR TITLE
fix(ZMSKVR): code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/zmsadmin/js/lib/utils.js
+++ b/zmsadmin/js/lib/utils.js
@@ -69,7 +69,7 @@ export const getFieldList = (field) => {
     let match;
     let reg = RegExp('([^[]+)', 'g');
     while ((match = reg.exec(field))) {
-        fieldList.push(match.pop().replace(']', ''))
+        fieldList.push(match.pop().replace(/\]/g, ''))
     }
     return fieldList;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/eappointment/security/code-scanning/4](https://github.com/it-at-m/eappointment/security/code-scanning/4)

Use a global regular expression for the `]` removal so all occurrences are stripped, not only the first.  
Best minimal fix (no behavior change beyond correctness): in `zmsadmin/js/lib/utils.js`, line 72 region, change:

- from: `match.pop().replace(']', '')`
- to: `match.pop().replace(/\]/g, '')`

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field extraction parsing to properly handle multiple occurrences of special characters in field names, resolving parsing errors that occurred when field identifiers contained repeated special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->