### PR TITLE
chore(GH): refactor schemas and tests for altcha v2

### DIFF
--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Captcha/CaptchaChallengeControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Captcha/CaptchaChallengeControllerTest.php
@@ -43,17 +43,7 @@ class CaptchaChallengeControllerTest extends ControllerTestCase
 
     public function testCreateChallengeSuccess()
     {
-        $expectedChallenge = [
-            'meta' => ['success' => true],
-            'data' => [
-                'algorithm' => 'SHA-256',
-                'challenge' => 'abcdefg0123456789',
-                'maxnumber' => 1000,
-                'salt' => '0123456789',
-                'signature' => 'abcdefg0123456789',
-                'signature' => 'abcdefg0123456789',
-            ]
-        ];
+        $expectedChallenge = json_decode($this->readFixture('GET_captcha_challenge.json'), true);
 
         $mockResponse = new Response(200, [], json_encode(['challenge' => $expectedChallenge]));
 

--- a/zmscitizenapi/tests/Zmscitizenapi/Controllers/Captcha/CaptchaVerifyControllerTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Controllers/Captcha/CaptchaVerifyControllerTest.php
@@ -43,10 +43,15 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
         parent::tearDown();
     }
 
+    private function encodedCaptchaPayload(): string
+    {
+        return base64_encode($this->readFixture('POST_captcha_verify_payload.json'));
+    }
+
     public function testRendering()
     {
         $parameters = [
-            'payload' => base64_encode(json_encode(['challenge' => 'abcdefg0123456789']))
+            'payload' => $this->encodedCaptchaPayload()
         ];
         $response = $this->render([], $parameters, [], 'POST');
         $this->assertEquals(200, $response->getStatusCode());
@@ -84,8 +89,7 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
             }
         };
 
-        $payload = base64_encode(json_encode(['challenge' => 'abcdefg0123456789']));
-        $result = $captcha->verifySolution($payload);
+        $result = $captcha->verifySolution($this->encodedCaptchaPayload());
 
         $this->assertEquals($expectedResponse['meta'], $result['meta']);
         $this->assertEquals($expectedResponse['data'], $result['data']);
@@ -117,8 +121,7 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
             }
         };
 
-        $payload = base64_encode(json_encode(['challenge' => 'abcdefg0123456789']));
-        $result = $captcha->verifySolution($payload);
+        $result = $captcha->verifySolution($this->encodedCaptchaPayload());
 
         $this->assertEquals($expectedResponse['meta'], $result['meta']);
         $this->assertEquals($expectedResponse['data'], $result['data']);
@@ -147,8 +150,7 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
             }
         };
 
-        $payload = base64_encode(json_encode(['challenge' => 'abcdefg0123456789']));
-        $result = $captcha->verifySolution($payload);
+        $result = $captcha->verifySolution($this->encodedCaptchaPayload());
 
         $this->assertEquals($expectedResponse['meta'], $result['meta']);
         $this->assertEquals($expectedResponse['data'], $result['data']);
@@ -202,8 +204,7 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
             }
         };
 
-        $payload = base64_encode(json_encode(['challenge' => 'abcdefg0123456789']));
-        $result = $captcha->verifySolution($payload);
+        $result = $captcha->verifySolution($this->encodedCaptchaPayload());
 
         $this->assertFalse($result['meta']['success']);
         $this->assertStringContainsString('Response from Captcha service is not valid JSON', $result['meta']['error']);
