### PR TITLE
clean(GH-1168): fix TypeScript path aliases in zmscitizenview tests

### DIFF
--- a/zmscitizenview/package.json
+++ b/zmscitizenview/package.json
@@ -8,6 +8,7 @@
     "build": "vite build --mode production && npm run post-build",
     "post-build": "node ./processes/post-build.js",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false",
+    "type-check:tests": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "prettier src/ --check",
     "format": "prettier --write src/",
     "test": "vitest run",

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
@@ -1,13 +1,11 @@
-import { mount } from "@vue/test-utils";
+import { mount, type VueWrapper } from "@vue/test-utils";
 import { describe, it, expect, vi, type Mock, beforeEach, afterEach } from "vitest";
 import { flushPromises } from '@vue/test-utils';
-// @ts-expect-error: Vue SFC import for test
 import AppointmentSelection from "@/components/Appointment/AppointmentSelection.vue";
-import { ref, nextTick } from "vue";
+import { ref, nextTick, type Ref } from "vue";
 import {
   fetchAvailableDays,
   fetchAvailableTimeSlots,
-// @ts-expect-error: API import for test
 } from "@/api/ZMSAppointmentAPI";
 
 const t = vi.fn((key: string) => key);
@@ -30,6 +28,13 @@ vi.mock('@/api/ZMSAppointmentAPI', () => ({
   fetchAvailableDays: vi.fn(),
   fetchAvailableTimeSlots: vi.fn(),
 }));
