### PR TITLE
clean(GH-1745): handle empty scopeIds in Process query

### DIFF
--- a/zmsdb/src/Zmsdb/Query/Process.php
+++ b/zmsdb/src/Zmsdb/Query/Process.php
@@ -496,7 +496,12 @@ class Process extends Base implements MappingInterface
 
     public function addConditionScopeIds($scopeIds)
     {
-        if (count($scopeIds) == 1) {
+        if (count($scopeIds) === 0) {
+            $this->query->where(self::expression('1'), '=', 0);
+            return $this;
+        }
+
+        if (count($scopeIds) === 1) {
             return $this->addConditionScopeId($scopeIds[0]);
         }
 

--- a/zmsdb/tests/Zmsdb/ProcessTest.php
+++ b/zmsdb/tests/Zmsdb/ProcessTest.php
@@ -379,6 +379,14 @@ class ProcessTest extends Base
         $this->assertEquals(105, $collection->count());
     }
 
+    public function testProcessListByScopesAndTimeWithEmptyScopeIds()
+    {
+        $now = static::$now;
+        $collection = (new Query)->readProcessListByScopesAndTime([], $now);
+        $this->assertEntityList("\\BO\\Zmsentities\\Process", $collection);
+        $this->assertEquals(0, $collection->count());
+    }
+
     public function testReadSlotCount()
     {
         $now = static::$now;


### PR DESCRIPTION
When a cluster has no scopes, readProcessListByScopesAndTime passes an empty array; addConditionScopeIds now returns no rows instead of building an invalid IN clause. Adds a regression test.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
