### PR TITLE
clean(ZMS): replace remaining error_log, echo, and print in app code

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .vitepress/cache/
 .vitepress/dist/
+.vitepress/data/log-inventory.json

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { writeLogInventory } from "../scripts/generate-log-inventory.mjs";
 
 const FEATURES_ROOT = path.resolve(
   import.meta.dirname,
@@ -168,6 +169,7 @@ const renderCucumberDoc = () => {
 };
 
 renderCucumberDoc();
+writeLogInventory();
 
 // docs/en/ is the single on-disk source for English content. We use VitePress
 // `rewrites` so every docs/en/<path>.md is rendered at URL /<path>.html (the
@@ -237,6 +239,7 @@ const sidebarLabels = {
     dependencyGraph: "Dependency Graph",
     branchingStrategy: "Branching Strategy",
     commitMessageConvention: "Commit Message Convention",
+    monologLogging: "Monolog logging",
     codeOfConduct: "Code of Conduct",
     contributing: "Contributing",
     security: "Security",
@@ -281,6 +284,7 @@ const sidebarLabels = {
     dependencyGraph: "Abhängigkeitsgraph",
     branchingStrategy: "Branching-Strategie",
     commitMessageConvention: "Commit-Message-Konvention",
+    monologLogging: "Monolog-Logging",
     codeOfConduct: "Verhaltenskodex",
     contributing: "Mitwirken",
     security: "Sicherheit",
@@ -458,6 +462,10 @@ const buildSidebar = (prefix, lang) => {
         {
           text: t.dldb,
           link: `${prefix}/operations/dldb-interface-documentation`,
+        },
+        {
+          text: t.monologLogging,
+          link: `${prefix}/operations/monolog-logging`,
         },
       ],
     },

--- a/docs/.vitepress/theme/LogInventory.vue
+++ b/docs/.vitepress/theme/LogInventory.vue
@@ -1,0 +1,234 @@
+<script setup>
+import { computed, ref } from "vue";
+import inventoryData from "../data/log-inventory.json";
+
+const inventory = ref(inventoryData);
+const levelFilter = ref("all");
+const moduleFilter = ref("all");
+const search = ref("");
+
+const levelOptions = computed(() => ["all", ...inventory.value.levels]);
+
+const moduleOptions = computed(() => ["all", ...inventory.value.modules]);
+
+const filteredEntries = computed(() => {
+  const q = search.value.trim().toLowerCase();
+  return inventory.value.entries.filter((entry) => {
+    if (levelFilter.value !== "all" && entry.level !== levelFilter.value) {
+      return false;
+    }
+    if (moduleFilter.value !== "all" && entry.module !== moduleFilter.value) {
+      return false;
+    }
+    if (!q) {
+      return true;
+    }
+    const haystack = `${entry.module} ${entry.level} ${entry.message} ${entry.file}`.toLowerCase();
+    return haystack.includes(q);
+  });
+});
+
+const githubBase = "https://github.com/it-at-m/eappointment/blob/main/";
+</script>
+
+<template>
+  <div class="log-inventory">
+    <p class="log-inventory-meta">
+      Generated:
+      <time :datetime="inventory.generatedAt">{{
+        new Date(inventory.generatedAt).toLocaleString()
+      }}</time>
+      · {{ inventory.totals.entries }} call(s) · {{ inventory.scanNote }}
+    </p>
+
+    <div class="log-inventory-filters">
+      <label>
+        Level
+        <select v-model="levelFilter">
+          <option v-for="opt in levelOptions" :key="opt" :value="opt">
+            {{ opt === "all" ? "All levels" : opt }}
+          </option>
+        </select>
+      </label>
+      <label>
+        Module
+        <select v-model="moduleFilter">
+          <option v-for="opt in moduleOptions" :key="opt" :value="opt">
+            {{ opt === "all" ? "All modules" : opt }}
+          </option>
+        </select>
+      </label>
+      <label class="log-inventory-search">
+        Search
+        <input
+          v-model="search"
+          type="search"
+          placeholder="message, file, module…"
+        />
+      </label>
+    </div>
+
+    <p class="log-inventory-count">
+      Showing {{ filteredEntries.length }} of
+      {{ inventory.totals.entries }} entries
+    </p>
+
+    <div class="log-inventory-table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Module</th>
+            <th>Level</th>
+            <th>Message</th>
+            <th>Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, idx) in filteredEntries" :key="idx">
+            <td><code>{{ row.module }}</code></td>
+            <td>
+              <span :class="['log-level', `log-level--${row.level}`]">{{
+                row.level
+              }}</span>
+            </td>
+            <td>{{ row.message }}</td>
+            <td>
+              <a
+                :href="`${githubBase}${row.file}#L${row.line}`"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><code>{{ row.file }}:{{ row.line }}</code></a
+              >
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.log-inventory-meta {
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2);
+}
+
+.log-inventory-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+  align-items: flex-end;
+}
+
+.log-inventory-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.log-inventory-search {
+  flex: 1 1 12rem;
+  min-width: 12rem;
+}
+
+.log-inventory-filters select,
+.log-inventory-filters input {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font: inherit;
+}
+
+.log-inventory-count {
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.log-inventory-table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+th,
+td {
+  border: 1px solid var(--vp-c-divider);
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: var(--vp-c-bg-soft);
+}
+
+.log-level {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.log-level--debug {
+  background: #e8eaf6;
+  color: #283593;
+}
+.log-level--info {
+  background: #e3f2fd;
+  color: #1565c0;
+}
+.log-level--notice {
+  background: #e0f7fa;
+  color: #00695c;
+}
+.log-level--warning {
+  background: #fff8e1;
+  color: #f57f17;
+}
+.log-level--error {
+  background: #ffebee;
+  color: #c62828;
+}
+.log-level--critical,
+.log-level--alert,
+.log-level--emergency {
+  background: #fce4ec;
+  color: #880e4f;
+}
+.log-level--dynamic {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+}
+
+.dark .log-level--debug {
+  background: #1a237e;
+  color: #c5cae9;
+}
+.dark .log-level--info {
+  background: #0d47a1;
+  color: #bbdefb;
+}
+.dark .log-level--notice {
+  background: #004d40;
+  color: #b2dfdb;
+}
+.dark .log-level--warning {
+  background: #ff6f00;
+  color: #fff8e1;
+}
+.dark .log-level--error {
+  background: #b71c1c;
+  color: #ffcdd2;
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -2,6 +2,7 @@ import DefaultTheme from "vitepress/theme";
 
 import BerlinChangelogEmbed from "./BerlinChangelogEmbed.vue";
 import ChangelogEmbed from "./ChangelogEmbed.vue";
+import LogInventory from "./LogInventory.vue";
 import LhmThemeExtension from "./LhmThemeExtension.vue";
 
 import "./style.css";
@@ -15,5 +16,6 @@ export default {
     }
     ctx.app.component("BerlinChangelogEmbed", BerlinChangelogEmbed);
     ctx.app.component("ChangelogEmbed", ChangelogEmbed);
+    ctx.app.component("LogInventory", LogInventory);
   },
 };

--- a/docs/de/operations/monolog-logging.md
+++ b/docs/de/operations/monolog-logging.md
@@ -1,0 +1,90 @@
+# Monolog-Logging (zmsslim)
+
+ZMS-Anwendungen nutzen einen gemeinsamen PSR-3-Logger auf der globalen `App`-Klasse: **`App::$log`**. Konfiguriert wird er in [`zmsslim`](https://github.com/it-at-m/eappointment/tree/main/zmsslim) durch `BO\Slim\Bootstrap` und von allen Slim-Modulen (`zmsapi`, `zmsadmin`, `zmscitizenapi`, …) geteilt.
+
+## Kurzreferenz
+
+| Thema | Detail |
+| --- | --- |
+| Logger-Property | `App::$log` (`Monolog\Logger`, vor Bootstrap `null`) |
+| Mindest-Level | `App::DEBUGLEVEL` ← Umgebung `DEBUGLEVEL` ← Standard `INFO` (Konstante `ZMS_DEBUGLEVEL` in zmsslim) |
+| Web-Bootstrap | `\BO\Slim\Bootstrap::init()` |
+| CLI / Cron | `\BO\Slim\Bootstrap::ensureLogger()` oder `initForCli()` über `script_bootstrap.php` |
+| Ausgabe | JSON-Zeilen auf **stderr** (Web) oder **stdout** (CLI/Cron) |
+| Nicht verwenden | PHP `error_log()`, `print_r()`, `echo` für Anwendungs-Logs |
+
+## Log-Level
+
+`DEBUGLEVEL` / `App::DEBUGLEVEL` legt das **Mindest-Level** für Monolog fest. Nachrichten darunter werden verworfen.
+
+| `DEBUGLEVEL` Env / Konstante | Monolog-Konstante | Typische Nutzung in ZMS |
+| --- | --- | --- |
+| `DEBUG` | `Logger::DEBUG` | Ausführliche Diagnose (Mail-Payloads, Cache) |
+| `INFO` | `Logger::INFO` | Normaler Betrieb (Login, Cron-Fortschritt, Cache-Treffer) |
+| `NOTICE` | `Logger::NOTICE` | Beachtenswert, aber erwartbar |
+| `WARNING` | `Logger::WARNING` | Behebbare Probleme (Rate Limits, übersprungene Entitäten) |
+| `ERROR` | `Logger::ERROR` | Fehler mit Handlungsbedarf |
+| `CRITICAL` | `Logger::CRITICAL` | Schwere Fehler (z. B. Twig-Exception-Handler) |
+| `ALERT` | `Logger::ALERT` | Selten; Monolog-Skala |
+| `EMERGENCY` | `Logger::EMERGENCY` | Selten; Monolog-Skala |
+
+Die Zuordnung steht in `zmsslim/src/Slim/Bootstrap.php` (`$debuglevels`, `parseDebugLevel()`).
+
+### Umgebungsvariable
+
+```bash
+DEBUGLEVEL=INFO
+```
+
+In `zmsslim/src/Slim/Application.php`:
+
+```php
+define('ZMS_DEBUGLEVEL', getenv('DEBUGLEVEL') ? getenv('DEBUGLEVEL') : 'INFO');
+const DEBUGLEVEL = ZMS_DEBUGLEVEL;
+```
+
+Ungültige Werte fallen in `parseDebugLevel()` auf **DEBUG** zurück.
+
+## Logging im Code
+
+Nach `bootstrap.php` oder `script_bootstrap.php`:
+
+```php
+\App::$log->info('Login successful', ['account' => $accountName]);
+\App::$log->warning('Could not remove availability', ['availabilityId' => $id]);
+\App::$log->error('SQL import failed', ['exception' => $e->getMessage()]);
+```
+
+PSR-3-Methoden in **Kleinbuchstaben**: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`.
+
+### Kontext-Arrays
+
+Strukturierten Kontext (zweites Argument) bevorzugen. Zusätzliche Felder u. a.: `application`, `module`, bei Cron `cron` / `cron_name` (`ZMS_CRON_LOG`, `ZMS_CRON_NAME`).
+
+### Bibliotheken ohne Bootstrap
+
+Optional nur mit Prüfung:
+
+```php
+if (class_exists('\App', false) && isset(\App::$log)) {
+    \App::$log->error('…', ['context' => $value]);
+}
+```
+
+## Log-Inventar im Repository
+
+Die folgende Tabelle wird **automatisch** aus `App::$log->…` in Modul-PHP-Quellen erzeugt (ohne `vendor/` und `tests/`). Lokal aktualisieren:
+
+```bash
+cd docs && npm run docs:log-inventory
+```
+
+Aktualisierung auch bei `npm run docs:dev` / `docs:build`.
+
+<LogInventory />
+
+## Verwandter Code
+
+- `zmsslim/src/Slim/Application.php` — `public static $log`
+- `zmsslim/src/Slim/Bootstrap.php` — Logger-Konfiguration
+- `zmsslim/README.md` — Slim-Bootstrap-Übersicht

--- a/docs/de/setup-and-development/getting-started/getting-started-with-docs.md
+++ b/docs/de/setup-and-development/getting-started/getting-started-with-docs.md
@@ -39,6 +39,16 @@ VitePress gibt eine lokale URL aus (typischerweise `http://localhost:5173`). Öf
 - **`npm run format:check`** — prüft die Formatierung, ohne Dateien zu schreiben (nützlich in CI)
 - **`npm run docs:build`** — Produktions-Build; Ausgabe nach `docs/.vitepress/dist`
 - **`npm run docs:preview`** — serviert die gebaute Site lokal, um den Build zu prüfen
+- **`npm run docs:log-inventory`** — erzeugt `docs/.vitepress/data/log-inventory.json` neu (läuft auch automatisch bei `docs:dev` / `docs:build`)
+
+## Automatisch erzeugte Dokumentation
+
+Einige Seiten werden beim Start oder Build von VitePress generiert:
+
+- **Cucumber-Feature-Liste** — aus `zmsautomation/src/test/resources/features`
+- **Monolog-Log-Inventar** — scannt `App::$log`-Aufrufe in ZMS-Modul-PHP; siehe [Monolog-Logging](/de/operations/monolog-logging)
+
+`log-inventory.json` wird lokal und in CI erzeugt und **nicht** committed (siehe `docs/.gitignore`).
 
 ## Konfiguration und Theme
 

--- a/docs/en/operations/monolog-logging.md
+++ b/docs/en/operations/monolog-logging.md
@@ -1,0 +1,132 @@
+# Monolog logging (zmsslim)
+
+ZMS applications use a single PSR-3 logger on the global `App` class: **`App::$log`**. It is configured in [`zmsslim`](https://github.com/it-at-m/eappointment/tree/main/zmsslim) by `BO\Slim\Bootstrap` and shared by all Slim-based modules (`zmsapi`, `zmsadmin`, `zmscitizenapi`, …).
+
+## Quick reference
+
+| Topic | Detail |
+| --- | --- |
+| Logger property | `App::$log` (`Monolog\Logger`, `null` before bootstrap) |
+| Minimum level | `App::DEBUGLEVEL` ← env `DEBUGLEVEL` ← default `INFO` (constant `ZMS_DEBUGLEVEL` in zmsslim) |
+| Web bootstrap | `\BO\Slim\Bootstrap::init()` |
+| CLI / cron | `\BO\Slim\Bootstrap::ensureLogger()` or `initForCli()` via `script_bootstrap.php` |
+| Output | JSON lines to **stderr** (web) or **stdout** (CLI/cron) |
+| Do not use | PHP `error_log()`, `print_r()`, `echo` for application logging |
+
+## Log levels
+
+`DEBUGLEVEL` / `App::DEBUGLEVEL` sets the **minimum** level written by Monolog. Messages below that level are dropped.
+
+| `DEBUGLEVEL` env / constant | Monolog constant | Typical use in ZMS |
+| --- | --- | --- |
+| `DEBUG` | `Logger::DEBUG` | Verbose diagnostics (mail payloads, cache details) |
+| `INFO` | `Logger::INFO` | Normal operations (login, cron progress, cache hits) |
+| `NOTICE` | `Logger::NOTICE` | Notable but expected events |
+| `WARNING` | `Logger::WARNING` | Recoverable problems (rate limits, skipped entities) |
+| `ERROR` | `Logger::ERROR` | Failures that need attention |
+| `CRITICAL` | `Logger::CRITICAL` | Severe errors (unhandled exceptions in Twig handler) |
+| `ALERT` | `Logger::ALERT` | Rare; same scale as Monolog |
+| `EMERGENCY` | `Logger::EMERGENCY` | Rare; same scale as Monolog |
+
+Implementation mapping lives in `zmsslim/src/Slim/Bootstrap.php` (`$debuglevels` and `parseDebugLevel()`).
+
+### Environment variable
+
+```bash
+# .env / deployment / DDEV
+DEBUGLEVEL=INFO
+```
+
+`zmsslim/src/Slim/Application.php` defines:
+
+```php
+define('ZMS_DEBUGLEVEL', getenv('DEBUGLEVEL') ? getenv('DEBUGLEVEL') : 'INFO');
+const DEBUGLEVEL = ZMS_DEBUGLEVEL;
+```
+
+Each module’s `class App extends \BO\…\Application` inherits this. Override in `config.php` only for local experiments, e.g. `const DEBUGLEVEL = 'WARNING';`.
+
+Invalid values fall back to **DEBUG** (permissive) in `parseDebugLevel()`.
+
+## How to log
+
+After `bootstrap.php` or `script_bootstrap.php`:
+
+```php
+\App::$log->info('Login successful', [
+    'account' => $accountName,
+]);
+
+\App::$log->warning('Could not remove availability', [
+    'availabilityId' => $availabilityId,
+]);
+
+\App::$log->error('SQL import failed', [
+    'file' => basename($file),
+    'exception' => $e->getMessage(),
+]);
+```
+
+Use **lowercase** PSR-3 method names: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`.
+
+### Context arrays
+
+Prefer structured context (second argument) over string concatenation. The JSON processor adds standard fields:
+
+- `time_local`, `client_ip`, `remote_addr`
+- `application` (`App::IDENTIFIER`)
+- `module` (`App::MODULE_NAME`)
+- `cron`, `cron_name` when `ZMS_CRON_LOG` / `ZMS_CRON_NAME` are set in cron shell scripts
+
+### Cron logging
+
+Cron entrypoints export `ZMS_CRON_LOG=1` and `ZMS_CRON_NAME=zmsapi_hourly` (example). `Bootstrap::isCronLogging()` adds searchable `cron` / `cron_name` fields to each JSON line.
+
+Helpers such as `zmsdb`’s `VerboseCronLogTrait` use `Bootstrap::normalizeLogLevelName()` for configurable cron verbosity.
+
+### Libraries without full bootstrap
+
+Shared packages (`zmsdldb`, `zmsclient`) may run without `App`. Use optional logging only when the class exists:
+
+```php
+if (class_exists('\App', false) && isset(\App::$log)) {
+    \App::$log->error('…', ['context' => $value]);
+}
+```
+
+Do **not** use `isset(\App::$log)` alone — PHP will fatal if `App` is not loaded.
+
+## JSON log shape (example)
+
+```json
+{
+  "time_local": "2026-05-26T12:00:00+02:00",
+  "client_ip": "127.0.0.1",
+  "application": "zmsapi",
+  "module": "zmsapi",
+  "cron": true,
+  "cron_name": "zmsapi_hourly",
+  "message": "Migration check finished",
+  "level": "INFO",
+  "context": { "pending": 0 },
+  "extra": []
+}
+```
+
+## Repository log inventory
+
+The table below is **generated automatically** from `App::$log->…` calls in module PHP sources (excluding `vendor/` and `tests/`). Regenerate locally:
+
+```bash
+cd docs && npm run docs:log-inventory
+```
+
+It updates when you run `npm run docs:dev` or `docs:build` (VitePress config runs the generator first).
+
+<LogInventory />
+
+## Related code
+
+- `zmsslim/src/Slim/Application.php` — `public static $log`
+- `zmsslim/src/Slim/Bootstrap.php` — `configureLogger()`, `ensureLogger()`, `normalizeLogLevelName()`
+- `zmsslim/README.md` — Slim bootstrap overview

--- a/docs/en/setup-and-development/getting-started/getting-started-with-docs.md
+++ b/docs/en/setup-and-development/getting-started/getting-started-with-docs.md
@@ -39,6 +39,16 @@ VitePress prints a local URL (typically `http://localhost:5173`). Open it in a b
 - **`npm run format:check`** — verify formatting without writing files (useful in CI)
 - **`npm run docs:build`** — production build; output is written to `docs/.vitepress/dist`
 - **`npm run docs:preview`** — serve the built site locally to verify the build
+- **`npm run docs:log-inventory`** — regenerate `docs/.vitepress/data/log-inventory.json` (also runs automatically on `docs:dev` / `docs:build`)
+
+## Auto-generated documentation
+
+Some pages are generated when VitePress starts or builds:
+
+- **Cucumber feature list** — from `zmsautomation/src/test/resources/features`
+- **Monolog log inventory** — scans `App::$log` calls in ZMS module PHP sources; see [Monolog logging](/operations/monolog-logging)
+
+`log-inventory.json` is generated locally and in CI; it is **not** committed (see `docs/.gitignore`).
 
 ## Configuration and theme
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,7 @@
     "docs:dev": "vitepress dev .",
     "docs:build": "vitepress build .",
     "docs:preview": "vitepress preview .",
+    "docs:log-inventory": "node scripts/generate-log-inventory.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/docs/scripts/generate-log-inventory.mjs
+++ b/docs/scripts/generate-log-inventory.mjs
@@ -1,0 +1,209 @@
+/**
+ * Scans the monorepo for App::$log usage and writes docs/.vitepress/data/log-inventory.json.
+ * Run: cd docs && npm run docs:log-inventory
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const OUTPUT = path.resolve(__dirname, "../.vitepress/data/log-inventory.json");
+
+const MODULE_PREFIXES = [
+  "zmsslim",
+  "zmsapi",
+  "zmsadmin",
+  "zmsdb",
+  "zmsdldb",
+  "zmsentities",
+  "zmsclient",
+  "zmscitizenapi",
+  "zmsmessaging",
+  "zmsstatistic",
+  "zmsticketprinter",
+  "zmscalldisplay",
+  "mellon",
+];
+
+const SKIP_DIR_NAMES = new Set([
+  "vendor",
+  "node_modules",
+  ".git",
+  ".phpunit.cache",
+  "coverage",
+  "fixtures",
+  ".vitepress",
+]);
+
+const LOG_METHOD =
+  /(?:\\)?App::\$log->(debug|info|notice|warning|warn|error|critical|alert|emergency)\s*\(/gi;
+
+const LOG_DYNAMIC = /(?:\\)?App::\$log->\$([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/g;
+
+const STRING_LITERAL = /^['"]([^'"]*)['"]/;
+
+const normalizeLevel = (level) => {
+  const lower = level.toLowerCase();
+  if (lower === "warn") {
+    return "warning";
+  }
+  return lower;
+};
+
+const detectModule = (relativePath) => {
+  const top = relativePath.split("/")[0];
+  if (MODULE_PREFIXES.includes(top)) {
+    return top;
+  }
+  return "other";
+};
+
+const isTestPath = (relativePath) =>
+  /(?:^|\/)(tests?|Tests?)(?:\/|$)/.test(relativePath) ||
+  relativePath.includes("/tests/") ||
+  /Test\.php$/.test(relativePath);
+
+const shouldScanFile = (relativePath) => {
+  if (!relativePath.endsWith(".php")) {
+    return false;
+  }
+  if (isTestPath(relativePath)) {
+    return false;
+  }
+  const top = relativePath.split("/")[0];
+  if (MODULE_PREFIXES.includes(top)) {
+    return true;
+  }
+  return false;
+};
+
+const walkPhpFiles = (dir, base = dir, out = []) => {
+  if (!fs.existsSync(dir)) {
+    return out;
+  }
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIR_NAMES.has(entry.name)) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    const rel = path.relative(base, full);
+    if (entry.isDirectory()) {
+      walkPhpFiles(full, base, out);
+      continue;
+    }
+    if (entry.isFile() && shouldScanFile(rel)) {
+      out.push({ abs: full, rel: rel.split(path.sep).join("/") });
+    }
+  }
+  return out;
+};
+
+const extractMessage = (line, openParenIndex) => {
+  const after = line.slice(openParenIndex + 1).trimStart();
+  const stringMatch = after.match(STRING_LITERAL);
+  if (stringMatch) {
+    return stringMatch[1];
+  }
+  if (after.startsWith("$") || after.startsWith("(")) {
+    return "(expression)";
+  }
+  return "(dynamic)";
+};
+
+const scanFile = (file) => {
+  const content = fs.readFileSync(file.abs, "utf8");
+  const lines = content.split("\n");
+  const entries = [];
+  const module = detectModule(file.rel);
+
+  lines.forEach((line, index) => {
+    const lineNo = index + 1;
+
+    for (const match of line.matchAll(LOG_METHOD)) {
+      const level = normalizeLevel(match[1]);
+      const openParen = match.index + match[0].length - 1;
+      entries.push({
+        module,
+        level,
+        message: extractMessage(line, openParen),
+        file: file.rel,
+        line: lineNo,
+        kind: "static",
+      });
+    }
+
+    for (const match of line.matchAll(LOG_DYNAMIC)) {
+      entries.push({
+        module,
+        level: "dynamic",
+        message: `(via $${match[1]})`,
+        file: file.rel,
+        line: lineNo,
+        kind: "variable",
+        variable: match[1],
+      });
+    }
+  });
+
+  return entries;
+};
+
+export const generateLogInventory = () => {
+  const files = MODULE_PREFIXES.flatMap((name) => {
+    const moduleRoot = path.join(REPO_ROOT, name);
+    return fs.existsSync(moduleRoot) ? walkPhpFiles(moduleRoot, REPO_ROOT) : [];
+  });
+
+  const entries = files.flatMap(scanFile).sort((a, b) => {
+    const moduleCmp = a.module.localeCompare(b.module);
+    if (moduleCmp !== 0) {
+      return moduleCmp;
+    }
+    const levelCmp = a.level.localeCompare(b.level);
+    if (levelCmp !== 0) {
+      return levelCmp;
+    }
+    const fileCmp = a.file.localeCompare(b.file);
+    if (fileCmp !== 0) {
+      return fileCmp;
+    }
+    return a.line - b.line;
+  });
+
+  const byModule = {};
+  const byLevel = {};
+  for (const entry of entries) {
+    byModule[entry.module] = (byModule[entry.module] ?? 0) + 1;
+    byLevel[entry.level] = (byLevel[entry.level] ?? 0) + 1;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    repoRoot: "eappointment",
+    scanNote:
+      "Production PHP only (module src/cron/bin). Excludes vendor, tests, and test_mysql-style dev scripts under Importer/.",
+    entries,
+    totals: {
+      entries: entries.length,
+      byModule,
+      byLevel,
+    },
+    modules: [...new Set(entries.map((e) => e.module))].sort(),
+    levels: [...new Set(entries.map((e) => e.level))].sort(),
+  };
+};
+
+export const writeLogInventory = () => {
+  const data = generateLogInventory();
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  return { output: OUTPUT, totals: data.totals };
+};
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  const { output, totals } = writeLogInventory();
+  console.log(`Wrote ${totals.entries} log call(s) to ${output}`);
+}

--- a/zmsapi/tests/Zmsapi/OverallCalendarReadTest.php
+++ b/zmsapi/tests/Zmsapi/OverallCalendarReadTest.php
@@ -81,12 +81,11 @@ class OverallCalendarReadTest extends Base
         if (!$result->isValid()) {
             $formatter = new ErrorFormatter();
             $errors    = $formatter->format($result->error());
-            error_log(
-                "Schema validation failed:\n"
+            $this->fail(
+                'Response does not match calendar schema: '
                 . json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
             );
         }
-        $this->assertTrue($result->isValid(), 'Response does not match calendar schema');
     }
 
     public function testEventIncludesDisplayNumberWhenSet(): void

--- a/zmsdb/src/Zmsdb/Log.php
+++ b/zmsdb/src/Zmsdb/Log.php
@@ -244,7 +244,7 @@ class Log extends Base
             $result = $this->writeItem($query);
             return $result !== false;
         } catch (\Exception $e) {
-            error_log("Error during log cleanup: " . $e->getMessage());
+            \App::$log->error('Error during log cleanup', ['exception' => $e->getMessage()]);
             return false;
         }
     }

--- a/zmsdb/src/Zmsdb/Organisation.php
+++ b/zmsdb/src/Zmsdb/Organisation.php
@@ -28,7 +28,6 @@ class Organisation extends Base
     public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
     {
         if (0 < $resolveReferences && $entity->hasId()) {
-            //error_log("Organisation Level $resolveReferences");
             $entity['departments'] = (new Department())
                 ->readByOrganisationId($entity->id, $resolveReferences - 1);
             $entity['ticketprinters'] = (new Ticketprinter())

--- a/zmsdb/src/Zmsdb/Owner.php
+++ b/zmsdb/src/Zmsdb/Owner.php
@@ -30,7 +30,6 @@ class Owner extends Base
     public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
     {
         if (0 < $resolveReferences && isset($entity['id'])) {
-            //error_log("Owner Level $resolveReferences");
             $entity['organisations'] = (new Organisation())->readByOwnerId($entity['id'], $resolveReferences - 1);
         }
         return $entity;

--- a/zmsdb/src/Zmsdb/Query/Base.php
+++ b/zmsdb/src/Zmsdb/Query/Base.php
@@ -293,7 +293,6 @@ abstract class Base
     protected function leftJoin($alias, $left = null, $operator = null, $right = null)
     {
         $aliasId = $alias->getAliasIdentifier();
-        //error_log(get_class($this) . " JOIN $aliasId CHECK " . implode(',', $this->joinedAliasList));
         if (!in_array($aliasId, $this->joinedAliasList)) {
             $this->joinedAliasList[] = $aliasId;
             $this->query->leftJoin($alias, $left, $operator, $right);

--- a/zmsdb/src/Zmsdb/Query/Owner.php
+++ b/zmsdb/src/Zmsdb/Query/Owner.php
@@ -37,7 +37,6 @@ class Owner extends Base implements MappingInterface
 
     public function addConditionOrganisationId($organisationId)
     {
-        //error_log(var_export($isNotAssigned,1));
         $this->leftJoin(
             new Alias(Organisation::TABLE, 'ownerorganisation'),
             'owner.KundenID',

--- a/zmsdb/src/Zmsdb/Query/SlotList.php
+++ b/zmsdb/src/Zmsdb/Query/SlotList.php
@@ -276,7 +276,6 @@ class SlotList extends Base
             $slot = $slotList->getSlot($slotnumber);
             if (null === $slot) {
                 $slotDebug = "$slotdate #$slotnumber @" . $slotData['slottime'] . " on " . $this->availability;
-                // error_log("Debugdata: Found database entry without a pre-generated slot $slotDebug");
                 throw new \BO\Zmsdb\Exception\SlotDataWithoutPreGeneratedSlot(
                     "Found database entry without a pre-generated slot $slotDebug"
                 );

--- a/zmsdb/tests/Zmsdb/Base.php
+++ b/zmsdb/tests/Zmsdb/Base.php
@@ -30,7 +30,6 @@ abstract class Base extends TestCase
 
     public function tearDown(): void
     {
-        //error_log("Memory usage " . round(memory_get_peak_usage() / 1024, 0) . "kb");
         \BO\Zmsdb\Scope::$cache = [];
         \BO\Zmsdb\Availability::$cache = [];
         \BO\Zmsdb\Department::$departmentCache = [];

--- a/zmsdb/tests/Zmsdb/SlotTest.php
+++ b/zmsdb/tests/Zmsdb/SlotTest.php
@@ -609,7 +609,7 @@ class SlotTest extends Base
             'processingNote',
             (isset($availability['processingNote'])) ? json_encode($availability['processingNote']) : 'none'
         );
-        error_log($debug);
+        \App::$log->debug('Slot availability debug', ['details' => $debug]);
     }
 
     protected function readTestAvailability()

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -142,8 +142,12 @@ class AbstractAccess
             }
             throw new Exception("Instance for accessing $instanceName failed");
         }
-        echo '<pre>' . print_r($this->accessInstance, 1) . '</pre>';
-        //exit;
+        if (class_exists('\App', false) && isset(\App::$log)) {
+            \App::$log->error('DLDB access locale missing', [
+                'instance' => $instanceName,
+                'locale' => $locale,
+            ]);
+        }
         throw new Exception("Locale for accessing $instanceName does not exists");
     }
 

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
@@ -16,8 +16,7 @@ class Authorities extends Base
                     $authority->save();
                 }
             } else {
-                print_r('NO Authorities(' . $this->getLocale() . ') Update needet' . \PHP_EOL);
-                #print_r($this->metaObject);
+                $this->logNoUpdateNeeded();
             }
             /*
             error_log(

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
@@ -18,17 +18,6 @@ class Authorities extends Base
             } else {
                 $this->logNoUpdateNeeded();
             }
-            /*
-            error_log(
-                print_r([
-                    'delete',
-                    $this->entityClass::getTableName(),
-                    $this->getLocale(),
-                    count($this->getCurrentEntitys()),
-                    array_keys($this->getCurrentEntitys())
-                ],1
-            ));
-            */
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();
             }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
@@ -15,8 +15,6 @@ class Authorities extends Base
                     $this->removeEntityFromCurrentList($authority->get('id'));
                     $authority->save();
                 }
-            } else {
-                $this->logNoUpdateNeeded();
             }
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
@@ -196,15 +196,5 @@ abstract class Base implements Options
     {
     }
 
