### PR TITLE
fix(GH-2353): skip holidays in opening-hours test data and CI

### DIFF
--- a/.github/workflows/zmsautomation-workflow.yaml
+++ b/.github/workflows/zmsautomation-workflow.yaml
@@ -257,6 +257,17 @@ jobs:
             done
           '
 
+      - name: Detect public holiday (feiertage test data)
+        id: holiday
+        shell: bash
+        run: |
+          set -euo pipefail
+          if bash zmsautomation/scripts/is-public-holiday-today.sh; then
+            echo "is_holiday=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run zmsautomation ATAF tests sequentially (by tag lines)
         shell: bash
         run: |
@@ -266,6 +277,7 @@ jobs:
           BROWSER="${{ matrix.browser }}"
           SCREENSHOT="${{ inputs.per_step_screenshots }}"
           INPUTS="${{ github.event_name == 'schedule' && '(@rest or @web) and not @ignore' || inputs.cucumber_tag_expressions }}"
+          IS_HOLIDAY="${{ steps.holiday.outputs.is_holiday }}"
 
           # Split by newlines and run sequentially.
           fail_any=0
@@ -276,6 +288,11 @@ jobs:
             expr="$(printf '%s' "$line" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             if [ -z "$expr" ]; then
               continue
+            fi
+
+            if [ "$IS_HOLIDAY" = "true" ] && [[ "$expr" != *@NotOnHoliday* ]]; then
+              expr="($expr) and not @NotOnHoliday"
+              echo "Public holiday: excluding @NotOnHoliday scenarios from tag expression"
             fi
 
             echo "Running zmsautomation-test for tags: $expr"

--- a/zmsautomation/scripts/is-public-holiday-today.sh
+++ b/zmsautomation/scripts/is-public-holiday-today.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Exit 0 when today (Europe/Berlin) is listed in V10 feiertage test data; exit 1 otherwise.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION="${1:-$SCRIPT_DIR/../src/main/resources/db/migration/V10__add_day_off_holidays_test_data.sql}"
+TODAY="$(TZ=Europe/Berlin date +%Y-%m-%d)"
+
+if grep -q "'${TODAY}'" "$MIGRATION"; then
+  echo "Public holiday detected for ${TODAY} (see V10 feiertage test data)."
+  exit 0
+fi
+
+exit 1

--- a/zmsautomation/src/main/resources/db/migration/V10__add_day_off_holidays_test_data.sql
+++ b/zmsautomation/src/main/resources/db/migration/V10__add_day_off_holidays_test_data.sql
@@ -1,4 +1,4 @@
--- Flyway Migration: Add days off and holidays so opening hours can be created.
+-- Flyway Migration: Add days off and holidays (runs before V11 opening-hours seed data).
 
 INSERT INTO `feiertage` (`FeiertagID`, `Datum`, `Feiertag`, `BehoerdenID`, `updateTimestamp`) VALUES
 (54, '2025-08-15', 'MariaHimmelfahrt', 0, '2023-02-23 07:27:05'),

--- a/zmsautomation/src/main/resources/db/migration/V11__opening_hours_availability_test_data.sql
+++ b/zmsautomation/src/main/resources/db/migration/V11__opening_hours_availability_test_data.sql
@@ -1,7 +1,8 @@
 -- Flyway migration: Opening hours availability test data
 --
 -- Ruppertstraße Standorte 160, 181, 172, 184 (offices 10489 / 10502) live in
--- V19__ZMSKVR-1124_zmscitizenapi_opening_hours_for_ruppertstasse.sql — not duplicated here.
+-- V19__ZMSKVR-1124_opening_hours_for_ruppertstasse.sql — not duplicated here.
+-- feiertage test data is seeded in V10; @range_start is advanced past holidays below.
 
 -- round current time to next 5 minute slot
 SET @rounded_start :=
@@ -26,8 +27,23 @@ SET @appt_end :=
   IF(@use_next_day, LEAST(ADDTIME('00:05:00', '03:00:00'), '23:55:00'), @rounded_end);
 
 SET @range_start := IF(@use_next_day, DATE_ADD(CURDATE(), INTERVAL 1 DAY), CURDATE());
