### PR TITLE
fix(ZMSKVR-1437): Redirect restricted roles and limit navigation for user_admin

### DIFF
--- a/zmsadmin/src/Zmsadmin/Helper/RestrictedRoleRedirect.php
+++ b/zmsadmin/src/Zmsadmin/Helper/RestrictedRoleRedirect.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @package Zmsadmin
+ * @copyright BerlinOnline Stadtportal GmbH & Co. KG
+ **/
+
+namespace BO\Zmsadmin\Helper;
+
+use BO\Slim\Render;
+use BO\Zmsentities\Useraccount;
+use Psr\Http\Message\ResponseInterface;
+
+class RestrictedRoleRedirect
+{
+    public static function create(Useraccount $useraccount): ?ResponseInterface
+    {
+        if ($useraccount->hasRole('user_admin')) {
+            return Render::redirect('useraccountList', [], ['hideNavigation' => 1]);
+        }
+
+        if ($useraccount->hasRole('audit_viewer')) {
+            return Render::redirect('search', [], ['hideNavigation' => 1]);
+        }
+
+        return null;
+    }
+}

--- a/zmsadmin/src/Zmsadmin/Helper/RestrictedRoleRedirect.php
+++ b/zmsadmin/src/Zmsadmin/Helper/RestrictedRoleRedirect.php
@@ -16,7 +16,7 @@ class RestrictedRoleRedirect
     public static function create(Useraccount $useraccount): ?ResponseInterface
     {
         if ($useraccount->hasRole('user_admin')) {
-            return Render::redirect('useraccountList', [], ['hideNavigation' => 1]);
+            return Render::redirect('useraccountList', [], []);
         }
 
         if ($useraccount->hasRole('audit_viewer')) {

--- a/zmsadmin/src/Zmsadmin/Index.php
+++ b/zmsadmin/src/Zmsadmin/Index.php
@@ -11,6 +11,7 @@ use BO\Zmsclient\ModuleAccess;
 use BO\Zmsentities\Useraccount;
 use BO\Zmsentities\Workstation;
 use BO\Zmsadmin\Helper\LoginForm;
+use BO\Zmsadmin\Helper\RestrictedRoleRedirect;
 use BO\Mellon\Validator;
 
 class Index extends BaseController
@@ -43,11 +44,8 @@ class Index extends BaseController
                 }
 
                 $useraccount = $loginData->getUseraccount();
-                if ($useraccount->hasRole('user_admin')) {
-                    return \BO\Slim\Render::redirect('useraccountList', [], ['hideNavigation' => 1]);
-                }
-                if ($useraccount->hasRole('audit_viewer')) {
-                    return \BO\Slim\Render::redirect('search', [], ['hideNavigation' => 1]);
+                if ($restrictedRoleRedirect = RestrictedRoleRedirect::create($useraccount)) {
+                    return $restrictedRoleRedirect;
                 }
                 return \BO\Slim\Render::redirect('workstationSelect', [], []);
             }
@@ -67,6 +65,10 @@ class Index extends BaseController
         if ($workstation instanceof Workstation && $workstation->hasId()) {
             if ($wrongModuleResponse = ModuleAccess::rejectWrongModuleAccess(ModuleAccess::MODULE_ADMIN, $workstation, $response)) {
                 return $wrongModuleResponse;
+            }
+
+            if ($restrictedRoleRedirect = RestrictedRoleRedirect::create($workstation->getUseraccount())) {
+                return $restrictedRoleRedirect;
             }
         }
 

--- a/zmsadmin/src/Zmsadmin/Oidc.php
+++ b/zmsadmin/src/Zmsadmin/Oidc.php
@@ -9,6 +9,7 @@ namespace BO\Zmsadmin;
 
 use BO\Zmsclient\ModuleAccess;
 use BO\Zmsclient\OidcHandler;
+use BO\Zmsadmin\Helper\RestrictedRoleRedirect;
 
 class Oidc extends BaseController
 {
@@ -29,6 +30,10 @@ class Oidc extends BaseController
 
             if ($wrongModuleResponse = ModuleAccess::rejectWrongModuleAccess(ModuleAccess::MODULE_ADMIN, $result['workstation'], $response)) {
                 return $wrongModuleResponse;
+            }
+
+            if ($restrictedRoleRedirect = RestrictedRoleRedirect::create($result['workstation']->getUseraccount())) {
+                return $restrictedRoleRedirect;
             }
 
             if ($result['redirect_to_index']) {

--- a/zmsadmin/src/Zmsadmin/UseraccountList.php
+++ b/zmsadmin/src/Zmsadmin/UseraccountList.php
@@ -43,9 +43,6 @@ class UseraccountList extends BaseController
             ->isNumber()
             ->setDefault(0)
             ->getValue();
-        if ($workstation->getUseraccount()->hasRole('user_admin')) {
-            $hideNavigation = 1;
-        }
 
         $useraccountList = new Collection();
         if ($workstation->getUseraccount()->isSuperUser()) {

--- a/zmsadmin/src/Zmsadmin/WorkstationSelect.php
+++ b/zmsadmin/src/Zmsadmin/WorkstationSelect.php
@@ -9,6 +9,7 @@ namespace BO\Zmsadmin;
 
 use BO\Zmsclient\ModuleAccess;
 use BO\Zmsadmin\Helper\LoginForm;
+use BO\Zmsadmin\Helper\RestrictedRoleRedirect;
 use BO\Mellon\Validator;
 
 class WorkstationSelect extends BaseController
@@ -29,6 +30,10 @@ class WorkstationSelect extends BaseController
         }
         if ($wrongModuleResponse = ModuleAccess::rejectWrongModuleAccess(ModuleAccess::MODULE_ADMIN, $workstation, $response)) {
             return $wrongModuleResponse;
+        }
+
+        if ($restrictedRoleRedirect = RestrictedRoleRedirect::create($workstation->getUseraccount())) {
+            return $restrictedRoleRedirect;
         }
 
         $input = $request->getParsedBody();

--- a/zmsadmin/templates/block/header/pageheader.twig
+++ b/zmsadmin/templates/block/header/pageheader.twig
@@ -33,6 +33,16 @@
             ) }}
             </form>
             #}
