### PR TITLE
docs(GH-2353): document zmsautomation holiday test limitations

### DIFF
--- a/docs/de/testing-and-automation/zmsautomation.md
+++ b/docs/de/testing-and-automation/zmsautomation.md
@@ -241,3 +241,11 @@ In Safari musst du außerdem aktivieren:
 ## Migrationshinweise
 
 - `zmsautomation` nutzt ATAF + Cucumber; CI-/Workflow-Umgebungen können separat festgepinnt werden.
+
+## Bekannte Einschränkungen
+
+### Buchungstests an gesetzlichen Feiertagen
+
+Die Slot-Berechnung erzeugt an gesetzlichen Feiertagen absichtlich keine Termine (Datensätze in der Tabelle `feiertage`, befüllt durch Migration V11). Die Testdaten für Öffnungszeiten in zmsautomation (relativ zum aktuellen Datum, z. B. in den Migrationen V10 und V19) können in einen Feiertag fallen. In diesem Fall gibt es am „ersten verfügbaren Tag“ ggf. keine buchbaren Slots und buchungsbezogene Szenarien (Citizen API und CitizenView Flows) können fehlschlagen.
+
+Das ist erwartetes Verhalten. Maßnahme: Pipeline am nächsten arbeitsfreien Nicht‑Feiertag erneut ausführen (oder lokal an einem Nicht‑Feiertag starten).

--- a/docs/en/testing-and-automation/zmsautomation.md
+++ b/docs/en/testing-and-automation/zmsautomation.md
@@ -241,3 +241,11 @@ In Safari, you must also enable:
 ## Migration Notes
 
 - `zmsautomation` uses ATAF + Cucumber; CI/workflows may pin environments separately.
+
+## Known limitations
+
+### Booking tests on public holidays
+
+By design, slot calculation does not create appointments on public holidays (dates in the `feiertage` table seeded by migration V11). The test data for opening hours in zmsautomation (seeded relative to the current date in migrations such as V10 and V19) can overlap with a holiday. When that happens, there may be zero bookable slots on the “first available day,” and booking-related scenarios (Citizen API and CitizenView flows) can fail.
+
+This is expected behavior. Action: re-run the pipeline on the next non‑holiday working day (or run locally on a non‑holiday date).


### PR DESCRIPTION
Document why booking scenarios can fail when opening-hour test data overlaps with public holidays in feiertage (V11) and how to re-run.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added known limitations section documenting expected test failures when booking-related tests overlap with public holidays, with mitigation guidance to rerun tests on non-holiday dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/eappointment/pull/2369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->