### PR TITLE
clean(GH-1582): add ProcessGetByExternalUserId for citizen access

### DIFF
--- a/zmsapi/routing.php
+++ b/zmsapi/routing.php
@@ -2625,6 +2625,55 @@ use \Psr\Http\Message\ResponseInterface;
 
 /**
  *  @swagger
+ *  "/process/{id}/externaluserid/{externalUserId}/":
+ *      get:
+ *          summary: Get a process for a citizen external user id (service auth)
+ *          description: "Trusted backends (e.g. zmscitizenapi after JWT validation) use this instead of WorkstationProcessGet. Requires X-Authkey and matching process.externalUserId."
+ *          tags:
+ *              - process
+ *          parameters:
+ *              -   name: X-Authkey
+ *                  required: true
+ *                  description: authentication key for service/workstation account
+ *                  in: header
+ *                  type: string
+ *              -   name: id
+ *                  description: process number
+ *                  in: path
+ *                  required: true
+ *                  type: integer
+ *              -   name: externalUserId
+ *                  description: external user id from citizen login (must match the process)
+ *                  in: path
+ *                  required: true
+ *                  type: string
+ *              -   name: resolveReferences
+ *                  description: "Resolve references with $ref"
+ *                  in: query
+ *                  type: integer
+ *          responses:
+ *              200:
+ *                  description: "success"
+ *                  schema:
+ *                      type: object
+ *                      properties:
+ *                          meta:
+ *                              $ref: "schema/metaresult.json"
+ *                          data:
+ *                              $ref: "schema/process.json"
+ *              403:
+ *                  description: "external user id does not match"
+ *              404:
+ *                  description: "process not found"
+ */
+\App::$slim->get(
+    '/process/{id:\d{1,11}}/externaluserid/{externalUserId}/',
+    '\BO\Zmsapi\ProcessGetByExternalUserId'
+)
+    ->setName("ProcessGetByExternalUserId");
+
+/**
+ *  @swagger
  *  "/process/{id}/{authKey}/appointment/":
  *      post:
  *          summary: Update an appointment of a process

--- a/zmsapi/src/Zmsapi/Exception/Process/ExternalUserIdMatchFailed.php
+++ b/zmsapi/src/Zmsapi/Exception/Process/ExternalUserIdMatchFailed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BO\Zmsapi\Exception\Process;
+
+class ExternalUserIdMatchFailed extends \Exception
+{
+    protected $code = 403;
+
+    protected $message = 'The process is not assigned to this external user id.';
+}

--- a/zmsapi/src/Zmsapi/ProcessGetByExternalUserId.php
+++ b/zmsapi/src/Zmsapi/ProcessGetByExternalUserId.php
@@ -28,7 +28,7 @@ class ProcessGetByExternalUserId extends BaseController
     ) {
         (new Helper\User($request, 2))->checkRights();
 
-        $resolveReferences = Validator::param('resolveReferences')->isNumber()->setDefault(2)->getValue();
+        $resolveReferences = (int) (Validator::param('resolveReferences')->isNumber()->setDefault(2)->getValue() ?? 2);
         $processId = (int) $args['id'];
         $externalUserId = $args['externalUserId'];
 

--- a/zmsapi/src/Zmsapi/ProcessGetByExternalUserId.php
+++ b/zmsapi/src/Zmsapi/ProcessGetByExternalUserId.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @package ZMS API
+ * @copyright BerlinOnline Stadtportal GmbH & Co. KG
+ **/
+
+namespace BO\Zmsapi;
+
+use BO\Slim\Render;
+use BO\Mellon\Validator;
+use BO\Zmsdb\Process;
+
+/**
+ * Citizen-scoped process read for trusted backends (e.g. zmscitizenapi after JWT validation).
+ * Requires workstation/service authentication via X-Authkey and matching external user id.
+ */
+class ProcessGetByExternalUserId extends BaseController
+{
+    /**
+     * @SuppressWarnings(Param)
+     * @return String
+     */
+    public function readResponse(
+        \Psr\Http\Message\RequestInterface $request,
+        \Psr\Http\Message\ResponseInterface $response,
+        array $args
+    ) {
+        (new Helper\User($request, 2))->checkRights();
+
+        $resolveReferences = Validator::param('resolveReferences')->isNumber()->setDefault(2)->getValue();
+        $processId = (int) $args['id'];
+        $externalUserId = $args['externalUserId'];
+
+        $process = (new Process())->readEntity(
+            $processId,
+            new \BO\Zmsdb\Helper\NoAuth(),
+            $resolveReferences
+        );
+
+        if (!$process || !$process->hasId()) {
+            $exception = new Exception\Process\ProcessNotFound();
+            $exception->data = ['processId' => $processId];
+            throw $exception;
+        }
+
+        $this->validateExternalUserId($process, $externalUserId);
+
+        $message = Response\Message::create($request);
+        $message->data = $process;
+
+        $response = Render::withLastModified($response, time(), '0');
+        $response = Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
+        return $response;
+    }
+
+    protected function validateExternalUserId(\BO\Zmsentities\Process $process, string $externalUserId): void
+    {
+        $processExternalUserId = $process->getExternalUserId();
+        if (
+            $processExternalUserId === null
+            || $processExternalUserId === ''
+            || (string) $processExternalUserId !== (string) $externalUserId
+        ) {
+            throw new Exception\Process\ExternalUserIdMatchFailed();
+        }
+    }
+}