+            {% set permissions = workstation.useraccount.permissions|default({}) %}
+            {% set isUserAdmin = 'user_admin' in workstation.useraccount.roles|default([]) %}
+            {% set hasScopeBoundWorkPermissions = not isUserAdmin and (
+                permissions.counter|default(false)
+                or permissions.appointment|default(false)
+                or permissions.calldisplay|default(false)
+                or permissions.ticketprinter|default(false)
+                or permissions.overviewcalendar|default(false)
+            ) %}
+            {% if hasScopeBoundWorkPermissions and workstation.scope.id|default(false) %}
             <div class="page-header__scope" data-header-scope="{{ workstation.scope.contact|json_encode }}">
                 {% set scopeName = workstation.scope.contact.name %}
         		{% if workstation.scope.contact.name|length > 30 %}
@@ -59,6 +69,7 @@
                     </li>
                 </ul>
             </div>
+            {% endif %}
             {%- endblock %}
             </div>
             <div class="grid__item min-width page-header__right">

--- a/zmsadmin/templates/block/navigation/navigation.twig
+++ b/zmsadmin/templates/block/navigation/navigation.twig
@@ -1,15 +1,16 @@
 {% block navigation %}
     {% set permissions = workstation.useraccount.permissions|default({}) %}
     {% set hasScope = workstation.scope.id|default(false) %}
+    {% set isUserAdmin = 'user_admin' in workstation.useraccount.roles|default([]) %}
 
