### PR TITLE
fix(ZMSKVR-1425): respect Wiederholungsaufrufe on skip-to-next

### DIFF
--- a/zmsapi/src/Zmsapi/WorkstationProcessRemove.php
+++ b/zmsapi/src/Zmsapi/WorkstationProcessRemove.php
@@ -65,7 +65,10 @@ class WorkstationProcessRemove extends BaseController
             $process->queue['wayTime'] = 0;
             $process['showUpTime'] = null;
             $process['timeoutTime'] = null;
-        } elseif ($isRequeueCalled && $process->queue['callCount'] > $workstation->scope->getPreference('queue', 'callCountMax')) {
+        } elseif (
+            ($isRequeueCalled || $isRequeueAndSkipToNext)
+            && $process->queue['callCount'] > $workstation->scope->getPreference('queue', 'callCountMax')
+        ) {
             $process->setWasMissed(true);
         } elseif ($isRequeueDecrementCalled) {
             $process->status = Process::STATUS_QUEUED;
@@ -79,8 +82,6 @@ class WorkstationProcessRemove extends BaseController
             }
             $process['showUpTime'] = null;
             $process['timeoutTime'] = null;
-        } elseif ($isRequeueAndSkipToNext) {
-            $process->setWasMissed(true);
         }
 
         $process = (new Query())->updateEntity(

--- a/zmsapi/tests/Zmsapi/WorkstationProcessRemoveTest.php
+++ b/zmsapi/tests/Zmsapi/WorkstationProcessRemoveTest.php
@@ -72,10 +72,18 @@ class WorkstationProcessRemoveTest extends Base
     private function assignCalledProcessToWorkstation(int $callCount): void
     {
         $process = (new \BO\Zmsdb\Process())->readEntity(self::CALLED_PROCESS_ID, self::CALLED_AUTHKEY, 1);
+        $previousStatus = $process->status;
+        $nowTs = \App::$now->getTimestamp();
+
         $process->status = Process::STATUS_CALLED;
         $process['status'] = Process::STATUS_CALLED;
         $process->queue['callCount'] = $callCount;
-        $process = (new \BO\Zmsdb\Process())->updateEntity($process, \App::$now, 0, Process::STATUS_CONFIRMED);
+        $process->queue['callTime'] = $nowTs;
+        $process->queue['lastCallTime'] = $nowTs;
+        $process->queue['arrivalTime'] = $nowTs - 600;
+        $process->queue['waitingTime'] = '00:10:00';
+
+        $process = (new \BO\Zmsdb\Process())->updateEntity($process, \App::$now, 0, $previousStatus);
         User::$workstation->process = (new \BO\Zmsdb\Workstation())->writeAssignedProcess(
             User::$workstation,
             $process,

--- a/zmsapi/tests/Zmsapi/WorkstationProcessRemoveTest.php
+++ b/zmsapi/tests/Zmsapi/WorkstationProcessRemoveTest.php
@@ -3,6 +3,7 @@
 namespace BO\Zmsapi\Tests;
 
 use BO\Zmsapi\Helper\User;
+use BO\Zmsentities\Process;
 
 class WorkstationProcessRemoveTest extends Base
 {
@@ -11,6 +12,36 @@ class WorkstationProcessRemoveTest extends Base
     const PROCESS_ID = 10030;
 
     const AUTHKEY = '1c56';
+
+    const CALLED_PROCESS_ID = 11468;
+
+    const CALLED_AUTHKEY = '7b41';
+
+    public function testRequeueAndSkipToNextKeepsProcessOnWaitingListWithinCallCountMax()
+    {
+        $this->setWorkstationWithCallCountMax('1');
+        $this->assignCalledProcessToWorkstation(1);
+
+        $response = $this->render([], ['action' => 'requeue_and_skip_to_next'], []);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $process = (new \BO\Zmsdb\Process())->readEntity(self::CALLED_PROCESS_ID, self::CALLED_AUTHKEY, 1);
+        $this->assertNotEquals(Process::STATUS_MISSED, $process->status);
+        $this->assertFalse($process->getWasMissed());
+    }
+
+    public function testRequeueAndSkipToNextMarksProcessMissedWhenCallCountExceedsMax()
+    {
+        $this->setWorkstationWithCallCountMax('1');
+        $this->assignCalledProcessToWorkstation(2);
+
+        $response = $this->render([], ['action' => 'requeue_and_skip_to_next'], []);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $process = (new \BO\Zmsdb\Process())->readEntity(self::CALLED_PROCESS_ID, self::CALLED_AUTHKEY, 1);
+        $this->assertEquals(Process::STATUS_MISSED, $process->status);
+        $this->assertTrue($process->getWasMissed());
+    }
 
     public function testRendering()
     {
@@ -30,5 +61,25 @@ class WorkstationProcessRemoveTest extends Base
         $this->expectException('\BO\Zmsapi\Exception\Process\ProcessNotFound');
         $this->expectExceptionCode(404);
         $this->render([], [], []);
+    }
+
+    private function setWorkstationWithCallCountMax(string $callCountMax): void
+    {
+        $this->setWorkstation();
+        User::$workstation->scope['preferences']['queue']['callCountMax'] = $callCountMax;
+    }
+
+    private function assignCalledProcessToWorkstation(int $callCount): void
+    {
+        $process = (new \BO\Zmsdb\Process())->readEntity(self::CALLED_PROCESS_ID, self::CALLED_AUTHKEY, 1);
+        $process->status = Process::STATUS_CALLED;
+        $process['status'] = Process::STATUS_CALLED;
+        $process->queue['callCount'] = $callCount;
+        $process = (new \BO\Zmsdb\Process())->updateEntity($process, \App::$now, 0, Process::STATUS_CONFIRMED);
+        User::$workstation->process = (new \BO\Zmsdb\Workstation())->writeAssignedProcess(
+            User::$workstation,
+            $process,
+            \App::$now
+        );
     }
 }


### PR DESCRIPTION
Apply callCountMax when requeueing via "Nein, nächster Kunde bitte" so appointments stay on the waiting list until repeat calls are exhausted.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process requeue logic to correctly evaluate call count limits before marking processes as missed. Requeue and skip actions now properly follow the configured call count thresholds, ensuring more accurate process status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/eappointment/pull/2371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->