@@ -246,7 +247,7 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
 
     public function testVerifySolutionException()
     {
-        $mockHandler = new MockHandler([ 
+        $mockHandler = new MockHandler([
             new \GuzzleHttp\Exception\ConnectException(
                 'Connection refused',
                 new \GuzzleHttp\Psr7\Request('POST', 'test')
@@ -267,8 +268,7 @@ class CaptchaVerifyControllerTest extends ControllerTestCase
             }
         };
 
-        $payload = base64_encode(json_encode(['challenge' => 'abcdefg0123456789']));
-        $result = $captcha->verifySolution($payload);
+        $result = $captcha->verifySolution($this->encodedCaptchaPayload());
 
         $this->assertFalse($result['meta']['success']);
         $this->assertStringContainsString('Connection refused', $result['meta']['error']);

--- a/zmscitizenapi/tests/Zmscitizenapi/fixtures/GET_captcha_challenge.json
+++ b/zmscitizenapi/tests/Zmscitizenapi/fixtures/GET_captcha_challenge.json
@@ -1,0 +1,16 @@
+{
+    "parameters": {
+        "algorithm": "SHA-256",
+        "nonce": "5808c72adc97dfdeb0146f0c24eac1d2073daf3ae1cdd7debbbed23462e7d03c",
+        "salt": "d065c7a20ad6e4920f567df4",
+        "cost": 1000,
+        "keyLength": 32,
+        "keyPrefix": "00",
+        "keySignature": null,
+        "memoryCost": null,
+        "parallelism": null,
+        "expiresAt": 1778916660,
+        "data": null
+    },
+    "signature": "0a706f95851b6a5803771d7c301a2b3ea9f8980ae4812c2e8ef80fa2ca081bfb"
+}

--- a/zmscitizenapi/tests/Zmscitizenapi/fixtures/POST_captcha_verify_payload.json
+++ b/zmscitizenapi/tests/Zmscitizenapi/fixtures/POST_captcha_verify_payload.json
@@ -1,0 +1,23 @@
+{
+    "challenge": {
+        "parameters": {
+            "algorithm": "SHA-256",
+            "nonce": "5808c72adc97dfdeb0146f0c24eac1d2073daf3ae1cdd7debbbed23462e7d03c",
+            "salt": "d065c7a20ad6e4920f567df4",
+            "cost": 1000,
+            "keyLength": 32,
+            "keyPrefix": "00",
+            "keySignature": null,
+            "memoryCost": null,
+            "parallelism": null,
+            "expiresAt": 1778916660,
+            "data": null
+        },
+        "signature": "0a706f95851b6a5803771d7c301a2b3ea9f8980ae4812c2e8ef80fa2ca081bfb"
+    },
+    "solution": {
+        "counter": 12,
+        "derivedKey": "00a1b2c3d4e5f6789abcdef0123456789abcdef",
+        "time": 47
+    }
+}

--- a/zmscitizenapi/tests/Zmscitizenapi/fixtures/POST_captcha_verify_payload.json
+++ b/zmscitizenapi/tests/Zmscitizenapi/fixtures/POST_captcha_verify_payload.json
@@ -17,7 +17,7 @@
     },
     "solution": {
         "counter": 12,
-        "derivedKey": "00a1b2c3d4e5f6789abcdef0123456789abcdef",
+        "derivedKey": "001234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
         "time": 47
     }
 }

--- a/zmsentities/schema/citizenapi/captcha/altchaVerifyPayload.json
+++ b/zmsentities/schema/citizenapi/captcha/altchaVerifyPayload.json
@@ -1,0 +1,35 @@
+{
+    "title": "AltchaVerifyPayload",
+    "type": "object",
+    "properties": {
+        "challenge": {
+            "$ref": "createChallengeResponse.json"
+        },
+        "solution": {
+            "type": "object",
+            "properties": {
+                "counter": {
+                    "type": "number",
+                    "description": "Brute-forced integer that satisfies the proof of work"
+                },
+                "derivedKey": {
+                    "type": "string",
+                    "description": "Lowercase hex of the derived key for counter"
+                },
+                "time": {
+                    "type": "number",
+                    "description": "Time of challenge completion in milliseconds"
+                }
+            },
+            "required": [
+                "counter",
+                "derivedKey"
+            ]
+        }
+    },
+    "required": [
+        "challenge",
+        "solution"
+    ],
+    "description": "Decoded JSON structure inside the base64-encoded payload field of POST /captcha-verify/"
+}

--- a/zmsentities/schema/citizenapi/captcha/createChallengeResponse.json
+++ b/zmsentities/schema/citizenapi/captcha/createChallengeResponse.json
@@ -19,11 +19,11 @@
                     "description": "Random salt for key derivation"
                 },
                 "cost": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Work factor (KDF iterations). Larger values are harder to solve"
                 },
                 "keyLength": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Length of the derived key in bytes"
                 },
                 "keyPrefix": {
@@ -35,15 +35,15 @@
                     "description": "Optional HMAC of the expected derived key"
                 },
                 "memoryCost": {
-                    "type": ["number", "null"],
+                    "type": ["integer", "null"],
                     "description": "Memory cost for memory-hard algorithms"
                 },
                 "parallelism": {
-                    "type": ["number", "null"],
+                    "type": ["integer", "null"],
                     "description": "Parallelism for memory-hard algorithms"
                 },
                 "expiresAt": {
-                    "type": ["number", "null"],
+                    "type": ["integer", "null"],
                     "description": "Unix timestamp (seconds) after which verification fails"
                 },
                 "data": {

--- a/zmsentities/schema/citizenapi/captcha/createChallengeResponse.json
+++ b/zmsentities/schema/citizenapi/captcha/createChallengeResponse.json
@@ -2,35 +2,72 @@
     "title": "AltchaCaptchaChallenge",
     "type": "object",
     "properties": {
-        "algorithm": {
-            "type": "string",
-            "description": "The algorithm used for HMAC signature"
-        },
-        "challenge": {
-            "type": "string",
-            "description": "The challenge itself"
-        },
-        "maxnumber": {
-            "type": "number",
-            "description": "The complexity of the challenge specified as a number"
-        },
-        "salt": {
-            "type": "string",
-            "minLength": 10,
-            "description": "Random string as part of the challenge"
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "algorithm": {
+                    "type": "string",
+                    "description": "Key-derivation algorithm used for the proof of work"
+                },
+                "nonce": {
+                    "type": "string",
+                    "description": "Random server-issued nonce used as part of the proof-of-work input"
+                },
+                "salt": {
+                    "type": "string",
+                    "minLength": 10,
+                    "description": "Random salt for key derivation"
+                },
+                "cost": {
+                    "type": "number",
+                    "description": "Work factor (KDF iterations). Larger values are harder to solve"
+                },
+                "keyLength": {
+                    "type": "number",
+                    "description": "Length of the derived key in bytes"
+                },
+                "keyPrefix": {
+                    "type": "string",
+                    "description": "Hex prefix the derived key must start with"
+                },
+                "keySignature": {
+                    "type": ["string", "null"],
+                    "description": "Optional HMAC of the expected derived key"
+                },
+                "memoryCost": {
+                    "type": ["number", "null"],
+                    "description": "Memory cost for memory-hard algorithms"
+                },
+                "parallelism": {
+                    "type": ["number", "null"],
+                    "description": "Parallelism for memory-hard algorithms"
+                },
+                "expiresAt": {
+                    "type": ["number", "null"],
+                    "description": "Unix timestamp (seconds) after which verification fails"
+                },
+                "data": {
+                    "type": ["object", "null"],
+                    "description": "Optional custom metadata attached to the challenge"
+                }
+            },
+            "required": [
+                "algorithm",
+                "nonce",
+                "salt",
+                "cost",
+                "keyLength",
+                "keyPrefix"
+            ]
         },
         "signature": {
             "type": "string",
-            "description": "HMAC signature of the verification data"
+            "description": "HMAC signature over the challenge parameters"
         }
     },
     "required": [
-        "algorithm",
-        "challenge",
-        "maxnumber",
-        "salt",
+        "parameters",
         "signature"
     ],