-    {% set hasWorkViews =
+    {% set hasWorkViews = not isUserAdmin and (
         (not hasScope)
         or (hasScope and permissions.counter|default(false))
         or (hasScope and permissions.appointment|default(false))
         or (hasScope and permissions.calldisplay|default(false))
         or (hasScope and permissions.ticketprinter|default(false))
         or permissions.overviewcalendar|default(false)
-    %}
+    ) %}
 
     {% set hasAdminViews =
         (workstation.id > 0 and permissions.superuser|default(false))

--- a/zmsadmin/templates/block/search/mask.twig
+++ b/zmsadmin/templates/block/search/mask.twig
@@ -3,7 +3,7 @@
 {% from 'element/helper/form.twig' import formgroup %}
 
 <section role="search" class="block panel--heavy" style="margin-bottom:0px;">
-    {% if workstation.scope.id %}
+    {% if workstation.scope.id and workstation.useraccount.permissions.customersearch|default(false) %}
         <h3 class="aural">Kundensuche</h3>
         <form method="GET" action="{{ urlGet('search', {}, {}) }}" class="form--base">
             {{ formgroup(

--- a/zmsadmin/tests/Zmsadmin/IndexTest.php
+++ b/zmsadmin/tests/Zmsadmin/IndexTest.php
@@ -322,4 +322,58 @@ class IndexTest extends Base
         $this->assertStringContainsString('/search/', $location);
         $this->assertStringContainsString('hideNavigation=1', $location);
     }
+
+    public function testAuditViewerRedirectsToSearchWhenAlreadyLoggedIn(): void
+    {
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'response' => $this->readFixture("GET_Workstation_audit_viewer.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/config/',
+                    'parameters' => [],
+                    'xtoken' => 'secure-token',
+                    'response' => $this->readFixture("GET_config.json"),
+                ]
+            ]
+        );
+
+        $response = $this->render($this->arguments, [], []);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $location = $response->getHeaderLine('Location');
+        $this->assertStringContainsString('/search/', $location);
+        $this->assertStringContainsString('hideNavigation=1', $location);
+    }
+
+    public function testUserAdminRedirectsToUseraccountListWhenAlreadyLoggedIn(): void
+    {
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'response' => $this->readFixture("GET_Workstation_user_admin.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/config/',
+                    'parameters' => [],
+                    'xtoken' => 'secure-token',
+                    'response' => $this->readFixture("GET_config.json"),
+                ]
+            ]
+        );
+
+        $response = $this->render($this->arguments, [], []);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $location = $response->getHeaderLine('Location');
+        $this->assertStringContainsString('/users/', $location);
+        $this->assertStringContainsString('hideNavigation=1', $location);
+    }
 }

--- a/zmsadmin/tests/Zmsadmin/IndexTest.php
+++ b/zmsadmin/tests/Zmsadmin/IndexTest.php
@@ -288,7 +288,7 @@ class IndexTest extends Base
         $this->assertEquals(302, $response->getStatusCode());
         $location = $response->getHeaderLine('Location');
         $this->assertStringContainsString('/users/', $location);
-        $this->assertStringContainsString('hideNavigation=1', $location);
+        $this->assertStringNotContainsString('hideNavigation=1', $location);
     }
 
     public function testAuditViewerRedirectsToSearchAfterLogin(): void
@@ -374,6 +374,6 @@ class IndexTest extends Base
         $this->assertEquals(302, $response->getStatusCode());
         $location = $response->getHeaderLine('Location');
         $this->assertStringContainsString('/users/', $location);
-        $this->assertStringContainsString('hideNavigation=1', $location);
+        $this->assertStringNotContainsString('hideNavigation=1', $location);
     }
 }

--- a/zmsadmin/tests/Zmsadmin/UseraccountEditTest.php
+++ b/zmsadmin/tests/Zmsadmin/UseraccountEditTest.php
@@ -336,5 +336,55 @@ class UseraccountEditTest extends Base
         $this->expectException(UserAccountAccessRightsFailed::class);
         $this->render($this->arguments, $this->parameters, []);
     }
+
+    public function testUserAdminShowsUserNavigationWithoutWorkViewsOnEdit(): void
+    {
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => ['resolveReferences' => 1],
+                    'response' => $this->readFixture('GET_Workstation_user_admin.json'),
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/useraccount/testuser/',
+                    'response' => $this->readFixture('GET_useraccount_testuser.json'),
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/owner/',
+                    'parameters' => ['resolveReferences' => 2],
+                    'response' => $this->readFixture('GET_owner.json'),
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/config/',
+                    'parameters' => [],
+                    'xtoken' => 'secure-token',
+                    'response' => $this->readFixture('GET_config.json'),
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/roles/',
+                    'parameters' => [],
+                    'response' => $this->readFixture('GET_rolelist.json'),
+                ],
+            ]
+        );
+
+        $response = $this->render($this->arguments, [], []);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('navigation-primary', $body);
+        $this->assertStringContainsString('Nutzer*innen', $body);
+        $this->assertStringNotContainsString('Standort auswählen', $body);
+        $this->assertStringNotContainsString('Arbeitsansichten', $body);
+        $this->assertStringNotContainsString('Kundensuche', $body);
+        $this->assertStringNotContainsString('page-header__scope', $body);
+        $this->assertStringNotContainsString('Auswahl ändern', $body);
+    }
 }
 


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based redirect handling for restricted accounts, sending admin users and audit viewers to the appropriate screens automatically.
  * Kept navigation hidden for audit viewer searches across search, pagination, and repeated submissions.

* **Bug Fixes**
  * Improved access flow so users land on the correct page after login, workstation selection, and sign-in callbacks.
  * Updated the header and navigation to show only the UI sections relevant to the current role and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->