### PR TITLE
clean(GH-1421): standardize Process entity property access in zmsdb

### DIFF
--- a/zmsdb/src/Zmsdb/Process.php
+++ b/zmsdb/src/Zmsdb/Process.php
@@ -48,10 +48,10 @@ class Process extends Base implements Interfaces\ResolveReferences
     {
         if (0 <= $resolveReferences) {
             if ($process->archiveId) {
-                $process['requests'] = (new Request())
+                $process->requests = (new Request())
                     ->readRequestByArchiveId($process->archiveId, $resolveReferences - 1);
             } else {
-                $process['requests'] = (new Request())
+                $process->requests = (new Request())
                     ->readRequestByProcessId($process->id, $resolveReferences - 1);
             }
         }
@@ -65,8 +65,8 @@ class Process extends Base implements Interfaces\ResolveReferences
     public function updateEntity(\BO\Zmsentities\Process $process, \DateTimeInterface $now, $resolveReferences = 0, $previousStatus = null, ?\BO\Zmsentities\Useraccount $useraccount = null)
     {
         $query = new Query\Process(Query\Base::UPDATE);
-        $query->addConditionProcessId($process['id']);
-        $query->addConditionAuthKey($process['authKey']);
+        $query->addConditionProcessId($process->getId());
+        $query->addConditionAuthKey($process->getAuthKey());
         $query->addValuesUpdateProcess($process, $now, 0, $previousStatus);
         if ($this->perform($query->getLockProcessId(), ['processId' => $process->getId()])) {
             $this->writeItem($query);
@@ -87,8 +87,8 @@ class Process extends Base implements Interfaces\ResolveReferences
     public function updateEntityDisplayNumber(Entity $process)
     {
         $query = new Query\Process(Query\Base::UPDATE);
-        $query->addConditionProcessId($process['id']);
-        $query->addConditionAuthKey($process['authKey']);
+        $query->addConditionProcessId($process->getId());
+        $query->addConditionAuthKey($process->getAuthKey());
 
         $process->displayNumber = $query->getNewDisplayNumber($process);
         $query->addValueDisplayNumber($process);

--- a/zmsdb/src/Zmsdb/ProcessStatusFree.php
+++ b/zmsdb/src/Zmsdb/ProcessStatusFree.php
@@ -187,8 +187,8 @@ class ProcessStatusFree extends Process
         $resultData = $this->fetchList($query, new Entity());
         foreach ($resultData as $process) {
             if (2 == $resolveReferences) {
-                $process['requests'] = (new Request())->readRequestByProcessId($process->id, $resolveReferences);
-                $process['scope'] = (new Scope())->readEntity($process->getScopeId(), $resolveReferences);
+                $process->requests = (new Request())->readRequestByProcessId($process->id, $resolveReferences);
+                $process->scope = (new Scope())->readEntity($process->getScopeId(), $resolveReferences);
             }
             if ($process instanceof Entity) {
                 $processList->addEntity($process);

--- a/zmsdb/src/Zmsdb/Query/Process.php
+++ b/zmsdb/src/Zmsdb/Query/Process.php
@@ -3,6 +3,7 @@
 namespace BO\Zmsdb\Query;
 
 use BO\Zmsdb\Scope as ScopeEntity;
+use BO\Zmsentities\Process as ProcessEntity;
 use BO\Zmsdldb\Helper\DateTime;
 use DateTimeImmutable;
 
@@ -696,7 +697,7 @@ class Process extends Base implements MappingInterface
         return $this;
     }
 
-    public function addValuesNewProcess(\BO\Zmsentities\Process $process, $parentProcess = 0, $childProcessCount = 0)
+    public function addValuesNewProcess(ProcessEntity $process, $parentProcess = 0, $childProcessCount = 0)
     {
         $values = [
             'BuergerID' => $process->id,
@@ -756,7 +757,7 @@ class Process extends Base implements MappingInterface
     }
 
     public function addValuesUpdateProcess(
-        \BO\Zmsentities\Process $process,
+        ProcessEntity $process,
         \DateTimeInterface $dateTime,
         $parentProcess = 0,
         $previousStatus = null
@@ -778,10 +779,10 @@ class Process extends Base implements MappingInterface
         $this->addValuesExternalUserId($process);
     }
 
-    public function addValuesIPAdress($process)
+    public function addValuesIPAdress(ProcessEntity $process)
     {
         $data = array();
-        $data['IPAdresse'] = $process['createIP'];
+        $data['IPAdresse'] = $process->createIP;
         $this->addValues($data);
     }
 
@@ -799,7 +800,7 @@ class Process extends Base implements MappingInterface
     }
 
     public function addValuesAppointmentData(
-        \BO\Zmsentities\Process $process
+        ProcessEntity $process
     ) {
         $data = array();
         $appointment = $process->getFirstAppointment();
@@ -812,24 +813,24 @@ class Process extends Base implements MappingInterface
     }
 
     public function addValuesScopeData(
-        \BO\Zmsentities\Process $process
+        ProcessEntity $process
     ) {
         $data = array();
         $data['StandortID'] = $process->getScopeId();
         $this->addValues($data);
     }
 
-    public function addValuesStatusData($process, \DateTimeInterface $dateTime)
+    public function addValuesStatusData(ProcessEntity $process, \DateTimeInterface $dateTime)
     {
         $data = array();
-        $data['vorlaeufigeBuchung'] = ($process['status'] == 'reserved') ? 1 : 0;
-        $data['aufruferfolgreich'] = ($process['status'] == 'processing') ? 1 : 0;
+        $data['vorlaeufigeBuchung'] = ($process->status == 'reserved') ? 1 : 0;
+        $data['aufruferfolgreich'] = ($process->status == 'processing') ? 1 : 0;
         if ($process->status == 'called') {
             $data['parked'] = 0;
             $data['nicht_erschienen'] = 0;
         }
         if ($process->status == 'pending') {
-            $data['AbholortID'] = $process->scope['id'];
+            $data['AbholortID'] = $process->scope->id;
             $data['Abholer'] = 1;
             $data['nicht_erschienen'] = 0;
             $data['parked'] = 0;
@@ -839,7 +840,7 @@ class Process extends Base implements MappingInterface
             $data['parked'] = 0;
             if (
                 $process->hasArrivalTime() &&
-                (isset($process->queue['withAppointment']) && $process->queue['withAppointment'])
+                (isset($process->queue->withAppointment) && $process->queue->withAppointment)
             ) {
                 $data['wsm_aufnahmezeit'] = $dateTime->format('H:i:s');
             }
@@ -856,7 +857,7 @@ class Process extends Base implements MappingInterface
         if ($process->status == 'preconfirmed') {
             $data['bestaetigt'] = 0;
         }
-        $data['status'] = $process['status'] ?? $process->status;
+        $data['status'] = $process->status;
         $data['parkedBy'] = $process->getParkedBy();
 
         $this->addValues($data);
@@ -1002,13 +1003,13 @@ class Process extends Base implements MappingInterface
         $this->addValues($data);
     }
 
-    protected function addValuesWaitingTimeData($process, $previousStatus = null)
+    protected function addValuesWaitingTimeData(ProcessEntity $process, $previousStatus = null)
     {
         $data = array();
         $hasWaitingTimeAlready = (
-            isset($process->queue['waitingTime'])
-            && $process->queue['waitingTime']
-            && $process->queue['waitingTime'] !== '00:00:00'
+            isset($process->queue->waitingTime)
+            && $process->queue->waitingTime
+            && $process->queue->waitingTime !== '00:00:00'
         );
 
         if (
@@ -1017,17 +1018,17 @@ class Process extends Base implements MappingInterface
             (
                 // Szenario 1: Vorheriger Status ist queued, missed oder confirmed und aktueller Status ist called
                 in_array($previousStatus, ['queued', 'missed', 'confirmed'])
-                && $process['status'] == 'called'
+                && $process->status == 'called'
                 && (
                     (
-                        isset($process->queue['callCount'])
-                        && $process->queue['callCount'] <= 0
+                        isset($process->queue->callCount)
+                        && $process->queue->callCount <= 0
                     )
                     || (
                         ($previousStatus === 'queued' || $previousStatus === 'confirmed')
                         && (
-                            !isset($process->queue['callTime'])
-                            || (int) $process->queue['callTime'] === 0
+                            !isset($process->queue->callTime)
+                            || (int) $process->queue->callTime === 0
                         )
                     )
                 )
@@ -1037,8 +1038,8 @@ class Process extends Base implements MappingInterface
                 // Szenario 2: Vorheriger Status ist missed, aktueller Status ist queued,
                 // es gibt den Hinweis wasMissed und die Queue sowie waitingTime sind gesetzt
                 $previousStatus == 'missed'
-                && $process['status'] == 'queued'
-                && !empty($process['wasMissed'])
+                && $process->status == 'queued'
+                && !empty($process->wasMissed)
                 && isset($process->queue)
                 && isset($process->queue->waitingTime)
             )
@@ -1059,10 +1060,10 @@ class Process extends Base implements MappingInterface
     }
 
 
-    protected function addValuesWayTimeData($process)
+    protected function addValuesWayTimeData(ProcessEntity $process)
     {
         $data = array();
-        if ($process['status'] == 'processing') {
+        if ($process->status == 'processing') {
             $wayTimeInSeconds = max(0, (int) $process->getWaySeconds());
             $hours = intdiv($wayTimeInSeconds, 3600);
             $minutes = intdiv($wayTimeInSeconds % 3600, 60);


### PR DESCRIPTION
Use object access instead of mixed array/object patterns in Query/Process, Process, and ProcessStatusFree. Add Process type hints on status mapping helpers.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code consistency and type safety in process data handling to enhance overall maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/eappointment/pull/2447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->