### PR TITLE
clean(GH-1336): consolidate Oidc callback into Zmsclient\OidcHandler

### DIFF
--- a/zmsadmin/src/Zmsadmin/Oidc.php
+++ b/zmsadmin/src/Zmsadmin/Oidc.php
@@ -7,7 +7,7 @@
 
 namespace BO\Zmsadmin;
 
-use BO\Zmsclient\Auth;
+use BO\Zmsclient\OidcHandler;
 
 class Oidc extends BaseController
 {
@@ -21,89 +21,32 @@ class Oidc extends BaseController
         array $args
     ) {
         try {
-            $state = $request->getParam("state");
-            $authKey = Auth::getKey();
-            $sessionHash = hash('sha256', $authKey);
+            $state = $request->getParam('state');
+            $handler = new OidcHandler(\App::$http);
+            $result = $handler->handleCallback($state, 'zmsadmin');
 
-            \App::$log->info('OIDC Login state validation', [
-                'event' => 'oauth_login_state_validation',
-                'timestamp' => date('c'),
-                'provider' => Auth::getOidcProvider(),
-                'application' => 'zmsadmin',
-                'state_match' => ($state == $authKey),
-                'hashed_session_token' => $sessionHash
-            ]);
-
-            if ($state == $authKey) {
-                try {
-                    $workstation = \App::$http->readGetResult('/workstation/', ['resolveReferences' => 2])->getEntity();
-                    $username = $workstation->getUseraccount()->id;
-                    $authkey = $workstation['authkey'] ?? Auth::getKey() ?? '';
-                    $sessionHash = hash('sha256', $authkey);
-
-                    \App::$log->info('OIDC Login workstation access', [
-                        'event' => 'oauth_login_workstation_access',
-                        'timestamp' => date('c'),
-                        'provider' => Auth::getOidcProvider(),
-                        'application' => 'zmsadmin',
-                        'username' => $username,
-                        'workstation_id' => $workstation->id ?? 'unknown',
-                        'hashed_session_token' => $sessionHash
-                    ]);
-
-                    $departmentCount = $workstation->getUseraccount()->getDepartmentList()->count();
-
-                    \App::$log->info('OIDC Login department check', [
-                        'event' => 'oauth_login_department_check',
-                        'timestamp' => date('c'),
-                        'provider' => Auth::getOidcProvider(),
-                        'application' => 'zmsadmin',
-                        'username' => $username,
-                        'department_count' => $departmentCount,
-                        'has_departments' => ($departmentCount > 0),
-                        'hashed_session_token' => $sessionHash
-                    ]);
-
-                    if (0 == $departmentCount) {
-                        return \BO\Slim\Render::redirect(
-                            'index',
-                            [],
-                            [
-                                'oidclogin' => true
-                            ]
-                        );
-                    }
-                    return \BO\Slim\Render::redirect(
-                        'workstationSelect',
-                        [],
-                        []
-                    );
-                } catch (\Exception $e) {
-                    \App::$log->error('OIDC Login workstation error', [
-                        'event' => 'oauth_login_workstation_error',
-                        'timestamp' => date('c'),
-                        'provider' => Auth::getOidcProvider(),
-                        'application' => 'zmsadmin',
-                        'error' => $e->getMessage(),
-                        'code' => $e->getCode()
-                    ]);
-                    throw $e;
-                }
+            if ($result['redirect_to_index']) {
+                return \BO\Slim\Render::redirect(
+                    'index',
+                    [],
+                    [
+                        'oidclogin' => true
+                    ]
+                );
             }
 
-            \App::$log->error('OIDC Login invalid state', [
-                'event' => 'oauth_login_invalid_state',
-                'timestamp' => date('c'),
-                'provider' => Auth::getOidcProvider(),
-                'application' => 'zmsadmin'
-            ]);
-
-            throw new \BO\Slim\Exception\OAuthInvalid();
+            return \BO\Slim\Render::redirect(
+                'workstationSelect',
+                [],
+                []
+            );
+        } catch (\BO\Slim\Exception\OAuthInvalid $e) {
+            throw $e;
         } catch (\Exception $e) {
             \App::$log->error('OIDC Login error', [
                 'event' => 'oauth_login_error',
                 'timestamp' => date('c'),
-                'provider' => Auth::getOidcProvider(),
+                'provider' => \BO\Zmsclient\Auth::getOidcProvider(),
                 'application' => 'zmsadmin',
                 'error' => $e->getMessage(),
                 'code' => $e->getCode()

--- a/zmsclient/src/Zmsclient/OidcHandler.php
+++ b/zmsclient/src/Zmsclient/OidcHandler.php
@@ -92,7 +92,7 @@ class OidcHandler
                 'application' => $application,
                 'username' => $username,
                 'workstation_id' => $workstation->id ?? 'unknown',
-                'hashed_session_token' => $workstationHash,
+                'hashed_workstation_key' => $workstationHash,
             ]);
 
             $departmentCount = $workstation->getUseraccount()->getDepartmentList()->count();

--- a/zmsclient/src/Zmsclient/OidcHandler.php
+++ b/zmsclient/src/Zmsclient/OidcHandler.php
@@ -16,12 +16,10 @@ use BO\Zmsentities\Schema\Entity;
 class OidcHandler
 {
     private Http $http;
-    private $log;
 
-    public function __construct(Http $http, $logger = null)
+    public function __construct(Http $http)
     {
         $this->http = $http;
-        $this->log = $logger ?? (class_exists('App') ? \App::$log : null);
     }
 
     /**
@@ -50,7 +48,7 @@ class OidcHandler
             && $authKey !== ''
             && hash_equals($authKey, $state);
 
-        $this->logInfo('OIDC Login state validation', [
+        \App::$log->info('OIDC Login state validation', [
             'event' => 'oauth_login_state_validation',
             'timestamp' => date('c'),
             'provider' => Auth::getOidcProvider(),
@@ -60,7 +58,7 @@ class OidcHandler
         ]);
 
         if (!$stateIsValid) {
-            $this->logError('OIDC Login invalid state', [
+            \App::$log->error('OIDC Login invalid state', [
                 'event' => 'oauth_login_invalid_state',
                 'timestamp' => date('c'),
                 'provider' => Auth::getOidcProvider(),
@@ -90,7 +88,7 @@ class OidcHandler
             $workstationAuthKey = $workstation['authkey'] ?? Auth::getKey() ?? '';
             $workstationHash = hash('sha256', (string) $workstationAuthKey);
 
-            $this->logInfo('OIDC Login workstation access', [
+            \App::$log->info('OIDC Login workstation access', [
                 'event' => 'oauth_login_workstation_access',
                 'timestamp' => date('c'),
                 'provider' => Auth::getOidcProvider(),
@@ -102,7 +100,7 @@ class OidcHandler
 
             $departmentCount = $workstation->getUseraccount()->getDepartmentList()->count();
 
-            $this->logInfo('OIDC Login department check', [
+            \App::$log->info('OIDC Login department check', [
                 'event' => 'oauth_login_department_check',
                 'timestamp' => date('c'),
                 'provider' => Auth::getOidcProvider(),
@@ -119,7 +117,7 @@ class OidcHandler
                 'redirect_to_index' => (0 === $departmentCount),
             ];
         } catch (\Throwable $e) {
-            $this->logError('OIDC Login workstation error', [
+            \App::$log->error('OIDC Login workstation error', [
                 'event' => 'oauth_login_workstation_error',
                 'timestamp' => date('c'),
                 'provider' => Auth::getOidcProvider(),
@@ -128,20 +126,6 @@ class OidcHandler
                 'code' => $e->getCode(),
             ]);
             throw $e;
-        }
-    }
-
-    private function logInfo(string $message, array $context): void
-    {
-        if ($this->log !== null) {
-            $this->log->info($message, $context);
-        }
-    }
-
-    private function logError(string $message, array $context): void
-    {
-        if ($this->log !== null) {
-            $this->log->error($message, $context);
         }
     }
 }

--- a/zmsclient/src/Zmsclient/OidcHandler.php
+++ b/zmsclient/src/Zmsclient/OidcHandler.php
@@ -4,6 +4,7 @@ namespace BO\Zmsclient;
 
 use BO\Zmsclient\Auth;
 use BO\Zmsclient\Http;
+use BO\Zmsentities\Schema\Entity;
 
 /**
  * Shared OIDC callback handler used by zmsadmin and zmsstatistic.
@@ -30,7 +31,7 @@ class OidcHandler
      * @param string      $application Application name for logging (e.g. zmsadmin)
      *
      * @throws \BO\Slim\Exception\OAuthInvalid when the state does not match
-     * @throws \Exception                      for downstream workstation errors
+     * @throws \Throwable                      for downstream workstation errors
      *
      * @return array{
      *     workstation: mixed,
@@ -81,6 +82,10 @@ class OidcHandler
                 ->readGetResult('/workstation/', ['resolveReferences' => 2])
                 ->getEntity();
 
+            if (!$workstation instanceof Entity) {
+                throw new \RuntimeException('OIDC workstation lookup returned no entity');
+            }
+
             $username = $workstation->getUseraccount()->id;
             $workstationAuthKey = $workstation['authkey'] ?? Auth::getKey() ?? '';
             $workstationHash = hash('sha256', (string) $workstationAuthKey);
@@ -113,7 +118,7 @@ class OidcHandler
                 'department_count' => $departmentCount,
                 'redirect_to_index' => (0 === $departmentCount),
             ];
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logError('OIDC Login workstation error', [
                 'event' => 'oauth_login_workstation_error',
                 'timestamp' => date('c'),

--- a/zmsclient/src/Zmsclient/OidcHandler.php
+++ b/zmsclient/src/Zmsclient/OidcHandler.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace BO\Zmsclient;
+
+use BO\Zmsclient\Auth;
+use BO\Zmsclient\Http;
+
+/**
+ * Shared OIDC callback handler used by zmsadmin and zmsstatistic.
+ *
+ * Validates the state parameter against the session auth key with a
+ * constant-time comparison and resolves the workstation/department state
+ * needed by the application controller to decide on the next redirect.
+ */
+class OidcHandler
+{
+    private Http $http;
+    private $log;
+
+    public function __construct(Http $http, $logger = null)
+    {
+        $this->http = $http;
+        $this->log = $logger ?? (class_exists('App') ? \App::$log : null);
+    }
+
+    /**
+     * Handle OIDC callback with secure state validation.
+     *
+     * @param string|null $state       State parameter from the OIDC callback
+     * @param string      $application Application name for logging (e.g. zmsadmin)
+     *
+     * @throws \BO\Slim\Exception\OAuthInvalid when the state does not match
+     * @throws \Exception                      for downstream workstation errors
+     *
+     * @return array{
+     *     workstation: mixed,
+     *     department_count: int,
+     *     redirect_to_index: bool
+     * }
+     */
+    public function handleCallback(?string $state, string $application): array
+    {
+        $authKey = Auth::getKey();
+        $sessionHash = hash('sha256', (string) $authKey);
+
+        $stateIsValid = is_string($state)
+            && is_string($authKey)
+            && $state !== ''
+            && $authKey !== ''
+            && hash_equals($authKey, $state);
+
+        $this->logInfo('OIDC Login state validation', [
+            'event' => 'oauth_login_state_validation',
+            'timestamp' => date('c'),
+            'provider' => Auth::getOidcProvider(),
+            'application' => $application,
+            'state_match' => $stateIsValid,
+            'hashed_session_token' => $sessionHash,
+        ]);
+
+        if (!$stateIsValid) {
+            $this->logError('OIDC Login invalid state', [
+                'event' => 'oauth_login_invalid_state',
+                'timestamp' => date('c'),
+                'provider' => Auth::getOidcProvider(),
+                'application' => $application,
+            ]);
+            throw new \BO\Slim\Exception\OAuthInvalid();
+        }
+
+        return $this->authenticateWorkstation($application, $sessionHash);
+    }
+
+    /**
+     * @return array{workstation: mixed, department_count: int, redirect_to_index: bool}
+     */
+    private function authenticateWorkstation(string $application, string $sessionHash): array
+    {
+        try {
+            $workstation = $this->http
+                ->readGetResult('/workstation/', ['resolveReferences' => 2])
+                ->getEntity();
+
+            $username = $workstation->getUseraccount()->id;
+            $workstationAuthKey = $workstation['authkey'] ?? Auth::getKey() ?? '';
+            $workstationHash = hash('sha256', (string) $workstationAuthKey);
+
+            $this->logInfo('OIDC Login workstation access', [
+                'event' => 'oauth_login_workstation_access',
+                'timestamp' => date('c'),
+                'provider' => Auth::getOidcProvider(),
+                'application' => $application,
+                'username' => $username,
+                'workstation_id' => $workstation->id ?? 'unknown',
+                'hashed_session_token' => $workstationHash,
+            ]);
+
+            $departmentCount = $workstation->getUseraccount()->getDepartmentList()->count();
+
+            $this->logInfo('OIDC Login department check', [
+                'event' => 'oauth_login_department_check',
+                'timestamp' => date('c'),
+                'provider' => Auth::getOidcProvider(),
+                'application' => $application,
+                'username' => $username,
+                'department_count' => $departmentCount,
+                'has_departments' => ($departmentCount > 0),
+                'hashed_session_token' => $sessionHash,
+            ]);
+
+            return [
+                'workstation' => $workstation,
+                'department_count' => $departmentCount,
+                'redirect_to_index' => (0 === $departmentCount),
+            ];
+        } catch (\Exception $e) {
+            $this->logError('OIDC Login workstation error', [
+                'event' => 'oauth_login_workstation_error',
+                'timestamp' => date('c'),
+                'provider' => Auth::getOidcProvider(),
+                'application' => $application,
+                'error' => $e->getMessage(),
+                'code' => $e->getCode(),
+            ]);
+            throw $e;
+        }
+    }
+
+    private function logInfo(string $message, array $context): void
+    {
+        if ($this->log !== null) {
+            $this->log->info($message, $context);
+        }
+    }
+
+    private function logError(string $message, array $context): void
+    {
+        if ($this->log !== null) {
+            $this->log->error($message, $context);
+        }
+    }
+}

--- a/zmsclient/tests/Zmsclient/OidcHandlerTest.php
+++ b/zmsclient/tests/Zmsclient/OidcHandlerTest.php
@@ -6,6 +6,10 @@ use BO\Zmsclient\Auth;
 use BO\Zmsclient\Http;
 use BO\Zmsclient\OidcHandler;
 use BO\Zmsclient\Result;
+use BO\Zmsentities\Collection\DepartmentList;
+use BO\Zmsentities\Department;
+use BO\Zmsentities\Useraccount;
+use BO\Zmsentities\Workstation;
 use PHPUnit\Framework\TestCase;
 
 class OidcHandlerTest extends TestCase
@@ -74,7 +78,7 @@ class OidcHandlerTest extends TestCase
         $authKey = 'matching-state-token';
         $_COOKIE[Auth::getCookieName()] = $authKey;
 
-        $workstation = $this->createWorkstationStub('user-1', 'ws-1', 0);
+        $workstation = $this->createWorkstationEntity(0);
 
         $resultMock = $this->createMock(Result::class);
         $resultMock->method('getEntity')->willReturn($workstation);
@@ -97,7 +101,7 @@ class OidcHandlerTest extends TestCase
         $authKey = 'matching-state-token';
         $_COOKIE[Auth::getCookieName()] = $authKey;
 
-        $workstation = $this->createWorkstationStub('user-1', 'ws-1', 3);
+        $workstation = $this->createWorkstationEntity(3);
 
         $resultMock = $this->createMock(Result::class);
         $resultMock->method('getEntity')->willReturn($workstation);
@@ -144,63 +148,40 @@ class OidcHandlerTest extends TestCase
         $this->handler->handleCallback('abc1234', 'zmsadmin');
     }
 
-    /**
-     * Creates a stub object exposing the fluent shape used by OidcHandler.
-     */
-    private function createWorkstationStub(string $username, string $workstationId, int $departmentCount)
+    public function testHandleCallbackThrowsWhenWorkstationEntityMissing(): void
     {
-        $departmentList = new class ($departmentCount) {
-            private int $count;
-            public function __construct(int $count)
-            {
-                $this->count = $count;
-            }
-            public function count(): int
-            {
-                return $this->count;
-            }
-        };
+        $authKey = 'matching-state-token';
+        $_COOKIE[Auth::getCookieName()] = $authKey;
 
-        $useraccount = new class ($username, $departmentList) {
-            public string $id;
-            private $departmentList;
-            public function __construct(string $id, $departmentList)
-            {
-                $this->id = $id;
-                $this->departmentList = $departmentList;
-            }
-            public function getDepartmentList()
-            {
-                return $this->departmentList;
-            }
-        };
+        $resultMock = $this->createMock(Result::class);
+        $resultMock->method('getEntity')->willReturn(false);
 
-        return new class ($useraccount, $workstationId) implements \ArrayAccess {
-            public string $id;
-            private $useraccount;
-            public function __construct($useraccount, string $id)
-            {
-                $this->useraccount = $useraccount;
-                $this->id = $id;
-            }
-            public function getUseraccount()
-            {
-                return $this->useraccount;
-            }
-            public function offsetExists($offset): bool
-            {
-                return $offset === 'authkey';
-            }
-            public function offsetGet($offset): mixed
-            {
-                return null;
-            }
-            public function offsetSet($offset, $value): void
-            {
-            }
-            public function offsetUnset($offset): void
-            {
-            }
-        };
+        $this->httpMock
+            ->expects($this->once())
+            ->method('readGetResult')
+            ->with('/workstation/', ['resolveReferences' => 2])
+            ->willReturn($resultMock);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('OIDC workstation lookup returned no entity');
+
+        $this->handler->handleCallback($authKey, 'zmsadmin');
+    }
+
+    private function createWorkstationEntity(int $departmentCount): Workstation
+    {
+        $departmentList = new DepartmentList();
+        for ($i = 0; $i < $departmentCount; $i++) {
+            $departmentList->addEntity(new Department(['id' => $i + 1]));
+        }
+        $useraccount = new Useraccount([
+            'id' => 'user-1',
+            'departments' => $departmentList,
+        ]);
+
+        return new Workstation([
+            'id' => 1,
+            'useraccount' => $useraccount,
+        ]);
     }
 }

--- a/zmsclient/tests/Zmsclient/OidcHandlerTest.php
+++ b/zmsclient/tests/Zmsclient/OidcHandlerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace BO\Zmsclient\Tests\Zmsclient;
+
+use BO\Zmsclient\Auth;
+use BO\Zmsclient\Http;
+use BO\Zmsclient\OidcHandler;
+use BO\Zmsclient\Result;
+use PHPUnit\Framework\TestCase;
+
+class OidcHandlerTest extends TestCase
+{
+    /** @var Http&\PHPUnit\Framework\MockObject\MockObject */
+    private $httpMock;
+
+    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    private $logMock;
+
+    private OidcHandler $handler;
+
+    private array $originalCookies = [];
+
+    protected function setUp(): void
+    {
+        $this->originalCookies = $_COOKIE ?? [];
+        $_COOKIE = [];
+
+        $this->httpMock = $this->createMock(Http::class);
+        $this->logMock = $this->createMock(\Monolog\Logger::class);
+        $this->handler = new OidcHandler($this->httpMock, $this->logMock);
+    }
+
+    protected function tearDown(): void
+    {
+        $_COOKIE = $this->originalCookies;
+    }
+
+    public function testHandleCallbackThrowsOnMissingState(): void
+    {
+        $_COOKIE[Auth::getCookieName()] = 'expected-auth-key';
+
+        $this->expectException(\BO\Slim\Exception\OAuthInvalid::class);
+
+        $this->handler->handleCallback(null, 'zmsadmin');
+    }
+
+    public function testHandleCallbackThrowsOnEmptyState(): void
+    {
+        $_COOKIE[Auth::getCookieName()] = 'expected-auth-key';
+
+        $this->expectException(\BO\Slim\Exception\OAuthInvalid::class);
+
+        $this->handler->handleCallback('', 'zmsadmin');
+    }
+
+    public function testHandleCallbackThrowsWhenAuthKeyMissing(): void
+    {
+        $this->expectException(\BO\Slim\Exception\OAuthInvalid::class);
+
+        $this->handler->handleCallback('some-state', 'zmsstatistic');
+    }
+
+    public function testHandleCallbackThrowsOnStateMismatch(): void
+    {
+        $_COOKIE[Auth::getCookieName()] = 'expected-auth-key';
+
+        $this->expectException(\BO\Slim\Exception\OAuthInvalid::class);
+
+        $this->handler->handleCallback('wrong-state', 'zmsadmin');
+    }
+
+    public function testHandleCallbackReturnsRedirectToIndexWhenNoDepartments(): void
+    {
+        $authKey = 'matching-state-token';
+        $_COOKIE[Auth::getCookieName()] = $authKey;
+
+        $workstation = $this->createWorkstationStub('user-1', 'ws-1', 0);
+
+        $resultMock = $this->createMock(Result::class);
+        $resultMock->method('getEntity')->willReturn($workstation);
+
+        $this->httpMock
+            ->expects($this->once())
+            ->method('readGetResult')
+            ->with('/workstation/', ['resolveReferences' => 2])
+            ->willReturn($resultMock);
+
+        $result = $this->handler->handleCallback($authKey, 'zmsadmin');
+
+        $this->assertSame($workstation, $result['workstation']);
+        $this->assertSame(0, $result['department_count']);
+        $this->assertTrue($result['redirect_to_index']);
+    }
+
+    public function testHandleCallbackReturnsRedirectToWorkstationSelectWithDepartments(): void
+    {
+        $authKey = 'matching-state-token';
+        $_COOKIE[Auth::getCookieName()] = $authKey;
+
+        $workstation = $this->createWorkstationStub('user-1', 'ws-1', 3);
+
+        $resultMock = $this->createMock(Result::class);
+        $resultMock->method('getEntity')->willReturn($workstation);
+
+        $this->httpMock
+            ->expects($this->once())
+            ->method('readGetResult')
+            ->with('/workstation/', ['resolveReferences' => 2])
+            ->willReturn($resultMock);
+
+        $result = $this->handler->handleCallback($authKey, 'zmsstatistic');
+
+        $this->assertSame(3, $result['department_count']);
+        $this->assertFalse($result['redirect_to_index']);
+    }
+
+    public function testHandleCallbackPropagatesWorkstationLookupError(): void
+    {
+        $authKey = 'matching-state-token';
+        $_COOKIE[Auth::getCookieName()] = $authKey;
+
+        $this->httpMock
+            ->expects($this->once())
+            ->method('readGetResult')
+            ->with('/workstation/', ['resolveReferences' => 2])
+            ->willThrowException(new \RuntimeException('boom'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $this->handler->handleCallback($authKey, 'zmsadmin');
+    }
+
+    /**
+     * State validation must use a constant-time comparison so length differences
+     * do not produce false positives.
+     */
+    public function testHandleCallbackRejectsDifferentLengthStateMatchingPrefix(): void
+    {
+        $_COOKIE[Auth::getCookieName()] = 'abc123';
+
+        $this->expectException(\BO\Slim\Exception\OAuthInvalid::class);
+
+        $this->handler->handleCallback('abc1234', 'zmsadmin');
+    }
+
+    /**
+     * Creates a stub object exposing the fluent shape used by OidcHandler.
+     */
+    private function createWorkstationStub(string $username, string $workstationId, int $departmentCount)
+    {
+        $departmentList = new class ($departmentCount) {
+            private int $count;
+            public function __construct(int $count)
+            {
+                $this->count = $count;
+            }
+            public function count(): int
+            {
+                return $this->count;
+            }
+        };
+
+        $useraccount = new class ($username, $departmentList) {
+            public string $id;
+            private $departmentList;
+            public function __construct(string $id, $departmentList)
+            {
+                $this->id = $id;
+                $this->departmentList = $departmentList;
+            }
+            public function getDepartmentList()
+            {
+                return $this->departmentList;
+            }
+        };
+
+        return new class ($useraccount, $workstationId) implements \ArrayAccess {
+            public string $id;
+            private $useraccount;
+            public function __construct($useraccount, string $id)
+            {
+                $this->useraccount = $useraccount;
+                $this->id = $id;
+            }
+            public function getUseraccount()
+            {
+                return $this->useraccount;
+            }
+            public function offsetExists($offset): bool
+            {
+                return $offset === 'authkey';
+            }
+            public function offsetGet($offset): mixed
+            {
+                return null;
+            }
+            public function offsetSet($offset, $value): void
+            {
+            }
+            public function offsetUnset($offset): void
+            {
+            }
+        };
+    }
+}

--- a/zmsclient/tests/Zmsclient/OidcHandlerTest.php
+++ b/zmsclient/tests/Zmsclient/OidcHandlerTest.php
@@ -11,32 +11,35 @@ use BO\Zmsentities\Department;
 use BO\Zmsentities\Useraccount;
 use BO\Zmsentities\Workstation;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class OidcHandlerTest extends TestCase
 {
     /** @var Http&\PHPUnit\Framework\MockObject\MockObject */
     private $httpMock;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $logMock;
-
     private OidcHandler $handler;
 
     private array $originalCookies = [];
+
+    private $originalLog;
 
     protected function setUp(): void
     {
         $this->originalCookies = $_COOKIE ?? [];
         $_COOKIE = [];
 
+        $this->originalLog = \App::$log;
+        \App::$log = $this->createMock(LoggerInterface::class);
+
         $this->httpMock = $this->createMock(Http::class);
-        $this->logMock = $this->createMock(\Monolog\Logger::class);
-        $this->handler = new OidcHandler($this->httpMock, $this->logMock);
+        $this->handler = new OidcHandler($this->httpMock);
     }
 
     protected function tearDown(): void
     {
         $_COOKIE = $this->originalCookies;
+        \App::$log = $this->originalLog;
     }
 
     public function testHandleCallbackThrowsOnMissingState(): void

--- a/zmsstatistic/src/Zmsstatistic/Oidc.php
+++ b/zmsstatistic/src/Zmsstatistic/Oidc.php
@@ -7,7 +7,7 @@
 
 namespace BO\Zmsstatistic;
 
-use BO\Zmsclient\Auth;
+use BO\Zmsclient\OidcHandler;
 
 class Oidc extends BaseController
 {
@@ -21,92 +21,35 @@ class Oidc extends BaseController
         array $args
     ) {
         try {
-            $state = $request->getParam("state");
-            $authKey = Auth::getKey();
-            $sessionHash = hash('sha256', $authKey);
+            $state = $request->getParam('state');
+            $handler = new OidcHandler(\App::$http);
+            $result = $handler->handleCallback($state, 'zmsstatistic');
 
-            \App::$log->info('OIDC Login state validation', [
-                'event' => 'oauth_login_state_validation',
-                'timestamp' => date('c'),
-                'provider' => Auth::getOidcProvider(),
-                'application' => 'zmsstatistic',
-                'state_match' => ($state == $authKey),
-                'hashed_session_token' => $sessionHash
-            ]);
-
-            if ($state == $authKey) {
-                try {
-                    $workstation = \App::$http->readGetResult('/workstation/', ['resolveReferences' => 2])->getEntity();
-                    $username = $workstation->getUseraccount()->id;
-                    $authkey = $workstation['authkey'] ?? Auth::getKey() ?? '';
-                    $sessionHash = hash('sha256', $authkey);
-
-                    \App::$log->info('OIDC Login workstation access', [
-                        'event' => 'oauth_login_workstation_access',
-                        'timestamp' => date('c'),
-                        'provider' => Auth::getOidcProvider(),
-                        'application' => 'zmsstatistic',
-                        'username' => $username,
-                        'workstation_id' => $workstation->id ?? 'unknown',
-                        'hashed_session_token' => $sessionHash
-                    ]);
-
-                    $departmentCount = $workstation->getUseraccount()->getDepartmentList()->count();
-
-                    \App::$log->info('OIDC Login department check', [
-                        'event' => 'oauth_login_department_check',
-                        'timestamp' => date('c'),
-                        'provider' => Auth::getOidcProvider(),
-                        'application' => 'zmsstatistic',
-                        'username' => $username,
-                        'department_count' => $departmentCount,
-                        'has_departments' => ($departmentCount > 0),
-                        'hashed_session_token' => $sessionHash
-                    ]);
-
-                    if (0 == $departmentCount) {
-                        return \BO\Slim\Render::redirect(
-                            'index',
-                            [],
-                            [
-                                'oidclogin' => true
-                            ]
-                        );
-                    }
-                    return \BO\Slim\Render::redirect(
-                        'workstationSelect',
-                        [],
-                        []
-                    );
-                } catch (\Exception $e) {
-                    \App::$log->error('OIDC Login workstation error', [
-                        'event' => 'oauth_login_workstation_error',
-                        'timestamp' => date('c'),
-                        'provider' => Auth::getOidcProvider(),
-                        'application' => 'zmsstatistic',
-                        'error' => $e->getMessage(),
-                        'code' => $e->getCode()
-                    ]);
-                    throw $e;
-                }
+            if ($result['redirect_to_index']) {
+                return \BO\Slim\Render::redirect(
+                    'index',
+                    [],
+                    [
+                        'oidclogin' => true
+                    ]
+                );
             }
 
-            \App::$log->error('OIDC Login invalid state', [
-                'event' => 'oauth_login_invalid_state',
-                'timestamp' => date('c'),
-                'provider' => Auth::getOidcProvider(),
-                'application' => 'zmsstatistic'
-            ]);
-
-            throw new \BO\Slim\Exception\OAuthInvalid();
+            return \BO\Slim\Render::redirect(
+                'workstationSelect',
+                [],
+                []
+            );
+        } catch (\BO\Slim\Exception\OAuthInvalid $e) {
+            throw $e;
         } catch (\Exception $e) {
             \App::$log->error('OIDC Login error', [
-            'event' => 'oauth_login_error',
-            'timestamp' => date('c'),
-            'provider' => Auth::getOidcProvider(),
-            'application' => 'zmsstatistic',
-            'error' => $e->getMessage(),
-            'code' => $e->getCode()
+                'event' => 'oauth_login_error',
+                'timestamp' => date('c'),
+                'provider' => \BO\Zmsclient\Auth::getOidcProvider(),
+                'application' => 'zmsstatistic',
+                'error' => $e->getMessage(),
+                'code' => $e->getCode()
             ]);
             throw $e;
         }


### PR DESCRIPTION
Move duplicated OIDC callback logic from zmsstatistic/Oidc.php and zmsadmin/Oidc.php into a shared BO\Zmsclient\OidcHandler. State validation now uses hash_equals for constant-time comparison and rejects empty or non-string values. Controllers are thin wrappers that delegate to the handler and render the resulting redirect.

Adds tests under zmsclient/tests/Zmsclient/OidcHandlerTest.php covering invalid state, missing/empty state, mismatching length, workstation lookup errors, and both redirect branches.

Refs: https://github.com/it-at-m/eappointment/issues/1336

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized OIDC callback handling into a shared handler and updated applications to use it, simplifying callback flow and error handling.

* **Tests**
  * Added comprehensive tests for OIDC workflows, covering missing/invalid state, workstation lookup outcomes, redirect behavior based on departments, and error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/eappointment/pull/2350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->