### PR TITLE
fix(ZMSKVR-1352): slot time in minutes fallback to provider

### DIFF
--- a/zmsadmin/src/Zmsadmin/Helper/GraphDefaults.php
+++ b/zmsadmin/src/Zmsadmin/Helper/GraphDefaults.php
@@ -350,6 +350,7 @@ EOS;
             name 
             data { 
                 payment 
+                slotTimeInMinutes
             }
         }
         preferences{

--- a/zmsadmin/src/Zmsadmin/QueueTable.php
+++ b/zmsadmin/src/Zmsadmin/QueueTable.php
@@ -7,7 +7,6 @@
 
 namespace BO\Zmsadmin;
 
-use BO\Zmsadmin\Helper\ClusterHelper;
 use BO\Zmsentities\Collection\QueueList;
 
 class QueueTable extends BaseController
@@ -66,7 +65,7 @@ class QueueTable extends BaseController
             )
             ->getCollection() ?? []) : [];
 
-        if ($queueListCalled instanceof \BO\Zmsentities\Collection\QueueList) {
+        if ($queueListCalled instanceof QueueList) {
             $queueListCalled->uasort(function ($queueA, $queueB) {
                 $statusOrder = ['called' => 0, 'processing' => 1];
 

--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -434,7 +434,9 @@
 									{% set appointment = item.appointments|first %}
 									{% set providerSlotTimeInMinutes = item.scope.provider.data.slotTimeInMinutes|default(null) %}
 									{% set availabilitySlotTimeInMinutes = appointment.availability.slotTimeInMinutes|default(null) %}
-									{% set slotTimeInMinutes = providerSlotTimeInMinutes|default(availabilitySlotTimeInMinutes) %}
+									{% set slotTimeInMinutes = (appointment.availability.id|default(0) > 0)
+										? availabilitySlotTimeInMinutes
+										: providerSlotTimeInMinutes|default(availabilitySlotTimeInMinutes) %}
 									{% set duration = slotTimeInMinutes * appointment.slotCount %}
 									{{ duration }}&nbsp;Min.
 								{% endif %}

--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -431,7 +431,11 @@
 									{% endif %}
 							<td class="nowrap">
 								{% if item.queue.withAppointment %}
-									{% set duration = item.appointments|first.availability.slotTimeInMinutes * item.appointments|first.slotCount %}
+									{% set appointment = item.appointments|first %}
+									{% set providerSlotTimeInMinutes = item.scope.provider.data.slotTimeInMinutes|default(null) %}
+									{% set availabilitySlotTimeInMinutes = appointment.availability.slotTimeInMinutes|default(null) %}
+									{% set slotTimeInMinutes = providerSlotTimeInMinutes|default(availabilitySlotTimeInMinutes) %}
+									{% set duration = slotTimeInMinutes * appointment.slotCount %}
 									{{ duration }}&nbsp;Min.
 								{% endif %}
 							</td>

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -155,4 +155,66 @@ class QueueTableTest extends Base
         $response = $this->render($this->arguments, $this->parameters, []);
         $this->assertStringContainsString('Alle Clusterstandorte anzeigen', (string)$response->getBody());
     }
+
+    public function testUsesProviderSlotTimeWhenAvailabilityIsMissing()
+    {
+        $processFixture = json_decode($this->readFixture("GET_processList_141_20160401.json"), true);
+        $firstProcess = &$processFixture['data']['0'];
+        $firstProcess['appointments'][0]['availability']['id'] = "0";
+        $firstProcess['appointments'][0]['availability']['slotTimeInMinutes'] = "10";
+        $firstProcess['appointments'][0]['slotCount'] = "2";
+        $firstProcess['scope'] = [
+            'id' => '141',
+            'provider' => [
+                'data' => [
+                    'slotTimeInMinutes' => 12
+                ]
+            ]
+        ];
+        $processFixtureJson = json_encode($processFixture);
+
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => [
+                        'resolveReferences' => 1,
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getWorkstation()
+                    ],
+                    'response' => $this->readFixture("GET_Workstation_Resolved2.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/department/',
+                    'response' => $this->readFixture("GET_department_74.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/cluster/',
+                    'response' => $this->readFixture("GET_cluster_109.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/process/2016-04-01/',
+                    'parameters' => [
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getProcess()
+                    ],
+                    'response' => $processFixtureJson
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/useraccount/queue/',
+                    'parameters' => [
+                        'resolveReferences' => 2,
+                        'status' => 'called,processing',
+                    ],
+                    'response' => $this->readFixture("GET_queuelist_141.json")
+                ]
+            ]
+        );
+
+        $response = $this->render($this->arguments, $this->parameters, []);
+        $this->assertStringContainsString('24&nbsp;Min.', (string)$response->getBody());
+    }
 }

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -217,4 +217,66 @@ class QueueTableTest extends Base
         $response = $this->render($this->arguments, $this->parameters, []);
         $this->assertStringContainsString('24&nbsp;Min.', (string)$response->getBody());
     }
+
+    public function testUsesAvailabilitySlotTimeWhenAvailabilityAndProviderArePresent()
+    {
+        $processFixture = json_decode($this->readFixture("GET_processList_141_20160401.json"), true);
+        $firstProcess = &$processFixture['data']['0'];
+        $firstProcess['appointments'][0]['availability']['id'] = "68985";
+        $firstProcess['appointments'][0]['availability']['slotTimeInMinutes'] = "10";
+        $firstProcess['appointments'][0]['slotCount'] = "2";
+        $firstProcess['scope'] = [
+            'id' => '141',
+            'provider' => [
+                'data' => [
+                    'slotTimeInMinutes' => 12
+                ]
+            ]
+        ];
+        $processFixtureJson = json_encode($processFixture);
+
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => [
+                        'resolveReferences' => 1,
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getWorkstation()
+                    ],
+                    'response' => $this->readFixture("GET_Workstation_Resolved2.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/department/',
+                    'response' => $this->readFixture("GET_department_74.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/cluster/',
+                    'response' => $this->readFixture("GET_cluster_109.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/process/2016-04-01/',
+                    'parameters' => [
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getProcess()
+                    ],
+                    'response' => $processFixtureJson
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/useraccount/queue/',
+                    'parameters' => [
+                        'resolveReferences' => 2,
+                        'status' => 'called,processing',
+                    ],
+                    'response' => $this->readFixture("GET_queuelist_141.json")
+                ]
+            ]
+        );
+
+        $response = $this->render($this->arguments, $this->parameters, []);
+        $this->assertStringContainsString('20&nbsp;Min.', (string)$response->getBody());
+    }
 }