-    "description": "Schema definition for an AltchaCaptcha challenge response"
+    "description": "Schema definition for an AltchaCaptcha v2 challenge response"
 }
-    

--- a/zmsentities/schema/citizenapi/captcha/verifySolutionRequest.json
+++ b/zmsentities/schema/citizenapi/captcha/verifySolutionRequest.json
@@ -1,121 +1,14 @@
 {
-    "title": "AltchaCaptchaSolutionRequest",
+    "title": "CaptchaVerifyRequest",
     "type": "object",
     "properties": {
-        "siteKey": {
-            "type": "string",
-            "description": "Site key for AltchaCaptcha integration"
-        },
-        "siteSecret": {
-            "type": "string",
-            "description": "Site secret for AltchaCaptcha integration"
-        },
-        "clientAddress": {
-            "type": "string",
-            "description": "Source IP address of the end user"
-        },
         "payload": {
-            "type": "object",
-            "properties": {
-                "challenge": {
-                    "type": "object",
-                    "properties": {
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "algorithm": {
-                                    "type": "string",
-                                    "description": "Key-derivation algorithm used for the proof of work"
-                                },
-                                "nonce": {
-                                    "type": "string",
-                                    "description": "Random server-issued nonce from the challenge"
-                                },
-                                "salt": {
-                                    "type": "string",
-                                    "minLength": 10,
-                                    "description": "Salt from the challenge"
-                                },
-                                "cost": {
-                                    "type": "number",
-                                    "description": "Work factor from the challenge"
-                                },
-                                "keyLength": {
-                                    "type": "number",
-                                    "description": "Length of the derived key in bytes"
-                                },
-                                "keyPrefix": {
-                                    "type": "string",
-                                    "description": "Hex prefix the derived key must start with"
-                                },
-                                "keySignature": {
-                                    "type": ["string", "null"]
-                                },
-                                "memoryCost": {
-                                    "type": ["number", "null"]
-                                },
-                                "parallelism": {
-                                    "type": ["number", "null"]
-                                },
-                                "expiresAt": {
-                                    "type": ["number", "null"]
-                                },
-                                "data": {
-                                    "type": ["object", "null"]
-                                }
-                            },
-                            "required": [
-                                "algorithm",
-                                "nonce",
-                                "salt",
-                                "cost",
-                                "keyLength",
-                                "keyPrefix"
-                            ]
-                        },
-                        "signature": {
-                            "type": "string",
-                            "description": "HMAC signature from the challenge"
-                        }
-                    },
-                    "required": [
-                        "parameters",
-                        "signature"
-                    ]
-                },
-                "solution": {
-                    "type": "object",
-                    "properties": {
-                        "counter": {
-                            "type": "number",
-                            "description": "Brute-forced integer that satisfies the proof of work"
-                        },
-                        "derivedKey": {
-                            "type": "string",
-                            "description": "Lowercase hex of the derived key for counter"
-                        },
-                        "time": {
-                            "type": "number",
-                            "description": "Time of challenge completion in milliseconds"
-                        }
-                    },
-                    "required": [
-                        "counter",
-                        "derivedKey"
-                    ]
-                }
-            },
-            "required": [
-                "challenge",
-                "solution"
-            ]
+            "type": "string",
+            "description": "Base64-encoded JSON (URL-safe alphabet) containing the Altcha challenge and solution. After decoding, the JSON conforms to altchaVerifyPayload.json."
         }
     },
     "required": [
-        "siteKey",
-        "siteSecret",
-        "clientAddress",
         "payload"
     ],