-    protected function logNoUpdateNeeded(): void
-    {
-        if (class_exists('\App', false) && isset(\App::$log)) {
-            \App::$log->notice('DLDB entity import skipped, no update needed', [
-                'entity' => $this->entityClass,
-                'locale' => $this->getLocale(),
-            ]);
-        }
-    }
-
     abstract public function runImport();
 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
@@ -88,16 +88,6 @@ abstract class Base implements Options
                 $entityObject = $this->createEntity(json_decode($entity->data_json, true));
                 $this->entitysToDelete[$entity->id] = $entityObject;
             }
-            /*
-            error_log(
-                print_r([
-                    'current',
-                    $this->entityClass::getTableName(),
-                    $this->getLocale(),
-                    count($this->entitysToDelete)
-                ],1
-            ));
-            */
         } catch (\Exception $e) {
             throw $e;
         }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
@@ -206,5 +206,15 @@ abstract class Base implements Options
     {
     }
 
+    protected function logNoUpdateNeeded(): void
+    {
+        if (class_exists('\App', false) && isset(\App::$log)) {
+            \App::$log->notice('DLDB entity import skipped, no update needed', [
+                'entity' => $this->entityClass,
+                'locale' => $this->getLocale(),
+            ]);
+        }
+    }
+
     abstract public function runImport();
 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
