### PR TITLE
clean(GH-483): rename WorkstationProcessDelete to WorkstationProcessRemove

### DIFF
--- a/zmsapi/routing.php
+++ b/zmsapi/routing.php
@@ -6179,9 +6179,9 @@ use \Psr\Http\Message\ResponseInterface;
  */
 \App::$slim->delete(
     '/workstation/process/',
-    '\BO\Zmsapi\WorkstationProcessDelete'
+    '\BO\Zmsapi\WorkstationProcessRemove'
 )
-    ->setName("WorkstationProcessDelete");
+    ->setName("WorkstationProcessRemove");
 
 /**
  *  @swagger

--- a/zmsapi/src/Zmsapi/WorkstationProcessRemove.php
+++ b/zmsapi/src/Zmsapi/WorkstationProcessRemove.php
@@ -13,7 +13,8 @@ use BO\Zmsdb\Workstation;
 use BO\Zmsdb\Process as Query;
 use BO\Zmsentities\Process;
 
-class WorkstationProcessDelete extends BaseController
+/** DELETE /workstation/process/ — update process (requeue / missed / etc.) then unassign from workstation. */
+class WorkstationProcessRemove extends BaseController
 {
     /**
      * @SuppressWarnings(Param)

--- a/zmsapi/src/Zmsapi/WorkstationProcessRemove.php
+++ b/zmsapi/src/Zmsapi/WorkstationProcessRemove.php
@@ -13,7 +13,6 @@ use BO\Zmsdb\Workstation;
 use BO\Zmsdb\Process as Query;
 use BO\Zmsentities\Process;
 
-/** DELETE /workstation/process/ — update process (requeue / missed / etc.) then unassign from workstation. */
 class WorkstationProcessRemove extends BaseController
 {
     /**

--- a/zmsapi/tests/Zmsapi/WorkstationProcessRemoveTest.php
+++ b/zmsapi/tests/Zmsapi/WorkstationProcessRemoveTest.php
@@ -4,9 +4,9 @@ namespace BO\Zmsapi\Tests;
 
 use BO\Zmsapi\Helper\User;
 
-class WorkstationProcessDeleteTest extends Base
+class WorkstationProcessRemoveTest extends Base
 {
-    protected $classname = "WorkstationProcessDelete";
+    protected $classname = "WorkstationProcessRemove";
 
     const PROCESS_ID = 10030;
 


### PR DESCRIPTION
The DELETE /workstation/process/ handler updates the process (requeue, missed, call-count actions) and unassigns it from the workstation; it does not delete the appointment record. Align naming with behaviour and with Workstation::writeRemovedProcess().

Refs: https://github.com/it-at-m/eappointment/issues/483

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
