### PR TITLE
fix-zmskvr-1363: Druckdialog wird nur in process.js getriggert

### DIFF
--- a/zmsticketprinter/templates/page/process.twig
+++ b/zmsticketprinter/templates/page/process.twig
@@ -8,11 +8,6 @@
 
 <div class="boxontop">
 	{{ block("print") }}
-	<script>
-		window.onload = function() {
-			window.print();
-		}
-	</script>
 	<div class="noprint">
 		<div style="display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center;">
 			<span class="msg_wartenummer_lautet">


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic print dialog that appeared when the ticket page loaded. Users can now manually trigger printing when ready, while the automatic redirect after 10 seconds is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->