-SET @range_end :=
-  IF(@use_next_day, DATE_ADD(CURDATE(), INTERVAL 8 DAY), DATE_ADD(CURDATE(), INTERVAL 7 DAY));
+
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+
+SET @range_end := DATE_ADD(@range_start, INTERVAL 7 DAY);
 
 INSERT IGNORE INTO `oeffnungszeit`
 (

--- a/zmsautomation/src/main/resources/db/migration/V19__ZMSKVR-1124_opening_hours_for_ruppertstasse.sql
+++ b/zmsautomation/src/main/resources/db/migration/V19__ZMSKVR-1124_opening_hours_for_ruppertstasse.sql
@@ -1,6 +1,6 @@
 -- Flyway migration: Opening hours for Ruppertstraße test data (ZMSKVR-1124)
 --
--- Mirrors V10__opening_hours_availability_test_data but focuses on
+-- Mirrors V11__opening_hours_availability_test_data but focuses on
 -- Ruppertstraße offices used in Citizen API zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links_citizenapi.feature:
 --  - Office 10489 (Bürgerbüro Ruppertstraße (KVR-II/22))
 --  - Office 10492 (Bürgerbüro Ruppertstraße (KVR-II/211))
@@ -37,8 +37,23 @@ SET @appt_end :=
   IF(@use_next_day, LEAST(ADDTIME('00:05:00', '03:00:00'), '23:55:00'), @rounded_end);
 
 SET @range_start := IF(@use_next_day, DATE_ADD(CURDATE(), INTERVAL 1 DAY), CURDATE());
-SET @range_end :=
-  IF(@use_next_day, DATE_ADD(CURDATE(), INTERVAL 8 DAY), DATE_ADD(CURDATE(), INTERVAL 7 DAY));
+
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+SET @range_start := IF(EXISTS (SELECT 1 FROM feiertage WHERE Datum = @range_start), DATE_ADD(@range_start, INTERVAL 1 DAY), @range_start);
+
+SET @range_end := DATE_ADD(@range_start, INTERVAL 7 DAY);
 
 INSERT IGNORE INTO `oeffnungszeit`
 (

--- a/zmsautomation/src/test/java/zms/ataf/hooks/PublicHolidayHook.java
+++ b/zmsautomation/src/test/java/zms/ataf/hooks/PublicHolidayHook.java
@@ -1,0 +1,22 @@
+package zms.ataf.hooks;
+
+import org.testng.SkipException;
+
+import ataf.core.logging.ScenarioLogManager;
+import io.cucumber.java.Before;
+import zms.ataf.support.PublicHolidayChecker;
+
+/**
+ * Skips scenarios tagged {@code @NotOnHoliday} when today is a public holiday in feiertage test data.
+ */
+public class PublicHolidayHook {
+
+    @Before("@NotOnHoliday")
+    public void skipWhenTodayIsPublicHoliday() {
+        if (PublicHolidayChecker.isTodayPublicHoliday()) {
+            String message = "Skipped @NotOnHoliday scenario: today is a public holiday in feiertage test data";
+            ScenarioLogManager.getLogger().warn(message);
+            throw new SkipException(message);
+        }
+    }
+}

--- a/zmsautomation/src/test/java/zms/ataf/support/PublicHolidayChecker.java
+++ b/zmsautomation/src/test/java/zms/ataf/support/PublicHolidayChecker.java
@@ -1,0 +1,51 @@
+package zms.ataf.support;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Detects whether today is a public holiday according to zmsautomation feiertage test data (V10 migration).
+ */
+public final class PublicHolidayChecker {
+
+    private static final ZoneId ZONE = ZoneId.of("Europe/Berlin");
+    private static final Pattern DATE_IN_INSERT = Pattern.compile("'(\\d{4}-\\d{2}-\\d{2})'");
+    private static final String HOLIDAY_MIGRATION = "db/migration/V10__add_day_off_holidays_test_data.sql";
+    private static final Set<LocalDate> HOLIDAYS = loadHolidays();
+
+    private PublicHolidayChecker() {}
+
+    public static boolean isTodayPublicHoliday() {
+        if (Boolean.parseBoolean(System.getenv().getOrDefault("ZMS_FORCE_PUBLIC_HOLIDAY", "false"))) {
+            return true;
+        }
+        if (Boolean.parseBoolean(System.getenv().getOrDefault("ZMS_FORCE_NOT_PUBLIC_HOLIDAY", "false"))) {
+            return false;
+        }
+        return isPublicHoliday(LocalDate.now(ZONE));
+    }
+
+    public static boolean isPublicHoliday(LocalDate date) {
+        return HOLIDAYS.contains(date);
+    }
+
+    private static Set<LocalDate> loadHolidays() {
+        try (InputStream in = PublicHolidayChecker.class.getClassLoader().getResourceAsStream(HOLIDAY_MIGRATION)) {
+            if (in == null) {
+                throw new IllegalStateException("Holiday migration not on classpath: " + HOLIDAY_MIGRATION);
+            }
+            String sql = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            return DATE_IN_INSERT.matcher(sql).results()
+                    .map(match -> LocalDate.parse(match.group(1)))
+                    .collect(Collectors.toUnmodifiableSet());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read holiday migration: " + HOLIDAY_MIGRATION, e);
+        }
+    }
+}

--- a/zmsautomation/src/test/java/zms/ataf/support/PublicHolidayCheckerTest.java
+++ b/zmsautomation/src/test/java/zms/ataf/support/PublicHolidayCheckerTest.java
@@ -1,0 +1,14 @@
+package zms.ataf.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+
+class PublicHolidayCheckerTest {
+
+    @Test
+    void detectsKnownHolidayFromMigrationData() {
+        assertThat(PublicHolidayChecker.isPublicHoliday(java.time.LocalDate.parse("2026-05-14"))).isTrue();
+        assertThat(PublicHolidayChecker.isPublicHoliday(java.time.LocalDate.parse("2026-05-15"))).isFalse();
+    }
+}

--- a/zmsautomation/src/test/resources/features/rest/zmscitizenapi/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links_citizenapi.feature
+++ b/zmsautomation/src/test/resources/features/rest/zmscitizenapi/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links_citizenapi.feature
@@ -1,4 +1,4 @@
-@rest @zmscitizenapi @ZMSKVR-1124
+@rest @zmscitizenapi @ZMSKVR-1124 @NotOnHoliday
 Feature: ZMSKVR-1124 Ruppertstraße booking — Citizen API (10502 / 10489 / 10492, jump-in allow-mix)
   As a citizen
   I want to complete a full appointment booking from offices-and-services through confirm

--- a/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links.feature
+++ b/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links.feature
@@ -1,5 +1,5 @@
 #language: en
-@web @zmscitizenview @ZMSKVR-1124 @executeLocally
+@web @zmscitizenview @ZMSKVR-1124 @executeLocally @NotOnHoliday
 Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 10502, Hauptkalender 10489, Abholung 10492, jump-in)
   As a citizen
   I want to book via the citizen view UI

--- a/zmsautomation/zmsautomation-test
+++ b/zmsautomation/zmsautomation-test
@@ -565,6 +565,25 @@ cd "$PROJECT_ROOT/zmsautomation"
 # Run with default ataf profile
 # Maven arguments (e.g., -Dcucumber.filter.tags="@smoke") are passed through via MAVEN_ARGS.
 # Scenarios tagged @ignore are excluded unless @ignore is explicitly in the tag expression.
+# On public holidays (V10 feiertage test data), @NotOnHoliday scenarios are excluded unless that tag is requested.
+is_public_holiday_today() {
+  local migration="$PROJECT_ROOT/zmsautomation/src/main/resources/db/migration/V10__add_day_off_holidays_test_data.sql"
+  local today
+  today="$(TZ=Europe/Berlin date +%Y-%m-%d)"
+  grep -q "'${today}'" "$migration" 2>/dev/null
+}
+
+append_holiday_tag_filter() {
+  local value="$1"
+  if is_public_holiday_today && [[ "$value" != *@NotOnHoliday* ]]; then
+    info "Public holiday ($(
+      TZ=Europe/Berlin date +%Y-%m-%d
+    )): excluding @NotOnHoliday scenarios"
+    value="($value) and not @NotOnHoliday"
+  fi
+  printf '%s' "$value"
+}
+
 ATAF_MAVEN_ARGS=()
 HAS_CUCUMBER_TAGS=false
 for arg in "${MAVEN_ARGS[@]+"${MAVEN_ARGS[@]}"}"; do
