### PR TITLE
fix(ZMSKVR-1375): remove family name as process auth token

### DIFF
--- a/zmsapi/src/Zmsapi/ProcessConfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirm.php
@@ -107,7 +107,7 @@ class ProcessConfirm extends BaseController
         $authCheck = (new Process())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] !== $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessConfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirm.php
@@ -107,7 +107,7 @@ class ProcessConfirm extends BaseController
         $authCheck = (new Process())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessConfirmationMail.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirmationMail.php
@@ -70,7 +70,7 @@ class ProcessConfirmationMail extends BaseController
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $process->authKey && $authCheck['authName'] != $process->authKey) {
+        } elseif ($authCheck['authKey'] != $process->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         } elseif (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&

--- a/zmsapi/src/Zmsapi/ProcessConfirmationMail.php
+++ b/zmsapi/src/Zmsapi/ProcessConfirmationMail.php
@@ -70,7 +70,7 @@ class ProcessConfirmationMail extends BaseController
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $process->authKey) {
+        } elseif ($authCheck['authKey'] !== $process->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         } elseif (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&

--- a/zmsapi/src/Zmsapi/ProcessDelete.php
+++ b/zmsapi/src/Zmsapi/ProcessDelete.php
@@ -83,8 +83,7 @@ class ProcessDelete extends BaseController
         if (!$process) {
             throw new Exception\Process\ProcessNotFound();
         }
-        $authName = $process->getFirstClient()['familyName'];
-        if ($process['authKey'] != $authKey && $authName != $authKey) {
+        if ($process['authKey'] != $authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessDelete.php
+++ b/zmsapi/src/Zmsapi/ProcessDelete.php
@@ -83,7 +83,7 @@ class ProcessDelete extends BaseController
         if (!$process) {
             throw new Exception\Process\ProcessNotFound();
         }
-        if ($process['authKey'] != $authKey) {
+        if ($process['authKey'] !== $authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessFinished.php
+++ b/zmsapi/src/Zmsapi/ProcessFinished.php
@@ -82,7 +82,7 @@ class ProcessFinished extends BaseController
         $processCheck = (new Process())->readEntity($process->id, new \BO\Zmsdb\Helper\NoAuth());
         if (null === $processCheck || false === $processCheck->hasId()) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($processCheck->authKey != $process->authKey) {
+        } elseif ($processCheck->authKey !== $process->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessGet.php
+++ b/zmsapi/src/Zmsapi/ProcessGet.php
@@ -38,7 +38,7 @@ class ProcessGet extends BaseController
         $authCheck = (new Process())->readAuthKeyByProcessId($processId);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $authKey) {
+        } elseif ($authCheck['authKey'] !== $authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessGet.php
+++ b/zmsapi/src/Zmsapi/ProcessGet.php
@@ -38,7 +38,7 @@ class ProcessGet extends BaseController
         $authCheck = (new Process())->readAuthKeyByProcessId($processId);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $authKey && $authCheck['authName'] != $authKey) {
+        } elseif ($authCheck['authKey'] != $authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessIcs.php
+++ b/zmsapi/src/Zmsapi/ProcessIcs.php
@@ -44,7 +44,7 @@ class ProcessIcs extends BaseController
         $authCheck = (new Process())->readAuthKeyByProcessId($processId);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $authKey && $authCheck['authName'] != $authKey) {
+        } elseif ($authCheck['authKey'] != $authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessIcs.php
+++ b/zmsapi/src/Zmsapi/ProcessIcs.php
@@ -44,7 +44,7 @@ class ProcessIcs extends BaseController
         $authCheck = (new Process())->readAuthKeyByProcessId($processId);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $authKey) {
+        } elseif ($authCheck['authKey'] !== $authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessPreconfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirm.php
@@ -66,7 +66,7 @@ class ProcessPreconfirm extends BaseController
 
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] !== $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessPreconfirm.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirm.php
@@ -66,7 +66,7 @@ class ProcessPreconfirm extends BaseController
 
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessPreconfirmationMail.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirmationMail.php
@@ -68,7 +68,7 @@ class ProcessPreconfirmationMail extends BaseController
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $process->authKey) {
+        } elseif ($authCheck['authKey'] !== $process->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         } elseif (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&

--- a/zmsapi/src/Zmsapi/ProcessPreconfirmationMail.php
+++ b/zmsapi/src/Zmsapi/ProcessPreconfirmationMail.php
@@ -68,7 +68,7 @@ class ProcessPreconfirmationMail extends BaseController
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $process->authKey && $authCheck['authName'] != $process->authKey) {
+        } elseif ($authCheck['authKey'] != $process->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         } elseif (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&

--- a/zmsapi/src/Zmsapi/ProcessQueued.php
+++ b/zmsapi/src/Zmsapi/ProcessQueued.php
@@ -65,7 +65,7 @@ class ProcessQueued extends BaseController
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] !== $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
         Helper\Matching::testCurrentScopeHasRequest($entity);

--- a/zmsapi/src/Zmsapi/ProcessQueued.php
+++ b/zmsapi/src/Zmsapi/ProcessQueued.php
@@ -65,7 +65,7 @@ class ProcessQueued extends BaseController
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
         Helper\Matching::testCurrentScopeHasRequest($entity);

--- a/zmsapi/src/Zmsapi/ProcessRedirect.php
+++ b/zmsapi/src/Zmsapi/ProcessRedirect.php
@@ -58,7 +58,7 @@ class ProcessRedirect extends BaseController
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessRedirect.php
+++ b/zmsapi/src/Zmsapi/ProcessRedirect.php
@@ -58,7 +58,7 @@ class ProcessRedirect extends BaseController
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] !== $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessUpdate.php
+++ b/zmsapi/src/Zmsapi/ProcessUpdate.php
@@ -118,7 +118,7 @@ class ProcessUpdate extends BaseController
 
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] !== $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/ProcessUpdate.php
+++ b/zmsapi/src/Zmsapi/ProcessUpdate.php
@@ -118,7 +118,7 @@ class ProcessUpdate extends BaseController
 
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
     }

--- a/zmsapi/src/Zmsapi/WorkstationProcess.php
+++ b/zmsapi/src/Zmsapi/WorkstationProcess.php
@@ -122,7 +122,7 @@ class WorkstationProcess extends BaseController
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] !== $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
         Helper\Matching::testCurrentScopeHasRequest($entity);