-    "description": "Schema definition for an AltchaCaptcha v2 solution request"
+    "description": "Request body for POST /captcha-verify/. The server adds siteKey, siteSecret, and clientAddress when forwarding verification to the Altcha service."
 }

--- a/zmsentities/schema/citizenapi/captcha/verifySolutionRequest.json
+++ b/zmsentities/schema/citizenapi/captcha/verifySolutionRequest.json
@@ -10,42 +10,112 @@
             "type": "string",
             "description": "Site secret for AltchaCaptcha integration"
         },
+        "clientAddress": {
+            "type": "string",
+            "description": "Source IP address of the end user"
+        },
         "payload": {
             "type": "object",
             "properties": {
-                "algorithm": {
-                    "type": "string",
-                    "description": "The algorithm used for HMAC signature"
-                },
                 "challenge": {
-                    "type": "string",
-                    "description": "The challenge itself"
+                    "type": "object",
+                    "properties": {
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "algorithm": {
+                                    "type": "string",
+                                    "description": "Key-derivation algorithm used for the proof of work"
+                                },
+                                "nonce": {
+                                    "type": "string",
+                                    "description": "Random server-issued nonce from the challenge"
+                                },
+                                "salt": {
+                                    "type": "string",
+                                    "minLength": 10,
+                                    "description": "Salt from the challenge"
+                                },
+                                "cost": {
+                                    "type": "number",
+                                    "description": "Work factor from the challenge"
+                                },
+                                "keyLength": {
+                                    "type": "number",
+                                    "description": "Length of the derived key in bytes"
+                                },
+                                "keyPrefix": {
+                                    "type": "string",
+                                    "description": "Hex prefix the derived key must start with"
+                                },
+                                "keySignature": {
+                                    "type": ["string", "null"]
+                                },
+                                "memoryCost": {
+                                    "type": ["number", "null"]
+                                },
+                                "parallelism": {
+                                    "type": ["number", "null"]
+                                },
+                                "expiresAt": {
+                                    "type": ["number", "null"]
+                                },
+                                "data": {
+                                    "type": ["object", "null"]
+                                }
+                            },
+                            "required": [
+                                "algorithm",
+                                "nonce",
+                                "salt",
+                                "cost",
+                                "keyLength",
+                                "keyPrefix"
+                            ]
+                        },
+                        "signature": {
+                            "type": "string",
+                            "description": "HMAC signature from the challenge"
+                        }
+                    },
+                    "required": [
+                        "parameters",
+                        "signature"
+                    ]
                 },