--- a/zmsapi/src/Zmsapi/ProcessListByClusterAndDate.php
+++ b/zmsapi/src/Zmsapi/ProcessListByClusterAndDate.php
@@ -59,7 +59,7 @@ class ProcessListByClusterAndDate extends BaseController
                 $cluster->id,
                 $date,
                 2,
-                ['availability']
+                ['availability', 'scope', 'scopeprovider']
             );
 
             if (! $dateQueueList) {

--- a/zmsapi/src/Zmsapi/ProcessListByScopeAndDate.php
+++ b/zmsapi/src/Zmsapi/ProcessListByScopeAndDate.php
@@ -53,7 +53,7 @@ class ProcessListByScopeAndDate extends BaseController
                 $scope,
                 $date,
                 2,
-                ['availability']
+                ['availability', 'scope', 'scopeprovider']
             ));
         }
 

--- a/zmsapi/tests/Zmsapi/ProcessListByClusterAndDateTest.php
+++ b/zmsapi/tests/Zmsapi/ProcessListByClusterAndDateTest.php
@@ -34,4 +34,22 @@ class ProcessListByClusterAndDateTest extends Base
         $this->expectExceptionCode(404);
         $this->render(['id' => 999, 'date' => '2016-04-01'], [], []);
     }
+
+    public function testProviderSlotTimeIsPresentInProcessScope()
+    {
+        $this->setWorkstation();
+        User::$workstation->useraccount->setRights('cluster');
+        $response = $this->render(['id' => 109, 'date' => '2016-04-01'], [], []);
+        $payload = json_decode((string)$response->getBody(), true);
+
+        $this->assertIsArray($payload['data']);
+        $this->assertNotEmpty($payload['data']);
+
+        $firstProcess = reset($payload['data']);
+        $this->assertArrayHasKey('scope', $firstProcess);
+        $this->assertArrayHasKey('provider', $firstProcess['scope']);
+        $this->assertArrayHasKey('data', $firstProcess['scope']['provider']);
+        $this->assertArrayHasKey('slotTimeInMinutes', $firstProcess['scope']['provider']['data']);
+        $this->assertEquals(12, (int) $firstProcess['scope']['provider']['data']['slotTimeInMinutes']);
+    }
 }

