### PR TITLE
fix(ZMSKVR-1102): keep waiting time from first call only

### DIFF
--- a/zmsdb/src/Zmsdb/Query/Process.php
+++ b/zmsdb/src/Zmsdb/Query/Process.php
@@ -1000,15 +1000,21 @@ class Process extends Base implements MappingInterface
     protected function addValuesWaitingTimeData($process, $previousStatus = null)
     {
         $data = array();
+        $hasWaitingTimeAlready = (
+            isset($process->queue['waitingTime'])
+            && $process->queue['waitingTime']
+            && $process->queue['waitingTime'] !== '00:00:00'
+        );
 
         if (
+            !$hasWaitingTimeAlready
+            && (
             (
                 // Szenario 1: Vorheriger Status ist queued, missed oder confirmed und aktueller Status ist called
                 in_array($previousStatus, ['queued', 'missed', 'confirmed'])
                 && $process['status'] == 'called'
                 && (
                     $process->queue['callCount'] <= 0
-                    || !empty($process['wasMissed'])
                     || (
                         ($previousStatus === 'queued' || $previousStatus === 'confirmed')
                         && (
@@ -1027,6 +1033,7 @@ class Process extends Base implements MappingInterface
                 && !empty($process['wasMissed'])
                 && isset($process->queue)
                 && isset($process->queue->waitingTime)
+            )
             )
         ) {
             $wartezeitInSeconds = $process->getWaitedSeconds();

--- a/zmsdb/src/Zmsdb/Query/Process.php
+++ b/zmsdb/src/Zmsdb/Query/Process.php
@@ -1014,7 +1014,10 @@ class Process extends Base implements MappingInterface
                 in_array($previousStatus, ['queued', 'missed', 'confirmed'])
                 && $process['status'] == 'called'
                 && (
-                    $process->queue['callCount'] <= 0
+                    (
+                        isset($process->queue['callCount'])
+                        && $process->queue['callCount'] <= 0
+                    )
                     || (
                         ($previousStatus === 'queued' || $previousStatus === 'confirmed')
                         && (


### PR DESCRIPTION
Prevent waiting_time from being recalculated on repeat recalls after not-shown transitions by making the update path idempotent once a non-zero waiting time is already persisted.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waiting-time handling: existing wait values are now detected and left unchanged to avoid redundant recalculation.
  * Tightened the conditions that trigger wait-time computation to prevent incorrect or spurious duration updates, resulting in more accurate displayed wait times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->