### PR TITLE
fix(ZMSKVR): use app DB credentials in zmsdb config example

### DIFF
--- a/zmsdb/config.example.php
+++ b/zmsdb/config.example.php
@@ -17,11 +17,12 @@ if (getenv('MYSQL_PORT')) {
 } else {
     $host = '127.0.0.1';
 }
-if (getenv('MYSQL_PASSWORD') || getenv('MYSQL_ROOT_PASSWORD')) {
-    \BO\Zmsdb\Connection\Select::$username = 
-        getenv('MYSQL_USER') ? getenv('MYSQL_USER') : 'root';
-    \BO\Zmsdb\Connection\Select::$password =
-        getenv('MYSQL_ROOT_PASSWORD') ? getenv('MYSQL_ROOT_PASSWORD') : getenv('MYSQL_PASSWORD');
+if (getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD')) {
+    \BO\Zmsdb\Connection\Select::$username = getenv('MYSQL_USER');
+    \BO\Zmsdb\Connection\Select::$password = getenv('MYSQL_PASSWORD');
+} elseif (getenv('MYSQL_ROOT_PASSWORD')) {
+    \BO\Zmsdb\Connection\Select::$username = 'root';
+    \BO\Zmsdb\Connection\Select::$password = getenv('MYSQL_ROOT_PASSWORD');
 } else {
     \BO\Zmsdb\Connection\Select::$username = 'server';
     \BO\Zmsdb\Connection\Select::$password = 'internet';


### PR DESCRIPTION
vendor/bin/migrate loads zmsdb/config.php in the monorepo layout. Prefer MYSQL_USER and MYSQL_PASSWORD over MYSQL_ROOT_PASSWORD so the app user is not authenticated with the root password when both env vars are set.

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
