### PR TITLE
clean(GH-1820): use citizen types and English keys in waiting statistics

### DIFF
--- a/zmsdb/src/Zmsdb/Helper/CalculateDailyWaitingStatisticByCron.php
+++ b/zmsdb/src/Zmsdb/Helper/CalculateDailyWaitingStatisticByCron.php
@@ -3,6 +3,7 @@
 namespace BO\Zmsdb\Helper;
 
 use BO\Zmsdb\Base;
+use BO\Zmsdb\Query\ExchangeWaitingscope;
 use DateTimeImmutable;
 
 /**
@@ -104,15 +105,14 @@ class CalculateDailyWaitingStatisticByCron extends Base
         return $scopeId;
     }
 
-    // Unterscheidung zwischen "spontan" und "termin"
-    // - Wenn 'Uhrzeit'=='00:00:00', behandeln wir es als spontan angekommen => Stunde aus wsm_aufnahmezeit
+    // Walk-in vs scheduled: Uhrzeit 00:00:00 means walk-in => hour from wsm_aufnahmezeit
     private function determineHourAndType(array $buergerRecord): array
     {
-        $type = 'termin';
+        $type = 'scheduled';
         $hourStr = $buergerRecord['Uhrzeit'];
 
         if ($buergerRecord['Uhrzeit'] === '00:00:00') {
-            $type = 'spontan';
+            $type = 'walkin';
             $hourStr = $buergerRecord['wsm_aufnahmezeit'];
         }
 
@@ -133,8 +133,8 @@ class CalculateDailyWaitingStatisticByCron extends Base
             $statsByScopeDate[$scopeId][$dateStr] = [];
             foreach (range(0, 23) as $h) {
                 $statsByScopeDate[$scopeId][$dateStr][$h] = [
-                    'spontan' => ['count' => 0, 'sumWait' => 0.0, 'sumWay' => 0.0],
-                    'termin'  => ['count' => 0, 'sumWait' => 0.0, 'sumWay' => 0.0],
+                    'walkin' => ['count' => 0, 'sumWait' => 0.0, 'sumWay' => 0.0],
+                    'scheduled' => ['count' => 0, 'sumWait' => 0.0, 'sumWay' => 0.0],
                 ];
             }
         }
@@ -174,10 +174,10 @@ class CalculateDailyWaitingStatisticByCron extends Base
         ];
         $updateCols = [];
 
-        // Für jede Stunde 0..23 Spalten für "spontan" und "termin" füllen
+        // Für jede Stunde 0..23 Spalten für walk-in und scheduled füllen
         foreach (range(0, 23) as $hour) {
-            $this->addHourUpdateColumns($updateCols, $updateParams, $hour, $hoursData, 'spontan');
-            $this->addHourUpdateColumns($updateCols, $updateParams, $hour, $hoursData, 'termin');
+            $this->addHourUpdateColumns($updateCols, $updateParams, $hour, $hoursData, 'walkin');
+            $this->addHourUpdateColumns($updateCols, $updateParams, $hour, $hoursData, 'scheduled');
         }
 
         $sqlUpdate = sprintf(
@@ -259,6 +259,8 @@ class CalculateDailyWaitingStatisticByCron extends Base
 
     private function hourSuffixForStatistic(string $type): string
     {
-        return $type === 'termin' ? 'appointment' : 'spontaneous';
+        return $type === 'scheduled'
+            ? ExchangeWaitingscope::HOUR_SUFFIX_SCHEDULED
+            : ExchangeWaitingscope::HOUR_SUFFIX_WALK_IN;
     }
 }

--- a/zmsdb/src/Zmsdb/Query/ExchangeWaitingscope.php
+++ b/zmsdb/src/Zmsdb/Query/ExchangeWaitingscope.php
@@ -9,6 +9,12 @@ class ExchangeWaitingscope extends Base
      */
     const TABLE = 'wartenrstatistik';
 
+    /** DB column suffix for scheduled (appointment) citizens */
+    public const HOUR_SUFFIX_SCHEDULED = 'appointment';
+
+    /** DB column suffix for walk-in (spontaneous) citizens */
+    public const HOUR_SUFFIX_WALK_IN = 'spontaneous';
+
     const WAITING_VALUES = "
         AVG(hour_00_waiting_time_spontaneous) as hour_00_waiting_time_spontaneous,
         AVG(hour_01_waiting_time_spontaneous) as hour_01_waiting_time_spontaneous,