@@ -173,22 +173,6 @@ class Location extends Base
     public function preSetup()
     {
         try {
-            /*
-            if (false === $this->get('meta.translated')) {
-                $this->setStatus(static::STATUS_OLD);
-                error_log(
-                    'not translated location - (' . $this->get('id') . ' | ' .
-                    $this->get('meta.locale') . ') - ' . $this->get('name')
-                );
-                return false;
-            }
-            else {
-                error_log(
-                    'translated location - (' . $this->get('id') . ' | ' .
-                    $this->get('meta.locale') . ') - ' . $this->get('name')
-                );
-            }
-            */
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
             $fields[] = static::getTableName();
             $this->setStatus(static::STATUS_OLD);

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
@@ -267,22 +267,6 @@ class Service extends Base
     public function preSetup()
     {
         try {
-            /*
-            if (false === $this->get('meta.translated')) {
-                $this->setStatus(static::STATUS_OLD);
-                error_log(
-                    'not translated service - (' . $this->get('id') . ' | ' .
-                    $this->get('meta.locale') . ') - ' . $this->get('name')
-                );
-                return false;
-            }
-            else {
-                error_log(
-                    'translated service - (' . $this->get('id') . ' | ' .
-                    $this->get('meta.locale') . ') - ' . $this->get('name')
-                );
-            }
-            */
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
             $fields[] = static::getTableName();
 
@@ -291,7 +275,6 @@ class Service extends Base
                     'fields' => $fields,
                 ]);
             }
-            #error_log(print_r($fields[2]));
 
             $this->setStatus(static::STATUS_OLD);
             if ($this->itemNeedsUpdate(...array_values($fields))) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
@@ -286,8 +286,10 @@ class Service extends Base
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
             $fields[] = static::getTableName();
 
-            if (is_array($fields[2])) {
-                error_log(print_r($fields[2]));
+            if (is_array($fields[2]) && class_exists('\App', false) && isset(\App::$log)) {
+                \App::$log->warning('Unexpected array in service meta hash during import', [
+                    'fields' => $fields,
+                ]);
             }
             #error_log(print_r($fields[2]));
 

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
@@ -18,18 +18,6 @@ class Locations extends Base
             } else {
                 $this->logNoUpdateNeeded();
             }
-            /*
-            error_log(
-                print_r([
-                    'delete',
-                     $this->entityClass::getTableName(),
-                     $this->getLocale(),
-                     count($this->getCurrentEntitys()),
-                     array_keys($this->getCurrentEntitys())
-                ],
-            1));
-
-                */
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();
             }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
