### PR TITLE
fix(ZMSKVR-1449): use error type for all captcha API error messages

### DIFF
--- a/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
@@ -56,7 +56,7 @@ class ErrorMessages
             'errorCode' => 'captchaVerificationFailed',
             'statusCode' => self::HTTP_BAD_REQUEST,
             'errorMessage' => 'Captcha verification failed.',
-            'errorType' => 'warning'
+            'errorType' => 'error'
         ],
         'invalidLocationAndServiceCombination' => [
             'errorCode' => 'invalidLocationAndServiceCombination',
@@ -187,25 +187,25 @@ class ErrorMessages
         'captchaVerificationError' => [
             'errorCode' => 'captchaVerificationError',
             'statusCode' => self::HTTP_BAD_REQUEST,
-            'errorType' => 'warning',
+            'errorType' => 'error',
             'errorMessage' => 'An error occurred during captcha verification.'
         ],
         'captchaMissing' => [
             'errorCode' => 'captchaMissing',
             'statusCode' => self::HTTP_BAD_REQUEST,
-            'errorType' => 'warning',
+            'errorType' => 'error',
             'errorMessage' => 'Missing captcha token.',
         ],
         'captchaInvalid' => [
             'errorCode' => 'captchaInvalid',
             'statusCode' => self::HTTP_BAD_REQUEST,
-            'errorType' => 'warning',
+            'errorType' => 'error',
             'errorMessage' => 'Invalid captcha token.',
         ],
         'captchaExpired' => [
             'errorCode' => 'captchaExpired',
             'statusCode' => self::HTTP_BAD_REQUEST,
-            'errorType' => 'warning',
+            'errorType' => 'error',
             'errorMessage' => 'Captcha token expired.',
         ],
         'serviceUnavailable' => [

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
@@ -1700,7 +1700,7 @@ describe("AppointmentSelection", () => {
   });
 
   describe("Error States Integration", () => {
-    it('shows captcha error warning callout when captcha error is set', async () => {
+    it('shows captcha error callout when captcha error is set', async () => {
       const wrapper = createWrapper({
         selectedService: {
           id: "service1",
@@ -1712,7 +1712,7 @@ describe("AppointmentSelection", () => {
         props: {
           bookingError: true,
           bookingErrorKey: "apiErrorCaptchaInvalid",
-          errorType: "warning"
+          errorType: "error"
         }
       });
 
@@ -1730,13 +1730,13 @@ describe("AppointmentSelection", () => {
       wrapper.vm.isSwitchingProvider = false;
       await nextTick();
 
-      // Find all callouts and get the warning one
+      // Find all callouts and get the error one
       const callouts = wrapper.findAll('[data-test="muc-callout"]');
-      const warningCallout = callouts.find(c => c.attributes('data-type') === 'warning');
+      const errorCallout = callouts.find(c => c.attributes('data-type') === 'error');
 
-      expect(warningCallout).toBeDefined();
-      expect(warningCallout!.html()).toContain("apiErrorCaptchaInvalidHeader");
-      expect(warningCallout!.html()).toContain("apiErrorCaptchaInvalidText");
+      expect(errorCallout).toBeDefined();
+      expect(errorCallout!.html()).toContain("apiErrorCaptchaInvalidHeader");
+      expect(errorCallout!.html()).toContain("apiErrorCaptchaInvalidText");
     });
 
     it('shows no appointment error info callout when no appointment error is set', async () => {


### PR DESCRIPTION
Align captcha errorType with red muc-callout styling in zmscitizenview.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced captcha error notifications. Captcha-related errors—including verification failures, missing captcha fields, invalid entries, and expired captchas—are now displayed with error-level severity instead of warnings. This provides users with more appropriate visual feedback and clearer indication of critical issues during the captcha verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->