+
+interface LoadingStates {
+  isReservingAppointment: Ref<boolean>;
+  isUpdatingAppointment: Ref<boolean>;
+  isBookingAppointment: Ref<boolean>;
+  isCancelingAppointment: Ref<boolean>;
+}
 
 interface WrapperOverrides {
   selectedService?: any;
@@ -1561,9 +1566,9 @@ describe("AppointmentSelection", () => {
   });
 
   describe('Submission/Loading State Integration', () => {
-    let wrapper;
-    let selectedTimeslotRef;
-    let loadingStates;
+    let wrapper: VueWrapper<InstanceType<typeof AppointmentSelection>>;
+    let selectedTimeslotRef: Ref<number>;
+    let loadingStates: LoadingStates;
     beforeEach(async () => {
       selectedTimeslotRef = ref(0);
       loadingStates = {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/AppointmentPreview.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/AppointmentPreview.spec.ts
@@ -1,6 +1,5 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect, vi } from "vitest";
-// @ts-expect-error: SFC import for test
 import AppointmentPreview from "@/components/Appointment/AppointmentSelection/AppointmentPreview.vue";
 
 const t = vi.fn((key: string) => key);

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/CalendarListToggle.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/CalendarListToggle.spec.ts
@@ -1,7 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect, vi } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: SFC import for test
 import CalendarListToggle from "@/components/Appointment/AppointmentSelection/CalendarListToggle.vue";
 
 const t = vi.fn((key: string) => key);

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/CalendarView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/CalendarView.spec.ts
@@ -1,7 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: SFC import for test
 import CalendarView from "@/components/Appointment/AppointmentSelection/CalendarView.vue";
 
 const t = (key: string) => key;

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ListView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ListView.spec.ts
@@ -1,7 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { describe, it, expect } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: SFC import for test
 import ListView from "@/components/Appointment/AppointmentSelection/ListView.vue";
 
 describe("ListView", () => {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ProviderSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/ProviderSelection.spec.ts
@@ -2,7 +2,6 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, nextTick } from "vue";
 // Mount parent to exercise logic and assert ProviderSelection UI
-// @ts-expect-error: Vue SFC import for test
 import AppointmentSelection from "@/components/Appointment/AppointmentSelection.vue";
 
 // Mock API to avoid real network calls

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection/TimeSlotGrid.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection/TimeSlotGrid.spec.ts
@@ -4,7 +4,6 @@ import { nextTick } from "vue";
 vi.mock("@/utils/formatAppointmentDateTime", () => ({
   formatTimeFromUnix: (t: number) => `fmt-${t}`,
 }));
-// @ts-expect-error: SFC import for test
 import TimeSlotGrid from "@/components/Appointment/AppointmentSelection/TimeSlotGrid.vue";
 
 describe("TimeSlotGrid", () => {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSummary.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSummary.spec.ts
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, beforeEach } from "vitest";
 import { nextTick, ref } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import AppointmentSummary from "@/components/Appointment/AppointmentSummary.vue";
 
 describe("AppointmentSummary", () => {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -1,11 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick, ref } from "vue";
-// @ts-expect-error: Vue SFC import for test
 import * as ZMSAppointmentAPI from "@/api/ZMSAppointmentAPI";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
-// @ts-expect-error: Vue SFC import for test
 import AppointmentView from "@/components/Appointment/AppointmentView.vue";
 import { useLogin } from "@/utils/auth";
 // beforeEach is already imported from vitest on line 2

--- a/zmscitizenview/tests/unit/Appointment/CustomerInfo.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/CustomerInfo.spec.ts
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, beforeEach } from "vitest";
 import { nextTick, ref } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import CustomerInfo from "@/components/Appointment/CustomerInfo.vue";
 
 describe("CustomerInfo", () => {

--- a/zmscitizenview/tests/unit/Appointment/ServiceFinder.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/ServiceFinder.spec.ts
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { nextTick, ref } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import ServiceFinder from "@/components/Appointment/ServiceFinder.vue";
 
 interface ServiceImpl {

--- a/zmscitizenview/tests/unit/Appointment/ServiceFinder/AltchaCaptcha.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/ServiceFinder/AltchaCaptcha.spec.ts
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import AltchaCaptcha from "@/components/Appointment/ServiceFinder/AltchaCaptcha.vue";
 
 // Mock window.scrollTo for jsdom

--- a/zmscitizenview/tests/unit/Appointment/ServiceFinder/SubserviceListItem.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/ServiceFinder/SubserviceListItem.spec.ts
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { nextTick } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import SubserviceListItem from "@/components/Appointment/ServiceFinder/SubserviceListItem.vue";
 
 describe("SubserviceListItem", () => {

--- a/zmscitizenview/tests/unit/AppointmentDetail/AppointmentDetailHeader.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentDetail/AppointmentDetailHeader.spec.ts
@@ -1,10 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
 import { nextTick } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import AppointmentDetailHeader from "@/components/AppointmentDetail/AppointmentDetailHeader.vue";
 
 describe("AppointmentDetailHeader", () => {

--- a/zmscitizenview/tests/unit/AppointmentDetail/AppointmentDetailView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentDetail/AppointmentDetailView.spec.ts
@@ -1,10 +1,8 @@
 import { mount } from "@vue/test-utils";
 import {afterAll, beforeAll, describe, expect, it, vi} from "vitest";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
 import { nextTick } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import AppointmentDetailView from "@/components/AppointmentDetail/AppointmentDetailView.vue";
 
 globalThis.scrollTo = vi.fn();

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCard.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCard.spec.ts
@@ -1,9 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
-// @ts-expect-error: Vue SFC import for test
 import AppointmentCard from "@/components/AppointmentOverview/AppointmentCard.vue";
 
 describe("AppointmentCard", () => {

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCardViewer.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCardViewer.spec.ts
@@ -1,9 +1,7 @@
 import {mount} from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
-// @ts-expect-error: Vue SFC import for test
 import AppointmentCardViewer from "@/components/AppointmentOverview/AppointmentCardViewer.vue";
 
 globalThis.scrollTo = vi.fn();

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentOverviewView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentOverviewView.spec.ts
@@ -1,9 +1,7 @@
 import {mount} from "@vue/test-utils";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
-// @ts-expect-error: Vue SFC import for test
 import AppointmentOverviewView from "@/components/AppointmentOverview/AppointmentOverviewView.vue";
 
 globalThis.scrollTo = vi.fn();

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentSliderView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentSliderView.spec.ts
@@ -1,9 +1,7 @@
 import {mount} from "@vue/test-utils";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-// @ts-expect-error: Vue SFC import for test
 import de from '@/utils/de-DE.json';
-// @ts-expect-error: Vue SFC import for test
 import AppointmentSliderView from "@/components/AppointmentOverview/AppointmentSliderView.vue";
 
 globalThis.scrollTo = vi.fn();

--- a/zmscitizenview/tests/unit/api/ZMSAppointmentAPI.spec.ts
+++ b/zmscitizenview/tests/unit/api/ZMSAppointmentAPI.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-// @ts-expect-error: API import for test
 import { fetchServicesAndProviders } from "@/api/ZMSAppointmentAPI";
 
 global.fetch = vi.fn();

--- a/zmscitizenview/tests/unit/utils/apiStatusService.spec.ts
+++ b/zmscitizenview/tests/unit/utils/apiStatusService.spec.ts
@@ -7,7 +7,6 @@ import {
   isInMaintenanceMode,
   isInSystemFailureMode,
   setApiStatus,
-// @ts-expect-error: API import for test
 } from "@/utils/apiStatusService";
 
 vi.mock("@/api/ZMSAppointmentAPI", () => {
@@ -16,7 +15,6 @@ vi.mock("@/api/ZMSAppointmentAPI", () => {
   };
 });
 
-// @ts-expect-error: API import for test
 const mockedApi = await import("@/api/ZMSAppointmentAPI");
 
 describe("apiStatusService", () => {

--- a/zmscitizenview/tests/unit/utils/calculateEstimatedDuration.spec.ts
+++ b/zmscitizenview/tests/unit/utils/calculateEstimatedDuration.spec.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect } from "vitest";
-// @ts-expect-error: Vue SFC import for test
 import { calculateEstimatedDuration } from "@/utils/calculateEstimatedDuration";
-// @ts-expect-error: Vue SFC import for test
 import { ServiceImpl } from "@/types/ServiceImpl";
-// @ts-expect-error: Vue SFC import for test
 import { OfficeImpl } from "@/types/OfficeImpl";
-// @ts-expect-error: Vue SFC import for test
 import { SubService } from "@/types/SubService";
 
 function makeProvider(id: string, slotTimeInMinutes = 10, slots = 1): OfficeImpl {

--- a/zmscitizenview/tests/unit/utils/errorHandler.spec.ts
+++ b/zmscitizenview/tests/unit/utils/errorHandler.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { ref } from "vue";
 
-// @ts-expect-error: Vue SFC import for test
 import { handleApiResponse, createErrorStates, handleApiError, type ApiErrorData } from "@/utils/errorHandler";
 
 describe("errorHandler", () => {

--- a/zmscitizenview/tests/unit/utils/getProviders.spec.ts
+++ b/zmscitizenview/tests/unit/utils/getProviders.spec.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-// @ts-expect-error: Vue SFC import for test
 import { getProviders } from "@/utils/getProviders";
 
 const relations = [

--- a/zmscitizenview/tests/unit/utils/infoForAllAppointments.spec.ts
+++ b/zmscitizenview/tests/unit/utils/infoForAllAppointments.spec.ts
@@ -4,7 +4,6 @@ import {
   optimizeProviderNames,
   generateAvailabilityInfoHtml,
   type ProviderInfo,
-// @ts-expect-error: Vue SFC import for test
 } from "@/utils/infoForAllAppointments";
 
 // Mock sanitizeHtml function

--- a/zmscitizenview/tests/unit/utils/sanitizeHtml.spec.ts
+++ b/zmscitizenview/tests/unit/utils/sanitizeHtml.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 
-// @ts-expect-error: Vue SFC import for test
 import { sanitizeHtml } from "@/utils/sanitizeHtml";
 
 describe("sanitizeHtml", () => {

--- a/zmscitizenview/tsconfig.app.json
+++ b/zmscitizenview/tsconfig.app.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ],
+  "exclude": ["node_modules", "tests"]
+}

--- a/zmscitizenview/tsconfig.json
+++ b/zmscitizenview/tsconfig.json
@@ -1,33 +1,14 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "jsx": "preserve",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "lib": ["ESNext", "DOM"],
-    "skipLibCheck": true,
-    "noEmit": true,
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue",
-    "auto-imports.d.ts"
-  ],
+  "files": [],
   "references": [
     {
+      "path": "./tsconfig.app.json"
+    },
+    {
       "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.vitest.json"
     }
-  ],
-  "exclude": ["node_modules"]
+  ]
 }

--- a/zmscitizenview/tsconfig.node.json
+++ b/zmscitizenview/tsconfig.node.json
@@ -7,6 +7,7 @@
     "types": ["node"]
   },
   "include": [
-    "vite.config.ts"
+    "vite.config.ts",
+    "vitest.config.ts"
   ]
 }

--- a/zmscitizenview/tsconfig.vitest.json
+++ b/zmscitizenview/tsconfig.vitest.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"]
+  },
+  "include": [
+    "tests/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Split tsconfig into app/vitest projects so @/ imports resolve in test files without @ts-expect-error suppressions, and add type-check:tests script.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