-                "number": {
-                    "type": "number",
-                    "description": "The solution to the challenge"
-                },
-                "salt": {
-                    "type": "string",
-                    "minLength": 10,
-                    "description": "Random string as part of the challenge"
-                },
-                "signature": {
-                    "type": "string",
-                    "description": "HMAC signature of the verification data"
-                },
-                "took": {
-                    "type": "number",
-                    "description": "Time of challenge completion in milliseconds"
+                "solution": {
+                    "type": "object",
+                    "properties": {
+                        "counter": {
+                            "type": "number",
+                            "description": "Brute-forced integer that satisfies the proof of work"
+                        },
+                        "derivedKey": {
+                            "type": "string",
+                            "description": "Lowercase hex of the derived key for counter"
+                        },
+                        "time": {
+                            "type": "number",
+                            "description": "Time of challenge completion in milliseconds"
+                        }
+                    },
+                    "required": [
+                        "counter",
+                        "derivedKey"
+                    ]
                 }
-            }
+            },
+            "required": [
+                "challenge",
+                "solution"
+            ]
         }
     },
     "required": [
         "siteKey",
         "siteSecret",
+        "clientAddress",
         "payload"
     ],
-    "description": "Schema definition for an AltchaCaptcha solution request"
+    "description": "Schema definition for an AltchaCaptcha v2 solution request"
 }
-    


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt: : https://github.com/it-at-m/eappointment/actions/runs/27677092367
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CAPTCHA API schemas to the Altcha v2 format: challenge configuration is now grouped under `parameters`, with a streamlined top-level response containing `parameters` and `signature`.
  * Updated verification request contract to use a single base64-encoded `payload` string containing the decoded `challenge` and `solution`, and added the schema for that decoded verify payload.

* **Tests**
  * Refreshed CAPTCHA fixtures and adjusted tests to build/validate requests using fixture-driven data and shared payload helpers (including base64-encoded verification payloads).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->