### PR TITLE
fix(ZMSKVR-1372): align waiting exchange addDataSet with waytime dictionary incorrect order

### DIFF
--- a/zmsdb/src/Zmsdb/ExchangeWaitingdepartment.php
+++ b/zmsdb/src/Zmsdb/ExchangeWaitingdepartment.php
@@ -49,12 +49,12 @@ class ExchangeWaitingdepartment extends Base implements Interfaces\ExchangeSubje
                         $hour,
                         $entry[sprintf('hour_%02d_waiting_count_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_waiting_time_spontaneous', $hour)],
-                        $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_way_time_spontaneous', $hour)],
+                        $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_waiting_count_appointment', $hour)],
                         $entry[sprintf('hour_%02d_waiting_time_appointment', $hour)],
-                        $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                         $entry[sprintf('hour_%02d_way_time_appointment', $hour)],
+                        $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                     ]);
                 }
             }

--- a/zmsdb/src/Zmsdb/ExchangeWaitingorganisation.php
+++ b/zmsdb/src/Zmsdb/ExchangeWaitingorganisation.php
@@ -50,12 +50,12 @@ class ExchangeWaitingorganisation extends Base implements Interfaces\ExchangeSub
                         $hour,
                         $entry[sprintf('hour_%02d_waiting_count_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_waiting_time_spontaneous', $hour)],
-                        $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_way_time_spontaneous', $hour)],
+                        $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_waiting_count_appointment', $hour)],
                         $entry[sprintf('hour_%02d_waiting_time_appointment', $hour)],
-                        $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                         $entry[sprintf('hour_%02d_way_time_appointment', $hour)],
+                        $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                     ]);
                 }
                 $entry = array_shift($raw);

--- a/zmsdb/src/Zmsdb/ExchangeWaitingowner.php
+++ b/zmsdb/src/Zmsdb/ExchangeWaitingowner.php
@@ -50,12 +50,12 @@ class ExchangeWaitingowner extends Base implements Interfaces\ExchangeSubject
                         $hour,
                         $entry[sprintf('hour_%02d_waiting_count_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_waiting_time_spontaneous', $hour)],
-                        $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_way_time_spontaneous', $hour)],
+                        $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                         $entry[sprintf('hour_%02d_waiting_count_appointment', $hour)],
                         $entry[sprintf('hour_%02d_waiting_time_appointment', $hour)],
-                        $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                         $entry[sprintf('hour_%02d_way_time_appointment', $hour)],
+                        $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                     ]);
                 }
                 $entry = array_shift($raw);

--- a/zmsdb/src/Zmsdb/ExchangeWaitingscope.php
+++ b/zmsdb/src/Zmsdb/ExchangeWaitingscope.php
@@ -52,8 +52,8 @@ class ExchangeWaitingscope extends Base implements Interfaces\ExchangeSubject
                     $entry[sprintf('hour_%02d_estimated_waiting_time_spontaneous', $hour)],
                     $entry[sprintf('hour_%02d_waiting_count_appointment', $hour)],
                     $entry[sprintf('hour_%02d_waiting_time_appointment', $hour)],
-                    $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                     $entry[sprintf('hour_%02d_way_time_appointment', $hour)],
+                    $entry[sprintf('hour_%02d_estimated_waiting_time_appointment', $hour)],
                 ]);
             }
         }


### PR DESCRIPTION
Exchange maps positional values to waytime then waitingcalculated (and *_termin). PR #2169 column renames listed estimated before way_time for appointment in scope, and for both buckets in department/organisation/owner, so waytime_termin showed estimated (often zero) instead of way_time_appointment.

Order hour_*_way_time_* before hour_*_estimated_waiting_time_* everywhere.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
