### PR TITLE
fix(ZMSKVR): for code scanning alert no. 195: Unused or undefined state property

### DIFF
--- a/zmsadmin/js/page/sourceEdit/index.js
+++ b/zmsadmin/js/page/sourceEdit/index.js
@@ -22,13 +22,13 @@ class SourceView extends Component {
         } else {
             newstate = deepMerge(newstate, makeNestedObj(fieldList, value))
         }
-        this.setState({ source: newstate });
+        if (this.props.onSourceChange) this.props.onSourceChange(newstate)
     }
 
     addNewHandler(field, props) {
         let newstate = this.props.source
         newstate[field] = this.props.source[field].concat(props)
-        this.setState({ source: newstate })
+        if (this.props.onSourceChange) this.props.onSourceChange(newstate)
     }
 
     deleteHandler(field, deleteIndex) {
@@ -36,7 +36,7 @@ class SourceView extends Component {
         newstate[field] = this.props.source[field].filter((item, index) => {
             return index !== deleteIndex
         })
-        this.setState({ source: newstate })
+        if (this.props.onSourceChange) this.props.onSourceChange(newstate)
     }
 
     componentDidMount() {
@@ -95,6 +95,7 @@ class SourceView extends Component {
 
 SourceView.propTypes = {
     source: PropTypes.object,
+    onSourceChange: PropTypes.func,
     parentProviders: PropTypes.array.isRequired,
     parentrequests: PropTypes.array.isRequired,
 }


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/eappointment/security/code-scanning/195](https://github.com/it-at-m/eappointment/security/code-scanning/195)

General fix: remove unused component state writes and use a proper data flow mechanism. Since this component currently renders from `this.props.source`, updates should be propagated to the owner of `source` via a callback prop (for example, `onSourceChange`) instead of writing to local state.

Best fix in this file:
- In `changeHandler`, `addNewHandler`, and `deleteHandler`, replace `this.setState({ source: newstate })` with a guarded callback invocation:
  - `if (this.props.onSourceChange) this.props.onSourceChange(newstate)`
- Extend `propTypes` to declare `onSourceChange` as an optional function.
- Keep all existing rendering behavior unchanged (`render` still uses `this.props.source`).

This resolves all three alert variants because all three writes to unused `state.source` are removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal state management in the source editor component to support external callback delegation, improving component flexibility for integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->