### PR TITLE
fix(ZMSKVR-1121): resolve wrapper.js from loader directory on flat deploy

### DIFF
--- a/zmscitizenview/processes/lib/loader.js.template
+++ b/zmscitizenview/processes/lib/loader.js.template
@@ -1,2 +1,16 @@
 import(document.currentScript ? new URL('./{{path}}', document.currentScript.src).href : './{{path}}');
-import(document.currentScript ? new URL('./../wrapper.js', document.currentScript.src).href : './../wrapper.js');
+/**
+ * wrapper.js lives next to the hashed entry under dist/, but loader.js may be deployed in two ways:
+ * - dist/zms-appointment-webcomponent/loader.js → wrapper is one level up (../wrapper.js)
+ * - dist/loader.js or /terminvereinbarung/loader.js → wrapper is in the same directory (./wrapper.js)
+ * Using ../ from a path like /terminvereinbarung/loader.js incorrectly resolves to /wrapper.js on the host.
+ */
+void (function () {
+  var u = document.currentScript && new URL(document.currentScript.src);
+  var base = u || new URL(import.meta.url);
+  var href =
+    base.pathname.indexOf("/zms-appointment-webcomponent/") !== -1
+      ? new URL("../wrapper.js", base).href
+      : new URL("./wrapper.js", base).href;
+  return import(href);
+})();


### PR DESCRIPTION
Flat top-level loader.js (e.g. under /terminvereinbarung.html/) used ../wrapper.js, which pointed at the host root (/wrapper.js) instead of co-located assets. Use ./wrapper.js unless the loader path contains zms-appointment-webcomponent/.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script loader path resolution to correctly identify wrapper resources in different deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->