@@ -572,6 +591,7 @@ for arg in "${MAVEN_ARGS[@]+"${MAVEN_ARGS[@]}"}"; do
     HAS_CUCUMBER_TAGS=true
     value="${arg#-Dcucumber.filter.tags=}"
     if [[ "$value" != *@ignore* ]]; then
+      value="$(append_holiday_tag_filter "$value")"
       ATAF_MAVEN_ARGS+=("-Dcucumber.filter.tags=($value) and not @ignore")
     else
       ATAF_MAVEN_ARGS+=("$arg")
@@ -581,7 +601,9 @@ for arg in "${MAVEN_ARGS[@]+"${MAVEN_ARGS[@]}"}"; do
   fi
 done
 if [[ "$HAS_CUCUMBER_TAGS" != true ]]; then
-  ATAF_MAVEN_ARGS+=("-Dcucumber.filter.tags=not @ignore")
+  default_tags="not @ignore"
+  default_tags="$(append_holiday_tag_filter "$default_tags")"
+  ATAF_MAVEN_ARGS+=("-Dcucumber.filter.tags=$default_tags")
 fi
 
 # SSO credentials for UI tests (default: ataf/vorschau for local Keycloak, override via SSO_USER/SSO_PASSWORD env vars)


### PR DESCRIPTION
Seed feiertage before opening hours (V10/V11 swap), advance range_start past holidays in V11 and V19, and exclude @NotOnHoliday scenarios on public holidays in CI and zmsautomation-test.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