@@ -15,8 +15,6 @@ class Locations extends Base
                     $this->removeEntityFromCurrentList($location->get('id'));
                     $location->save();
                 }
-            } else {
-                $this->logNoUpdateNeeded();
             }
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
@@ -16,8 +16,7 @@ class Locations extends Base
                     $location->save();
                 }
             } else {
-                print_r('NO Locations(' . $this->getLocale() . ') Update needet' . \PHP_EOL);
-                #print_r($this->metaObject);
+                $this->logNoUpdateNeeded();
             }
             /*
             error_log(

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
@@ -16,7 +16,7 @@ class Services extends Base
                     $service->save();
                 }
             } else {
-                print_r('NO Services(' . $this->getLocale() . ') Update needet' . \PHP_EOL);
+                $this->logNoUpdateNeeded();
             }
             /*
             error_log(

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
@@ -15,10 +15,7 @@ class Services extends Base
                     $this->removeEntityFromCurrentList($service->get('id'));
                     $service->save();
                 }
-            } else {
-                $this->logNoUpdateNeeded();
             }
-
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();
             }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
@@ -18,17 +18,6 @@ class Services extends Base
             } else {
                 $this->logNoUpdateNeeded();
             }
-            /*
-            error_log(
-                print_r([
-                    'delete',
-                    $this->entityClass::getTableName(),
-                    $this->getLocale(),
-                    count($this->getCurrentEntitys()),
-                    array_keys($this->getCurrentEntitys())
-                ],
-            1));
-            */
 
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
@@ -16,8 +16,7 @@ class Topics extends Base
                     $topic->save();
                 }
             } else {
-                print_r('NO Topics(' . $this->getLocale() . ') Update needet' . \PHP_EOL);
-                #print_r($this->metaObject);
+                $this->logNoUpdateNeeded();
             }
             /*
             error_log(

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
@@ -15,8 +15,6 @@ class Topics extends Base
                     $this->removeEntityFromCurrentList($topic->get('id'));
                     $topic->save();
                 }
-            } else {
-                $this->logNoUpdateNeeded();
             }
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
@@ -18,17 +18,6 @@ class Topics extends Base
             } else {
                 $this->logNoUpdateNeeded();
             }
-            /*
-            error_log(
-                print_r([
-                    'delete',
-                    $this->entityClass::getTableName(),
-                    $this->getLocale(),
-                    count($this->getCurrentEntitys()),
-                    array_keys($this->getCurrentEntitys())
-                ],
-            1));
-            */
             foreach ($this->getCurrentEntitys() as $entityToDelete) {
                 $entityToDelete->delete();
             }

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -15,7 +15,7 @@ class Timer
     {
         $this->start();
         if (true === DEBUG) {
-            echo 'Working - please wait...' . PHP_EOL;
+            fwrite(STDERR, 'Working - please wait...' . PHP_EOL);
         }
     }
 
