### PR TITLE
chore(GH-1547): replace deprecated docker-compose CLI usage

### DIFF
--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -271,12 +271,6 @@ jobs:
           done
         shell: bash
 
-      - name: Install Docker Compose
-        run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          docker-compose --version
-
       - name: Run Unit Tests
         env:
           XDEBUG_MODE: coverage
@@ -284,10 +278,10 @@ jobs:
           set -e  # Exit immediately on any error
           cd ./zmsclient
           mkdir -p coverage
-          docker-compose up -d
+          docker compose up -d
           
           echo "Running tests WITH coverage for zmsclient"
-          docker-compose exec -T test php -dmemory_limit=-1 \
+          docker compose exec -T test php -dmemory_limit=-1 \
             ./vendor/bin/phpunit \
             --coverage-html coverage/html \
             --coverage-clover coverage/clover.xml \

--- a/docs/de/testing-and-automation/testing-unit.md
+++ b/docs/de/testing-and-automation/testing-unit.md
@@ -53,7 +53,7 @@ Für `zmsclient` benötigst du das PHP-Basis-Image, das einen lokalen Mock-Serve
 
 ```bash
 cd zmsclient
-docker-compose down && docker-compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
+docker compose down && docker compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
 ```
 
 **Mit Podman:**

--- a/docs/en/testing-and-automation/testing-unit.md
+++ b/docs/en/testing-and-automation/testing-unit.md
@@ -53,7 +53,7 @@ For `zmsclient` you need the php base image which starts a local mock server. Th
 
 ```bash
 cd zmsclient
-docker-compose down && docker-compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
+docker compose down && docker compose up -d && docker exec zmsclient-test-1 ./vendor/bin/phpunit
 ```
 
 **Using Podman:**

--- a/zmsclient/README.md
+++ b/zmsclient/README.md
@@ -42,13 +42,13 @@ Setting up default CURL-Options, use the following line:
 
 ## Testing
 
-If you want to run the test, docker-compose is required. Testing needs an HTTP server to answer the HTTP calls from this library.
+If you want to run the test, Docker with the Compose V2 plugin (`docker compose`) is required. Testing needs an HTTP server to answer the HTTP calls from this library.
 
 Run the following command:
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
-The docker-compose starts the mockup server, waits 10 seconds and starts the unit tests. After the tests are finished, the mockup server is still running. If there are failures, you need to lookup possible HTTP calls. There is a port forwarding and you can see the calls under http://localhost:8082/
+Docker Compose starts the mockup server, waits 10 seconds and starts the unit tests. After the tests are finished, the mockup server is still running. If there are failures, you need to lookup possible HTTP calls. There is a port forwarding and you can see the calls under http://localhost:8082/
 

--- a/zmsclient/bin/coverage
+++ b/zmsclient/bin/coverage
@@ -11,6 +11,6 @@ EEND="\033[00m"
 echo "Testing application with coverage"
 cd $ROOT
 
-docker-compose up -d
+docker compose up -d
 XDEBUG_MODE=coverage php -dmemory_limit=-1 $ROOT/vendor/bin/phpunit -v --colors=never --coverage-text --coverage-html $ROOT/public/_tests/coverage/ --log-junit $ROOT/public/_tests/junit.xml
-docker-compose down
+docker compose down

--- a/zmsclient/bin/test
+++ b/zmsclient/bin/test
@@ -27,7 +27,7 @@ else
     echo "Checking $PHPFILES"
 fi
 
-docker-compose up -d
+docker compose up -d
 
 docker exec zmsclient_test_1 vendor/bin/phpcs --standard=psr2 $PHPFILES
 if [ $? -eq 0 ]; then
@@ -38,4 +38,4 @@ if [ $? -eq 0 ]; then
     docker exec zmsclient_test_1 vendor/bin/phpunit -v
 fi
 
-docker-compose down
+docker compose down

--- a/zmsclient/zmsclient-test
+++ b/zmsclient/zmsclient-test
@@ -80,13 +80,10 @@ fi
 
 if [[ "$USE_PODMAN" == false ]]; then
   require_cmd docker
-  # Check for docker compose v2 (space) or v1 (hyphen)
   if docker compose version >/dev/null 2>&1; then
     COMPOSE_CMD="docker compose"
-  elif command -v docker-compose >/dev/null 2>&1; then
-    COMPOSE_CMD="docker-compose"
   else
-    echo "ERROR: docker compose or docker-compose is required" >&2
+    echo "ERROR: docker compose (Compose V2 plugin) is required" >&2
     exit 1
   fi
   info "Using Docker ($COMPOSE_CMD)"


### PR DESCRIPTION
Use Docker Compose V2 (`docker compose`) in docs, zmsclient-test, and CI. Drop standalone docker-compose v1 install in php-unit-tests workflow.

Compose file names (e.g. docker-compose.yml) are unchanged.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
