### PR TITLE
fix(ZMSKVR-1437): keep navigation hidden after search for restricted roles

### DIFF
--- a/zmsadmin/src/Zmsadmin/Search.php
+++ b/zmsadmin/src/Zmsadmin/Search.php
@@ -29,6 +29,9 @@ class Search extends BaseController
     ): \Psr\Http\Message\ResponseInterface {
         $workstation = \App::$http->readGetResult('/workstation/', ['resolveReferences' => 2])->getEntity();
         $parameters = $this->readSearchParameters($request->getAttribute('validator'));
+        if ($workstation->getUseraccount()->hasRole('audit_viewer')) {
+            $parameters['hideNavigation'] = 1;
+        }
         $scopeIds = $workstation->getUseraccount()->getDepartmentList()->getUniqueScopeList()->getIds();
 
         [$processList, $processSearchTotal] = $this->readProcessSearchResults(

--- a/zmsadmin/src/Zmsadmin/UseraccountList.php
+++ b/zmsadmin/src/Zmsadmin/UseraccountList.php
@@ -43,6 +43,9 @@ class UseraccountList extends BaseController
             ->isNumber()
             ->setDefault(0)
             ->getValue();
+        if ($workstation->getUseraccount()->hasRole('user_admin')) {
+            $hideNavigation = 1;
+        }
 
         $useraccountList = new Collection();
         if ($workstation->getUseraccount()->isSuperUser()) {

--- a/zmsadmin/templates/block/search/searchresults.twig
+++ b/zmsadmin/templates/block/search/searchresults.twig
@@ -36,6 +36,9 @@
                 </div>
 
                 <input type="hidden" name="perPage" value="{{ perPage }}">
+                {% if hideNavigation %}
+                    <input type="hidden" name="hideNavigation" value="1">
+                {% endif %}
 
                 <div class="grid__item six-twelfths" style="margin-bottom: 12px;">
                     <button type="submit" class="btn btn-primary">Übernehmen</button>
@@ -137,6 +140,9 @@
                 <input type="hidden" name="provider" value="{{ provider }}">
                 <input type="hidden" name="user" value="{{ userAction }}">
                 <input type="hidden" name="date" value="{{ date }}">
+                {% if hideNavigation %}
+                    <input type="hidden" name="hideNavigation" value="1">
+                {% endif %}
                 <label for="perPage">Pro Seite</label>
                 <input
                         type="number"
@@ -157,7 +163,8 @@
                     'service': service,
                     'provider': provider,
                     'user': userAction,
-                    'date': date
+                    'date': date,
+                    'hideNavigation': hideNavigation ? 1 : null
                 }) %}
 
                 {% set nextParams = (queryParams ?? {})|merge({
@@ -167,7 +174,8 @@
                     'service': service,
                     'provider': provider,
                     'user': userAction,
-                    'date': date
+                    'date': date,
+                    'hideNavigation': hideNavigation ? 1 : null
                 }) %}
 
                 {% if currentPage > 1 %}

--- a/zmsadmin/templates/block/search/useraccountSearchForm.twig
+++ b/zmsadmin/templates/block/search/useraccountSearchForm.twig
@@ -7,6 +7,9 @@
     
     {% block board_body %}
     <form method="GET" action="{{ urlGet('useraccountList', {}, {}) }}" class="form--base">
+        {% if hideNavigation %}
+            <input type="hidden" name="hideNavigation" value="1">
+        {% endif %}
         {{ formgroup(
         {},
         [{

--- a/zmsadmin/tests/Zmsadmin/SearchTest.php
+++ b/zmsadmin/tests/Zmsadmin/SearchTest.php
@@ -144,6 +144,43 @@ class SearchTest extends Base
             'hideNavigation' => 1
         ], []);
         $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('navigation-primary', (string) $response->getBody());
+    }
+
+    public function testAuditViewerKeepsHiddenNavigationAfterSearch()
+    {
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => ['resolveReferences' => 2],
+                    'response' => $this->readFixture("GET_Workstation_audit_viewer.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/log/process/',
+                    'parameters' => [
+                        'searchQuery' => 'Test%2520BO',
+                        'page' => 1,
+                        'perPage' => 100,
+                        'service' => null,
+                        'provider' => null,
+                        'userAction' => 0,
+                        'date' => null,
+                        'scopeIds' => '380,1,141,140,142',
+                    ],
+                    'response' => $this->readFixture("GET_loglist.json")
+                ]
+            ]
+        );
+        $response = $this->render($this->arguments, $this->parameters, []);
+        $body = (string) $response->getBody();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('navigation-primary', $body);
+        $this->assertStringNotContainsString('Arbeitsansichten', $body);
+        $this->assertStringNotContainsString('Standort auswählen', $body);
+        $this->assertStringContainsString('name="hideNavigation" value="1"', $body);
     }
 
     public function testAuditAccountCanSearchLogsByServiceWithoutProcessQuery()


### PR DESCRIPTION
Audit viewer and user admin roles now always hide the sidebar navigation, and search forms preserve hideNavigation across submits and pagination.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation can now stay hidden while searching and paging through results.
  * Users with elevated admin/audit access may see a simplified view without the main navigation.

* **Bug Fixes**
  * Hidden navigation now remains in place after submitting searches and moving between result pages.
  * The user account list now consistently respects the hidden-navigation setting for eligible users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->