### PR TITLE
fix(GH-1782): harden parseJwt validation and error handling

### DIFF
--- a/zmscitizenview/src/utils/auth.ts
+++ b/zmscitizenview/src/utils/auth.ts
@@ -3,19 +3,92 @@ import { ref } from "vue";
 import { useDBSLoginWebcomponentPlugin } from "@/components/DBSLoginWebcomponentPlugin";
 import AuthorizationEventDetails from "@/types/AuthorizationEventDetails";
 
-function parseJwt(token: string) {
-  const base64Url = token.split(".")[1];
+class JwtParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "JwtParseError";
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+function getJwtPayloadSegment(token: string): string {
+  if (!token?.trim()) {
+    throw new JwtParseError("Invalid JWT: token must be a non-empty string");
+  }
+
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new JwtParseError(
+      `Invalid JWT: expected 3 dot-separated segments, got ${parts.length}`
+    );
+  }
+
+  const payloadSegment = parts[1];
+  if (!payloadSegment) {
+    throw new JwtParseError("Invalid JWT: payload segment is missing");
+  }
+
+  return payloadSegment;
+}
+
+function base64UrlToBase64(base64Url: string): string {
   const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
-  const jsonPayload = decodeURIComponent(
-    window
-      .atob(base64)
-      .split("")
-      .map(function (c) {
-        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
-      })
-      .join("")
-  );
-  return JSON.parse(jsonPayload);
+  const paddingLength = (4 - (base64.length % 4)) % 4;
+  return base64 + "=".repeat(paddingLength);
+}
+
+function decodeJwtPayloadSegment(payloadSegment: string): string {
+  const base64 = base64UrlToBase64(payloadSegment);
+
+  let decoded: string;
+  try {
+    decoded = window.atob(base64);
+  } catch (error) {
+    throw new JwtParseError("Invalid JWT: failed to base64-decode payload", {
+      cause: error,
+    });
+  }
+
+  try {
+    return decodeURIComponent(
+      decoded
+        .split("")
+        .map((character) => {
+          return "%" + ("00" + character.charCodeAt(0).toString(16)).slice(-2);
+        })
+        .join("")
+    );
+  } catch (error) {
+    throw new JwtParseError("Invalid JWT: failed to decode payload bytes", {
+      cause: error,
+    });
+  }
+}
+
+function parseJwt(token: string): Record<string, unknown> {
+  const payloadSegment = getJwtPayloadSegment(token);
+  const jsonPayload = decodeJwtPayloadSegment(payloadSegment);
+
+  try {
+    const parsed: unknown = JSON.parse(jsonPayload);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      throw new JwtParseError("Invalid JWT: payload must be a JSON object");
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof JwtParseError) {
+      throw error;
+    }
+    throw new JwtParseError("Invalid JWT: payload is not valid JSON", {
+      cause: error,
+    });
+  }
 }
 
 export function getTokenData(accessToken: string): {
@@ -23,7 +96,11 @@ export function getTokenData(accessToken: string): {
   given_name?: string;
   family_name?: string;
 } {
-  return parseJwt(accessToken);
+  return parseJwt(accessToken) as {
+    email?: string;
+    given_name?: string;
+    family_name?: string;
+  };
 }
 
 export function useLogin() {

--- a/zmscitizenview/tests/unit/utils/auth.spec.ts
+++ b/zmscitizenview/tests/unit/utils/auth.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { getTokenData } from "@/utils/auth";
+
+function createJwt(payload: Record<string, unknown>): string {
+  const json = JSON.stringify(payload);
+  const base64 = btoa(json);
+  const base64Url = base64
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `eyJhbGciOiJIUzI1NiJ9.${base64Url}.signature`;
+}
+
+describe("getTokenData / parseJwt", () => {
+  it("parses a valid JWT payload", () => {
+    const token = createJwt({
+      email: "user@example.com",
+      given_name: "Max",
+      family_name: "Mustermann",
+    });
+
+    expect(getTokenData(token)).toEqual({
+      email: "user@example.com",
+      given_name: "Max",
+      family_name: "Mustermann",
+    });
+  });
+
+  it("handles base64url payloads that require padding", () => {
+    const token = createJwt({ sub: "123" });
+
+    expect(getTokenData(token)).toEqual({ sub: "123" });
+  });
+
+  it("rejects tokens without three segments", () => {
+    expect(() => getTokenData("only-one-segment")).toThrow(
+      "Invalid JWT: expected 3 dot-separated segments, got 1"
+    );
+    expect(() => getTokenData("a.b")).toThrow(
+      "Invalid JWT: expected 3 dot-separated segments, got 2"
+    );
+  });
+
+  it("rejects tokens with an empty payload segment", () => {
+    expect(() => getTokenData("header..signature")).toThrow(
+      "Invalid JWT: payload segment is missing"
+    );
+  });
+
+  it("rejects empty tokens", () => {
+    expect(() => getTokenData("")).toThrow(
+      "Invalid JWT: token must be a non-empty string"
+    );
+  });
+
+  it("rejects invalid base64 payload", () => {
+    expect(() => getTokenData("a.!!!.c")).toThrow(
+      "Invalid JWT: failed to base64-decode payload"
+    );
+  });
+
+  it("rejects non-JSON payload", () => {
+    const notJson = btoa("not-json").replace(/\+/g, "-").replace(/\//g, "_");
+    expect(() => getTokenData(`a.${notJson}.c`)).toThrow(
+      "Invalid JWT: payload is not valid JSON"
+    );
+  });
+
+  it("rejects JSON payload that is not an object", () => {
+    const arrayPayload = btoa("[1,2,3]")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    expect(() => getTokenData(`a.${arrayPayload}.c`)).toThrow(
+      "Invalid JWT: payload must be a JSON object"
+    );
+  });
+});


### PR DESCRIPTION
Validate JWT structure, apply base64url padding before atob, and throw JwtParseError with clear messages when decoding or JSON parsing fails.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