@@ -291,7 +297,7 @@ class ExchangeWaitingscope extends Base
      */
     public static function getQuerySelectByDateTime(\DateTimeInterface $date, bool $withAppointment = false)
     {
-        $hourSuffix = $withAppointment ? 'appointment' : 'spontaneous';
+        $hourSuffix = $withAppointment ? self::HOUR_SUFFIX_SCHEDULED : self::HOUR_SUFFIX_WALK_IN;
 
         $query = sprintf(
             "SELECT
@@ -323,7 +329,7 @@ class ExchangeWaitingscope extends Base
      */
     public static function getQueryUpdateByDateTime(\DateTimeInterface $date, bool $withAppointment = false)
     {
-        $hourSuffix = $withAppointment ? 'appointment' : 'spontaneous';
+        $hourSuffix = $withAppointment ? self::HOUR_SUFFIX_SCHEDULED : self::HOUR_SUFFIX_WALK_IN;
 
         $query = sprintf(
             "UPDATE %s

--- a/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
@@ -17,23 +17,23 @@ use Psr\Http\Message\ResponseInterface;
 
 class WaitingReport extends Base
 {
-    private const CUSTOMER_TYPE_GESAMT = 'gesamt';
-    private const CUSTOMER_TYPE_TERMIN = 'termin';
-    private const CUSTOMER_TYPE_SPONTAN = 'spontan';
+    private const CITIZEN_TYPE_TOTAL = 'total';
+    private const CITIZEN_TYPE_SCHEDULED = 'scheduled';
+    private const CITIZEN_TYPE_WALK_IN = 'walkin';
 
-    protected $reportPartsGesamt = [
+    protected $reportPartsTotal = [
         'waitingtime_total' => 'Durchschnittliche Wartezeit in Min. (Gesamt)',
         'waitingcount_total' => 'Wartende Gesamtkunden',
         'waytime_total' => 'Durchschnittliche Wegezeit in Min. (Gesamt)',
     ];
 
-    protected $reportPartsTermin = [
+    protected $reportPartsScheduled = [
         'waitingtime_termin' => 'Durchschnittliche Wartezeit in Min. (Terminkunden)',
         'waitingcount_termin' => 'Wartende Terminkunden',
         'waytime_termin' => 'Durchschnittliche Wegezeit in Min. (Terminkunden)',
     ];
 
-    protected $reportPartsSpontan = [
+    protected $reportPartsWalkIn = [
         'waitingtime' => 'Durchschnittliche Wartezeit in Min. (Spontankunden)',
         'waitingcount' => 'Wartende Spontankunden',
         'waytime' => 'Durchschnittliche Wegezeit in Min. (Spontankunden)',
@@ -47,7 +47,7 @@ class WaitingReport extends Base
         Spreadsheet $spreadsheet,
         string $sheetTitle,
         array $args,
-        string $customerType,
+        string $citizenType,
         bool $isFirstSheet = false
     ): void {
         if (!$isFirstSheet) {
@@ -58,7 +58,7 @@ class WaitingReport extends Base
         $spreadsheet->setActiveSheetIndexByName($sheetTitle);
         $this->writeInfoHeader($args, $spreadsheet);
         foreach ($args['reports'] as $report) {
-            $this->writeWaitingReport($report, $spreadsheet, $customerType, 'dd.MM.yyyy');
+            $this->writeWaitingReport($report, $spreadsheet, $citizenType, 'dd.MM.yyyy');
         }
     }
 
@@ -71,9 +71,9 @@ class WaitingReport extends Base
         $download = (new Download($request))->setSpreadSheet($title);
         $spreadsheet = $download->getSpreadSheet();
 
-        $this->createAndPopulateSheet($spreadsheet, 'Gesamt', $args, self::CUSTOMER_TYPE_GESAMT, true);
-        $this->createAndPopulateSheet($spreadsheet, 'Terminkunden', $args, self::CUSTOMER_TYPE_TERMIN);
-        $this->createAndPopulateSheet($spreadsheet, 'Spontankunden', $args, self::CUSTOMER_TYPE_SPONTAN);
+        $this->createAndPopulateSheet($spreadsheet, 'Gesamt', $args, self::CITIZEN_TYPE_TOTAL, true);
+        $this->createAndPopulateSheet($spreadsheet, 'Terminkunden', $args, self::CITIZEN_TYPE_SCHEDULED);
+        $this->createAndPopulateSheet($spreadsheet, 'Spontankunden', $args, self::CITIZEN_TYPE_WALK_IN);
 
         // Für den Download das erste Blatt aktiv lassen
         $spreadsheet->setActiveSheetIndexByName('Gesamt');
@@ -81,17 +81,17 @@ class WaitingReport extends Base
         return $download->writeDownload($response);
     }
 
-    private function assertValidCustomerType(string $customerType): void
+    private function assertValidCitizenType(string $citizenType): void
     {
         $validTypes = [
-            self::CUSTOMER_TYPE_GESAMT,
-            self::CUSTOMER_TYPE_TERMIN,
-            self::CUSTOMER_TYPE_SPONTAN,
+            self::CITIZEN_TYPE_TOTAL,
+            self::CITIZEN_TYPE_SCHEDULED,
+            self::CITIZEN_TYPE_WALK_IN,
         ];
 
-        if (!in_array($customerType, $validTypes, true)) {
+        if (!in_array($citizenType, $validTypes, true)) {
             throw new \InvalidArgumentException(
-                "Invalid customer type: {$customerType}. Must be one of: " . implode(', ', $validTypes)
+                "Invalid citizen type: {$citizenType}. Must be one of: " . implode(', ', $validTypes)
             );
         }
     }
@@ -99,20 +99,20 @@ class WaitingReport extends Base
     public function writeWaitingReport(
         ReportEntity $report,
         Spreadsheet $spreadsheet,
-        string $customerType,
+        string $citizenType,
         $datePatternCol = 'dd.MM.yyyy',
     ) {
-        $this->assertValidCustomerType($customerType);
+        $this->assertValidCitizenType($citizenType);
 
         $sheet = $spreadsheet->getActiveSheet();
         $this->writeHeader($report, $sheet, $datePatternCol);
-        $this->writeTotals($report, $sheet, $customerType);
-        if ($customerType === self::CUSTOMER_TYPE_TERMIN) {
-            $parts = $this->reportPartsTermin;
-        } elseif ($customerType === self::CUSTOMER_TYPE_SPONTAN) {
-            $parts = $this->reportPartsSpontan;
+        $this->writeTotals($report, $sheet, $citizenType);
+        if ($citizenType === self::CITIZEN_TYPE_SCHEDULED) {
+            $parts = $this->reportPartsScheduled;
+        } elseif ($citizenType === self::CITIZEN_TYPE_WALK_IN) {
+            $parts = $this->reportPartsWalkIn;
         } else {
-            $parts = $this->reportPartsGesamt;
+            $parts = $this->reportPartsTotal;
         }
         foreach ($parts as $partName => $headline) {
             $this->writeReportPart($report, $sheet, $partName, $headline);
@@ -145,39 +145,39 @@ class WaitingReport extends Base
         }
     }
 
-    private function getCustomerTypeKeys(string $customerType): array
+    private function getCitizenTypeKeys(string $citizenType): array
     {
-        $this->assertValidCustomerType($customerType);
+        $this->assertValidCitizenType($citizenType);
         $keyMappings = [
-            self::CUSTOMER_TYPE_TERMIN => [
+            self::CITIZEN_TYPE_SCHEDULED => [
                 'max' => 'max_waitingtime_termin',
                 'avg' => 'average_waitingtime_termin',
                 'avg_way' => 'average_waytime_termin',
             ],
-            self::CUSTOMER_TYPE_SPONTAN => [
+            self::CITIZEN_TYPE_WALK_IN => [
                 'max' => 'max_waitingtime',
                 'avg' => 'average_waitingtime',
                 'avg_way' => 'average_waytime',
             ],
-            self::CUSTOMER_TYPE_GESAMT => [
+            self::CITIZEN_TYPE_TOTAL => [
                 'max' => 'max_waitingtime_total',
                 'avg' => 'average_waitingtime_total',
                 'avg_way' => 'average_waytime_total',
             ],
         ];
 
-        return $keyMappings[$customerType];
+        return $keyMappings[$citizenType];
     }
 
-    public function writeTotals(ReportEntity $report, $sheet, string $customerType)
+    public function writeTotals(ReportEntity $report, $sheet, string $citizenType)
     {
-        $this->assertValidCustomerType($customerType);
+        $this->assertValidCitizenType($citizenType);
 
         $entity = clone $report;
         $totals = $entity->data['max'];
         unset($entity->data['max']);
 
-        $keys = $this->getCustomerTypeKeys($customerType);
+        $keys = $this->getCitizenTypeKeys($citizenType);
 
         $reportTotal['max'][] = 'Stunden-Max (Spaltenmaximum) der Wartezeit in Min.';
         $reportTotal['average'][] = 'Stundendurchschnitt (Spalten) der Wartezeit in Min.';


### PR DESCRIPTION
Rename customer to citizen in WaitingReport, translate internal type values to total/scheduled/walkin, and centralize DB hour suffix constants in ExchangeWaitingscope.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.