--- a/zmsapi/tests/Zmsapi/ProcessListByScopeAndDateTest.php
+++ b/zmsapi/tests/Zmsapi/ProcessListByScopeAndDateTest.php
@@ -49,4 +49,22 @@ class ProcessListByScopeAndDateTest extends Base
         $this->assertStringContainsString('process.json', (string)$response->getBody());
         $this->assertTrue(200 == $response->getStatusCode());
     }
+
+    public function testProviderSlotTimeIsPresentInProcessScope()
+    {
+        $this->setWorkstation();
+        User::$workstation->useraccount->setRights('scope');
+        $response = $this->render(['id' => 141, 'date' => '2016-04-01'], [], []);
+        $payload = json_decode((string)$response->getBody(), true);
+
+        $this->assertIsArray($payload['data']);
+        $this->assertNotEmpty($payload['data']);
+
+        $firstProcess = reset($payload['data']);
+        $this->assertArrayHasKey('scope', $firstProcess);
+        $this->assertArrayHasKey('provider', $firstProcess['scope']);
+        $this->assertArrayHasKey('data', $firstProcess['scope']['provider']);
+        $this->assertArrayHasKey('slotTimeInMinutes', $firstProcess['scope']['provider']['data']);
+        $this->assertEquals(12, (int) $firstProcess['scope']['provider']['data']['slotTimeInMinutes']);
+    }
 }

--- a/zmsdb/src/Zmsdb/Query/Scope.php
+++ b/zmsdb/src/Zmsdb/Query/Scope.php
@@ -238,6 +238,7 @@ class Scope extends Base implements MappingInterface
             'provider__source' => $this->shouldLoadEntity('scopeprovider') ? self::expression(
                 'IF(`scopeprovider`.`source`!="", `scopeprovider`.`source`, `scope`.`source`)'
             ) : '',
+            'provider__data' => $this->shouldLoadEntity('scopeprovider') ? 'scopeprovider.data' : '',
             'source' => 'scope.source'
         ], 'strlen');
     }

--- a/zmsdb/src/Zmsdb/Query/Scope.php
+++ b/zmsdb/src/Zmsdb/Query/Scope.php
@@ -238,7 +238,9 @@ class Scope extends Base implements MappingInterface
             'provider__source' => $this->shouldLoadEntity('scopeprovider') ? self::expression(
                 'IF(`scopeprovider`.`source`!="", `scopeprovider`.`source`, `scope`.`source`)'
             ) : '',
-            'provider__data' => $this->shouldLoadEntity('scopeprovider') ? 'scopeprovider.data' : '',
+            'provider__data' => $this->shouldLoadEntity('scopeprovider') ? self::expression(
+                'IFNULL(`scopeprovider`.`data`, "{}")'
+            ) : '',
             'source' => 'scope.source'
         ], 'strlen');
     }

--- a/zmsdb/tests/Zmsdb/fixtures/locations_de.json
+++ b/zmsdb/tests/Zmsdb/fixtures/locations_de.json
@@ -3619,7 +3619,8 @@
             "allowed": false
           }
         }
-      ]
+      ],
+      "slotTimeInMinutes": 12
     },
     {
       "id": "122219",


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider slot time information is now included in API responses.
  * Queue displays now use provider slot time for appointment duration calculations, with fallback to availability data when unavailable.

* **Tests**
  * Added test coverage verifying provider slot time availability in API responses.
  * Added test validating correct appointment duration calculation using provider slot time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->