--- a/zmsapi/src/Zmsapi/WorkstationProcess.php
+++ b/zmsapi/src/Zmsapi/WorkstationProcess.php
@@ -122,7 +122,7 @@ class WorkstationProcess extends BaseController
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
             throw new Exception\Process\ProcessNotFound();
-        } elseif ($authCheck['authKey'] != $entity->authKey && $authCheck['authName'] != $entity->authKey) {
+        } elseif ($authCheck['authKey'] != $entity->authKey) {
             throw new Exception\Process\AuthKeyMatchFailed();
         }
         Helper\Matching::testCurrentScopeHasRequest($entity);

--- a/zmsapi/tests/Zmsapi/ProcessDeleteTest.php
+++ b/zmsapi/tests/Zmsapi/ProcessDeleteTest.php
@@ -70,6 +70,13 @@ class ProcessDeleteTest extends Base
         $this->render(['id' => '10030', 'authKey' => $this->authKey], [], []); //day off Beispiel Termin
     }
 
+    public function testFamilyNameIsNotAcceptedAsAuthKey()
+    {
+        $this->expectException('BO\Zmsapi\Exception\Process\AuthKeyMatchFailed');
+        $this->expectExceptionCode(403);
+        $this->render(['id' => '10030', 'authKey' => 'Dayoff'], [], []);
+    }
+
     public function testFailedDelete()
     {
         $this->expectException('BO\Zmsapi\Exception\Process\ProcessNotFound');

--- a/zmsapi/tests/Zmsapi/ProcessGetTest.php
+++ b/zmsapi/tests/Zmsapi/ProcessGetTest.php
@@ -82,4 +82,11 @@ class ProcessGetTest extends Base
         $this->expectExceptionCode(403);
         $this->render(['id' => 10030, 'authKey' => null], [], []);
     }
+
+    public function testFamilyNameIsNotAcceptedAsAuthKey()
+    {
+        $this->expectException('\BO\Zmsapi\Exception\Process\AuthKeyMatchFailed');
+        $this->expectExceptionCode(403);
+        $this->render(['id' => 10030, 'authKey' => 'Dayoff'], [], []);
+    }
 }

--- a/zmsapi/tests/Zmsapi/ProcessIcsTest.php
+++ b/zmsapi/tests/Zmsapi/ProcessIcsTest.php
@@ -32,4 +32,11 @@ class ProcessIcsTest extends Base
         $this->expectExceptionCode(403);
         $this->render(['id' => 10030, 'authKey' => null], [], []);
     }
+
+    public function testFamilyNameIsNotAcceptedAsAuthKey()
+    {
+        $this->expectException('\BO\Zmsapi\Exception\Process\AuthKeyMatchFailed');
+        $this->expectExceptionCode(403);
+        $this->render(['id' => 10030, 'authKey' => 'Dayoff'], [], []);
+    }
 }

--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -291,12 +291,9 @@ class Process extends Base implements Interfaces\ResolveReferences
     }
 
     /**
-     * Read authKey by processId
+     * Read auth data by processId (for request-side auth checks).
      *
-     * @param
-     * processId
-     *
-     * @return String authKey
+     * @return array{authKey: string}|null
      */
     public function readAuthKeyByProcessId($processId)
     {
@@ -307,7 +304,6 @@ class Process extends Base implements Interfaces\ResolveReferences
             ->addConditionProcessId($processId);
         $process = $this->fetchOne($query, new Entity());
         return ($process->hasId()) ? array(
-            'authName' => $process->getFirstClient()['familyName'],
             'authKey' => $process->authKey
         ) : null;
     }

--- a/zmsdb/src/Zmsdb/Query/Process.php
+++ b/zmsdb/src/Zmsdb/Query/Process.php
@@ -548,12 +548,7 @@ class Process extends Base implements MappingInterface
     public function addConditionAuthKey($authKey)
     {
         $authKey = urldecode($authKey);
-        $this->query
-            ->where(function (\BO\Zmsdb\Query\Builder\ConditionBuilder $condition) use ($authKey) {
-                $condition
-                    ->andWith('process.absagecode', '=', $authKey)
-                    ->orWith('process.Name', '=', $authKey);
-            });
+        $this->query->where('process.absagecode', '=', $authKey);
         return $this;
     }
 


### PR DESCRIPTION
Remove authName fallback from handlers and readAuthKeyByProcessId. Restrict addConditionAuthKey to absagecode only (no process.Name OR). Add regression tests ensuring familyName is not accepted as authKey.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication validation across process-related endpoints to require exact key matching, removing fallback credential acceptance paths.

* **Tests**
  * Added test coverage for stricter authentication requirements on process endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->