@@ -77,12 +77,7 @@ class Timer
     public function __destruct()
     {
         if (true === DEBUG) {
-            echo 'Job finished in ' . $this->getTime() . PHP_EOL;
+            fwrite(STDERR, 'Job finished in ' . $this->getTime() . PHP_EOL);
         }
     }
-}
-
-function print_rFnArgs()
-{
-    print_r(func_get_args());
 }

--- a/zmsdldb/src/Zmsdldb/Importer/test_mysql.php
+++ b/zmsdldb/src/Zmsdldb/Importer/test_mysql.php
@@ -64,8 +64,9 @@ try {
     $mysqlIporter->commit();
 } catch (\Exception $e) {
     $mysqlIporter->rollBack();
-    error_log('Import faild - ' . $e->getMessage());
+    fwrite(STDERR, 'Import failed: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
 }
 
 unset($timer);
-echo "Memory usage: " . number_format((memory_get_usage() / (1024 * 1024)), 2) . ' mb' . PHP_EOL;
+fwrite(STDERR, 'Memory usage: ' . number_format((memory_get_usage() / (1024 * 1024)), 2) . ' mb' . PHP_EOL);

--- a/zmsdldb/src/Zmsdldb/Importer/test_sqlite.php
+++ b/zmsdldb/src/Zmsdldb/Importer/test_sqlite.php
@@ -97,9 +97,9 @@ try {
     $sqLiteIporter->commit();
 } catch (\Exception $e) {
     $sqLiteIporter->rollBack();
-    error_log('Import faild');
+    fwrite(STDERR, 'Import failed: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
 }
 
-
 unset($timer);
-echo "Memory usage: " . number_format((memory_get_usage() / (1024 * 1024)), 2) . ' mb' . PHP_EOL;
+fwrite(STDERR, 'Memory usage: ' . number_format((memory_get_usage() / (1024 * 1024)), 2) . ' mb' . PHP_EOL);

--- a/zmsdldb/tests/Zmsdldb/TwigExtensionCompat.php
+++ b/zmsdldb/tests/Zmsdldb/TwigExtensionCompat.php
@@ -35,7 +35,7 @@ class TwigExtensionCompat extends \Twig_Extension
 
     public function includeUrl($withUri = true)
     {
-        //error_log("TODO: Remove includeUrl and baseUrl functions and use template parameters");
+        // TODO: Remove includeUrl and baseUrl functions and use template parameters
         return "/";
     }
 

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -154,7 +154,6 @@ class Appointment extends Schema\Entity
      */
     public function isMatching(self $appointment)
     {
-        //error_log("Compare $this with $appointment");
         if (
             $appointment['scope']['id'] == $this['scope']['id']
             && $appointment['date'] == $this['date']

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -412,12 +412,10 @@ class Availability extends Schema\Entity
         $startDate = $this->getBookableStart($now)->modify('00:00:00');
 
         if ($bookableCurrentTime->getTimestamp() < $startDate->getTimestamp()) {
-            //error_log("START " . $bookableCurrentTime->format('c').'<'.$startDate->format('c'). " " . $this);
             return false;
         }
         $endDate = $this->getBookableEnd($now)->modify('23:59:59');
         if ($bookableCurrentTime->getTimestamp() > $endDate->getTimestamp()) {
-            //error_log("END " . $bookableCurrentTime->format('c').'>'.$endDate->format('c'). " " . $this);
             return false;
         }
         if (
@@ -427,10 +425,6 @@ class Availability extends Schema\Entity
             // Avoid releasing all appointments on midnight, allow smaller contingents distributed over the day
             $delayedStart = $this->getBookableEnd($now)->modify($this->getStartDateTime()->format('H:i:s'));
             if ($bookableCurrentTime->getTimestamp() < $delayedStart->getTimestamp()) {
-                //error_log(
-                //    sprintf("DELAY %s<%s", $bookableCurrentTime->format('c'), $delayedStart->format('c'))
-                //    ." $this"
-                //);
                 return false;
             }
         }

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -130,25 +130,20 @@ class SlotList extends Base
         $takeFollowingSlot = 0;
         $startTime = $appointment->toDateTime()->format('H:i');
         $containsAppointment = false;
-        //error_log('check: ' . $appointment);
         foreach ($this as $slot) {
             if ($takeFollowingSlot > 0) {
                 if (0 == $slot['intern']) {
-                    //error_log('false 2: ' . $slot);
                     return false;
                 }
                 $slot->removeAppointment();
                 $takeFollowingSlot--;
-                //error_log('intern 2: ' . $slot . ' | following: ' . $takeFollowingSlot);
             }
             if ($slot->hasTime() && $slot->time == $startTime) {
                 $takeFollowingSlot = $appointment['slotCount'] - 1;
-                //error_log('intern: ' . $slot . ' | following: ' . $takeFollowingSlot);
                 if (0 < $slot['intern']) {
                     $containsAppointment = true;
                     $slot->removeAppointment();
                 } else {
-                    //error_log('false: ' . $slot);
                     return false;
                 }
             }
@@ -170,7 +165,6 @@ class SlotList extends Base
         $sum = ($slot instanceof Slot) ? $slot : new Slot();
         $sum->type = Slot::SUM;
         foreach ($this as $slot) {
-            //error_log("$slot");
             $sum['public'] += $slot['public'];
             $sum['intern'] += $slot['intern'];
         }

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -37,11 +37,9 @@ class Schema extends \ArrayObject
 
     protected function resolveKey($key, $value, $resolveLevel)
     {
-        //error_log("Resolve($resolveLevel) Key = " . $key . " -> " . gettype($value));
         if (is_array($value)) {
             $value = $this->resolveReferences($value, $resolveLevel);
         } elseif ($key === '$ref' && $value[0] != '#') {
-            //error_log("Load $value");
             $value = Loader::asArray($value)->withResolvedReferences($resolveLevel - 1);
         }
         return $value;

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -367,17 +367,14 @@ class Useraccount extends Schema\Entity
     {
         // Do you have old, turbo-legacy, non-crypt hashes?
         if (strpos($this->password, '$') !== 0) {
-            //error_log(__METHOD__ . "::legacy_hash\n");
             $result = $this->password === md5($password);
         } else {
-            //error_log(__METHOD__ . "::password_verify\n");
             $result = password_verify($password, $this->password);
         }
 
         // on passed validation check if the hash needs updating.
         if ($result && $this->isPasswordNeedingRehash()) {
             $this->password = $this->getHash($password);
-            //error_log(__METHOD__ . "::rehash\n");
         }
 
         return $this;

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -82,17 +82,6 @@ class ProcessValidator
         $length = strlen((string)$valid->getUnvalidated());
         $process = $this->getProcess();
 
-        /*
-        error_log(
-            "Mail validate: ".$valid->getUnvalidated()
-            ." ($length) with scope mail required="
-            . ($process->getCurrentScope()->isEmailRequired() ? 'yes' : 'no')
-            ." with appointment="
-            . ($process->isWithAppointment() ? 'yes' : 'no')
-            ." with callback="
-            . ( ($isRequiredCallback && $isRequiredCallback()) ? 'yes' : 'no')
-        );
-        */
         if (!$length && $process->getCurrentScope()->isEmailRequired() && $process->isWithAppointment()) {
             $valid->isBiggerThan(
                 6,

--- a/zmsentities/tests/Zmsentities/AvailabilityTest.php
+++ b/zmsentities/tests/Zmsentities/AvailabilityTest.php
@@ -409,7 +409,6 @@ class AvailabilityTest extends EntityCommonTests
         $entity['startDate'] = $time->modify("-60 day")->getTimestamp();
         $entity['endDate'] = $time->modify("+200 day")->getTimestamp();
         $entity['scope'] = (new \BO\Zmsentities\Scope())->getExample();
-        //error_log(__METHOD__ . ": $entity ". $time->format('c'));
         $this->assertTrue(
             $entity->isBookable($time->modify("+1month"), $time),
             'Availability endInDays is before startInDays'
@@ -920,13 +919,6 @@ class AvailabilityTest extends EntityCommonTests
         $conflicts = $availabilityList->getConflicts($startDate, $startDate);
         $list = [];
         foreach ($conflicts as $conflict) {
-            /*error_log(
-                "\n$conflict " .
-                $conflict->amendment .
-                "(ID: ". $conflict->getFirstAppointment()->getAvailability()->getId() ." ". $conflict->getFirstAppointment()->getAvailability()->getStartDateTime() ." - ". $conflict->getFirstAppointment()->getAvailability()->getEndDateTime() .")"
-            );
-            */
-
             $id = $conflict->getFirstAppointment()->getAvailability()->getId();
             if (! isset($list[$conflict->amendment])) {
                 $list[$conflict->amendment] = [];

--- a/zmsslim/README.md
+++ b/zmsslim/README.md
@@ -274,6 +274,20 @@ For nice URLs you need a `.htaccess` file if you use an Apache2 webserver:
     RewriteRule ^ /index.php [QSA,L]
 ```
 
+## Logging (Monolog / `App::$log`)
+
+All ZMS Slim modules share one PSR-3 logger: `App::$log`, configured by `BO\Slim\Bootstrap::configureLogger()`.
+
+- Minimum level: `App::DEBUGLEVEL` (env `DEBUGLEVEL`, default `INFO`; defined as `ZMS_DEBUGLEVEL` in `Application.php`)
+- Web: JSON logs on **stderr**; CLI/cron: **stdout**
+- Use `\App::$log->info('message', ['key' => $value])` — not PHP `error_log()`
+
+Full guide, level reference, and an auto-generated inventory of all `App::$log` calls in the monorepo:
+
+**[Monolog logging (docs)](https://it-at-m.github.io/eappointment/operations/monolog-logging.html)**
+
+Regenerate the inventory locally: `cd docs && npm run docs:log-inventory`
+
 ## Twig integration
 
 Our implementation of Slim uses Twig as the templating engine.

--- a/zmsslim/src/Slim/Bootstrap.php
+++ b/zmsslim/src/Slim/Bootstrap.php
@@ -307,7 +307,10 @@ class Bootstrap
             try {
                 $container['router']->setCacheFile($cacheFile);
             } catch (\Exception $exception) {
-                error_log("Could not write Router-Cache-File: $cacheFile");
+                App::$log->warning('Could not write router cache file', [
+                    'cacheFile' => $cacheFile,
+                    'exception' => $exception->getMessage(),
+                ]);
                 throw $exception;
             }
         }

--- a/zmsslim/src/Slim/TwigExceptionHandler.php
+++ b/zmsslim/src/Slim/TwigExceptionHandler.php
@@ -93,20 +93,16 @@ class TwigExceptionHandler implements ErrorHandlerInterface
                 $status
             );
         } catch (\Throwable $subexception) {
-            error_log(
-                "Not catchable Exception: "
-                . $exception->getMessage()
-                . " "
-                . $exception->getFile()
-                . ":"
-                . $exception->getLine()
-                . " "
-                . $exception->getTraceAsString()
-                . " ---- because of "
-                . $subexception->getMessage()
-                . " "
-                . $subexception->getTraceAsString()
-            );
+            \App::$log->critical('Not catchable exception while rendering error page', [
+                'exception' => get_class($exception),
+                'message' => $exception->getMessage(),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'trace' => $exception->getTraceAsString(),
+                'cause' => get_class($subexception),
+                'causeMessage' => $subexception->getMessage(),
+                'causeTrace' => $subexception->getTraceAsString(),
+            ]);
         }
     }
 

--- a/zmsslim/src/Slim/TwigExceptionHandler.php
+++ b/zmsslim/src/Slim/TwigExceptionHandler.php
@@ -46,7 +46,7 @@ class TwigExceptionHandler implements ErrorHandlerInterface
         ResponseInterface $response,
         \Throwable $exception,
         $status = 500
-    ) {
+    ): ResponseInterface {
         try {
             $request = Controller::prepareRequest($request);
             if ($exception->getCode() >= 200) {
@@ -103,6 +103,13 @@ class TwigExceptionHandler implements ErrorHandlerInterface
                 'causeMessage' => $subexception->getMessage(),
                 'causeTrace' => $subexception->getTraceAsString(),
             ]);
+
+            $fallback = $response
+                ->withStatus(500)
+                ->withHeader('Content-Type', 'text/plain; charset=UTF-8');
+            $fallback->getBody()->write('Internal Server Error');
+
+            return $fallback;
         }
     }
 

--- a/zmsticketprinter/src/Zmsticketprinter/Helper/Ticketprinter.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Helper/Ticketprinter.php
@@ -38,7 +38,9 @@ class Ticketprinter
         try {
             $entity = $this->getByHash($hash, $entity);
         } catch (\Exception $e) {
-            error_log('Error in getByHash creating new organisation hash: ' . $e->getMessage());
+            \App::$log->warning('Error in getByHash, creating new organisation hash', [
+                'exception' => $e->getMessage(),
+            ]);
             $entity = $this->writeNewWithHash($request, $entity);
         }
 


### PR DESCRIPTION
Route production paths through App::$log (Monolog JSON), use $this->fail() in tests instead of error_log, and fwrite(STDERR) for standalone DLDB dev scripts. DLDB MySQL importers log skipped updates via logNoUpdateNeeded().

<img width="1470" height="868" alt="Screenshot 2026-05-26 at 13 59 57" src="https://github.com/user-attachments/assets/0062b0c1-92a9-49a7-836a-afa4a33ea16e" />

<img width="1470" height="868" alt="Screenshot 2026-05-26 at 13 56 13" src="https://github.com/user-attachments/assets/04892727-dac4-43cc-92ef-3c54bf33d607" />

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting and logging across the application for enhanced diagnostics and troubleshooting when operations fail.
  * Enhanced error messages for import operations, cleanup tasks, and system failures with better context.

* **Tests**
  * Test failure messages now include detailed validation error information in a more readable format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/eappointment/pull/2451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->