--- a/zmsapi/tests/Zmsapi/ProcessGetByExternalUserIdTest.php
+++ b/zmsapi/tests/Zmsapi/ProcessGetByExternalUserIdTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace BO\Zmsapi\Tests;
+
+class ProcessGetByExternalUserIdTest extends Base
+{
+    protected $classname = "ProcessGetByExternalUserId";
+
+    const PROCESS_ID = 10030;
+
+    const AUTHKEY = '1c56';
+
+    const EXTERNAL_USER_ID = 'gh1582-citizen-user';
+
+    protected function assignExternalUserIdToTestProcess(): void
+    {
+        $process = (new \BO\Zmsdb\Process())->readEntity(self::PROCESS_ID, self::AUTHKEY, 0);
+        $process->setExternalUserId(self::EXTERNAL_USER_ID);
+        (new \BO\Zmsdb\Process())->updateEntity($process, \App::$now, 0);
+    }
+
+    public function testRendering()
+    {
+        $this->setWorkstation();
+        $this->assignExternalUserIdToTestProcess();
+
+        $response = $this->render(
+            ['id' => self::PROCESS_ID, 'externalUserId' => self::EXTERNAL_USER_ID],
+            [],
+            []
+        );
+
+        $this->assertStringContainsString('process.json', (string) $response->getBody());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testExternalUserIdMatchFailed()
+    {
+        $this->setWorkstation();
+        $this->assignExternalUserIdToTestProcess();
+
+        $this->expectException('\BO\Zmsapi\Exception\Process\ExternalUserIdMatchFailed');
+        $this->expectExceptionCode(403);
+        $this->render(
+            ['id' => self::PROCESS_ID, 'externalUserId' => 'other-user'],
+            [],
+            []
+        );
+    }
+
+    public function testNotFound()
+    {
+        $this->setWorkstation();
+
+        $this->expectException('\BO\Zmsapi\Exception\Process\ProcessNotFound');
+        $this->expectExceptionCode(404);
+        $this->render(
+            ['id' => 999999, 'externalUserId' => self::EXTERNAL_USER_ID],
+            [],
+            []
+        );
+    }
+
+    public function testNoLogin()
+    {
+        $this->expectException('BO\Zmsentities\Exception\UseraccountMissingLogin');
+        $this->expectExceptionCode(401);
+        $this->render(
+            ['id' => self::PROCESS_ID, 'externalUserId' => self::EXTERNAL_USER_ID],
+            [],
+            []
+        );
+    }
+}

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ExceptionService.php
@@ -53,6 +53,7 @@ class ExceptionService
 
                 break;
             case 'BO\\Zmsapi\\Exception\\Process\\AuthKeyMatchFailed':
+            case 'BO\\Zmsapi\\Exception\\Process\\ExternalUserIdMatchFailed':
                 $error = self::getError('authKeyMismatch');
 
                 break;

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
@@ -398,14 +398,22 @@ class ZmsApiClientService
         }
     }
 
-    public static function getProcessByIdAuthenticated(int $processId): Process
+    /**
+     * Load a process for a citizen authenticated via JWT (validated in zmscitizenapi).
+     * Calls zmsapi ProcessGetByExternalUserId — not WorkstationProcessGet — so access
+     * is limited to processes owned by the given external user id (GH-1582).
+     */
+    public static function getProcessByIdAuthenticated(int $processId, string $externalUserId): Process
     {
         try {
             $resolveReferences = 2;
-            // This endpoint is normally reserved for workstation (zmsadmin) Users.
-            $result = \App::$http->readGetResult("/process/{$processId}/", [
-                'resolveReferences' => $resolveReferences
-            ]);
+            $externalUserIdUrlEncoded = urlencode($externalUserId);
+            $result = \App::$http->readGetResult(
+                "/process/{$processId}/externaluserid/{$externalUserIdUrlEncoded}/",
+                [
+                    'resolveReferences' => $resolveReferences,
+                ]
+            );
             $entity = $result?->getEntity();
             if (!$entity instanceof Process) {
                 return new Process();

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiClientService.php
@@ -407,7 +407,7 @@ class ZmsApiClientService
     {
         try {
             $resolveReferences = 2;
-            $externalUserIdUrlEncoded = urlencode($externalUserId);
+            $externalUserIdUrlEncoded = rawurlencode($externalUserId);
             $result = \App::$http->readGetResult(
                 "/process/{$processId}/externaluserid/{$externalUserIdUrlEncoded}/",
                 [
@@ -507,7 +507,7 @@ class ZmsApiClientService
             if (!is_null($status)) {
                 $params['status'] = $status;
             }
-            $externalUserIdUrlEncoded = urlencode($externalUserId);
+            $externalUserIdUrlEncoded = rawurlencode($externalUserId);
             $result = \App::$http->readGetResult("/process/externaluserid/{$externalUserIdUrlEncoded}/", $params);
             $collection = $result?->getCollection();
             if (!$collection instanceof ProcessList) {

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -803,11 +803,7 @@ class ZmsApiFacadeService
             return ZmsApiClientService::getProcessById($processId, $authKey);
         } elseif (!is_null($user)) {
             $externalUserId = $user->getExternalUserId();
-            $process = ZmsApiClientService::getProcessByIdAuthenticated($processId);
-            if ($externalUserId !== $process->getExternalUserId()) {
-                throw new UnauthorizedException();
-            }
-            return $process;
+            return ZmsApiClientService::getProcessByIdAuthenticated($processId, $externalUserId);
         } else {
             throw new UnauthorizedException();
         }


### PR DESCRIPTION
Introduce GET /process/{id}/externaluserid/{externalUserId}/ for trusted backends after JWT validation. zmscitizenapi uses it instead of WorkstationProcessGet; zmsapi enforces external user id ownership.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for retrieving process information using external user ID authentication, designed for trusted backend services.
  * Enhanced authorization validation to verify processes are assigned to the specified external user.

* **Tests**
  * Added comprehensive test coverage for the new external user ID-based process retrieval functionality, including success and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/eappointment/pull/2375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->