### PR TITLE
clean(ZMS): replace log amendment still in data as JSON with an indexed column and remove remaining data uses references then drop data from the log table

### DIFF
--- a/docs/de/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
+++ b/docs/de/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
@@ -919,7 +919,7 @@ array (
 | `citizen_phone`     | `citizen_phone`          | Aus `data.Telefon`                                      |
 | `process_status`    | `process_status`         | Aus `data.Status`                                       |
 | `db_status`         | `db_status`              | Aus `data.DB Status`                                    |
-| `citizen_amendment` | `citizen_amendment`      | Aus `data.Anmerkung` (`91783691659`)                    |
+| `process_amendment` | `process_amendment`      | Aus `data.Anmerkung` (`91783691659`)                    |
 | `data`              | — (entfernen)            | Legacy-JSON; Backfill `91780720006`, Drop `91783691660` |
 
 #### migrations
@@ -1336,7 +1336,7 @@ Die Tabelle ist extrem breit: stündliche Spalten für geschätzte Wartezeit, ec
 
 #### Normalisierung von `log.data` (JSON)
 
-Häufig gefilterte Felder aus dem JSON-Blob `data` sind in typisierte Spalten ausgelagert (`action`, `display_number`, `queue_number`, `appointment_at`, `slot_count`, `citizen_name`, `services`, `scope_name`, `citizen_email`, `citizen_phone`, `process_status`, `db_status`, `citizen_amendment`). Backfill der Suchspalten: `91780720006`; `citizen_amendment`: `91783691659`.
+Häufig gefilterte Felder aus dem JSON-Blob `data` sind in typisierte Spalten ausgelagert (`action`, `display_number`, `queue_number`, `appointment_at`, `slot_count`, `citizen_name`, `services`, `scope_name`, `citizen_email`, `citizen_phone`, `process_status`, `db_status`, `process_amendment`). Backfill der Suchspalten: `91780720006`; `process_amendment`: `91783691659`.
 
 **Expand/Contract:** `91783691659` (Spalte + Backfill aus `data.Anmerkung`), Code-Deploy ohne Lese-/Schreibzugriff auf `data`, danach `91783691660` (`DROP COLUMN data`).
 

--- a/docs/de/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
+++ b/docs/de/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
@@ -251,19 +251,19 @@ Damit gilt:
 
 ### Phase 6: Daten- & Prozess-Tabellen
 
-| Current             | New (snake_case)            | Reason                                                                 |
-| ------------------- | --------------------------- | ---------------------------------------------------------------------- |
-| `closures`          | `closures`                  | Already snake_case                                                     |
-| `config`            | `config`                    | Already snake_case                                                     |
-| `eventlog`          | `event_log`                 | Event-Log; Nutzungsumfang prüfen (Abschnitt 4)                         |
-| `imagedata`         | `image_data`                | Bilddaten; Assets nach S3 (Abschnitt 4)                                |
-| `log`               | `log`                       | `data`-JSON für Suche aufteilen (Abschnitt 4)                          |
-| `migrations`        | `migrations`                | Already snake_case                                                     |
-| `preferences`       | `scope_preferences` / split | Scope- und Systemeinstellungen; umbenennen und aufteilen (Abschnitt 4) |
-| `process_sequence`  | `process_sequence`          | Already snake_case                                                     |
-| `sessiondata`       | `session_data`              | Session data                                                           |
-| `source`            | `source`                    | Already snake_case                                                     |
-| `overview_calendar` | `overview_calendar`         | Overview calendar (already snake_case)                                 |
+| Current             | New (snake_case)            | Reason                                                                                                   |
+| ------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `closures`          | `closures`                  | Already snake_case                                                                                       |
+| `config`            | `config`                    | Already snake_case                                                                                       |
+| `eventlog`          | `event_log`                 | Event-Log; Nutzungsumfang prüfen (Abschnitt 4)                                                           |
+| `imagedata`         | `image_data`                | Bilddaten; Assets nach S3 (Abschnitt 4)                                                                  |
+| `log`               | `log`                       | `data`-JSON in typisierte Suchspalten ausgelagert; `data` per Contract-Migration entfernen (Abschnitt 4) |
+| `migrations`        | `migrations`                | Already snake_case                                                                                       |
+| `preferences`       | `scope_preferences` / split | Scope- und Systemeinstellungen; umbenennen und aufteilen (Abschnitt 4)                                   |
+| `process_sequence`  | `process_sequence`          | Already snake_case                                                                                       |
+| `sessiondata`       | `session_data`              | Session data                                                                                             |
+| `source`            | `source`                    | Already snake_case                                                                                       |
+| `overview_calendar` | `overview_calendar`         | Overview calendar (already snake_case)                                                                   |
 
 ### Phase 7: Leistungs- & Anbieter-Tabellen
 
@@ -898,16 +898,29 @@ array (
 
 #### log
 
-| Aktuelle Spalte | Neue Spalte (snake_case) | Grund              |
-| --------------- | ------------------------ | ------------------ |
-| `log_id`        | `log_id`                 | Bereits snake_case |
-| `type`          | `type`                   | Bereits snake_case |
-| `reference_id`  | `reference_id`           | Bereits snake_case |
-| `ts`            | `ts`                     | Bereits snake_case |
-| `message`       | `message`                | Bereits snake_case |
-| `scope_id`      | `scope_id`               | Bereits snake_case |
-| `data`          | `data`                   | Bereits snake_case |
-| `user_id`       | `user_id`                | Bereits snake_case |
+| Aktuelle Spalte     | Neue Spalte (snake_case) | Grund                                                   |
+| ------------------- | ------------------------ | ------------------------------------------------------- |
+| `log_id`            | `log_id`                 | Bereits snake_case                                      |
+| `type`              | `type`                   | Bereits snake_case                                      |
+| `reference_id`      | `reference_id`           | Bereits snake_case                                      |
+| `ts`                | `ts`                     | Bereits snake_case                                      |
+| `message`           | `message`                | Bereits snake_case                                      |
+| `scope_id`          | `scope_id`               | Bereits snake_case                                      |
+| `user_id`           | `user_id`                | Bereits snake_case                                      |
+| `action`            | `action`                 | Aus `data.Aktion`; Suchspalte (`91780720002`)           |
+| `display_number`    | `display_number`         | Aus `data.Terminnummer`                                 |
+| `queue_number`      | `queue_number`           | Aus `data.Wartenummer`                                  |
+| `appointment_at`    | `appointment_at`         | Aus `data.Terminzeit`                                   |
+| `slot_count`        | `slot_count`             | Aus `data.Slots`                                        |
+| `citizen_name`      | `citizen_name`           | Aus `data.Bürger*in`                                    |
+| `services`          | `services`               | Aus `data.Dienstleistungen`                             |
+| `scope_name`        | `scope_name`             | Aus `data.Standort`                                     |
+| `citizen_email`     | `citizen_email`          | Aus `data.E-Mail`                                       |
+| `citizen_phone`     | `citizen_phone`          | Aus `data.Telefon`                                      |
+| `process_status`    | `process_status`         | Aus `data.Status`                                       |
+| `db_status`         | `db_status`              | Aus `data.DB Status`                                    |
+| `citizen_amendment` | `citizen_amendment`      | Aus `data.Anmerkung` (`91783691659`)                    |
+| `data`              | — (entfernen)            | Legacy-JSON; Backfill `91780720006`, Drop `91783691660` |
 
 #### migrations
 
@@ -1323,9 +1336,9 @@ Die Tabelle ist extrem breit: stündliche Spalten für geschätzte Wartezeit, ec
 
 #### Normalisierung von `log.data` (JSON)
 
-Neben indexierten Spalten (`type`, `scope_id`, `user_id`, `reference_id`) liegt ein JSON-Blob `data`. Suche darin ist langsam.
+Häufig gefilterte Felder aus dem JSON-Blob `data` sind in typisierte Spalten ausgelagert (`action`, `display_number`, `queue_number`, `appointment_at`, `slot_count`, `citizen_name`, `services`, `scope_name`, `citizen_email`, `citizen_phone`, `process_status`, `db_status`, `citizen_amendment`). Backfill der Suchspalten: `91780720006`; `citizen_amendment`: `91783691659`.
 
-**Richtung:** häufig gefilterte Felder als typisierte Spalten; `data` nur noch für Debug oder entfernen.
+**Expand/Contract:** `91783691659` (Spalte + Backfill aus `data.Anmerkung`), Code-Deploy ohne Lese-/Schreibzugriff auf `data`, danach `91783691660` (`DROP COLUMN data`).
 
 #### Aufteilen und umbenennen von `preferences`
 

--- a/docs/en/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
+++ b/docs/en/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
@@ -919,7 +919,7 @@ array (
 | `citizen_phone`     | `citizen_phone`         | From `data.Telefon`                                     |
 | `process_status`    | `process_status`        | From `data.Status`                                      |
 | `db_status`         | `db_status`             | From `data.DB Status`                                   |
-| `citizen_amendment` | `citizen_amendment`     | From `data.Anmerkung` (`91783691659`)                   |
+| `process_amendment` | `process_amendment`     | From `data.Anmerkung` (`91783691659`)                   |
 | `data`              | — (drop)                | Legacy JSON; backfill `91780720006`, drop `91783691660` |
 
 #### migrations
@@ -1341,7 +1341,7 @@ Benefits: simpler migrations, easier aggregation, room for new metrics without `
 
 #### Normalize `log.data` (JSON)
 
-Frequently filtered fields from the JSON blob `data` are promoted to typed columns (`action`, `display_number`, `queue_number`, `appointment_at`, `slot_count`, `citizen_name`, `services`, `scope_name`, `citizen_email`, `citizen_phone`, `process_status`, `db_status`, `citizen_amendment`). Search-column backfill: `91780720006`; `citizen_amendment`: `91783691659`.
+Frequently filtered fields from the JSON blob `data` are promoted to typed columns (`action`, `display_number`, `queue_number`, `appointment_at`, `slot_count`, `citizen_name`, `services`, `scope_name`, `citizen_email`, `citizen_phone`, `process_status`, `db_status`, `process_amendment`). Search-column backfill: `91780720006`; `process_amendment`: `91783691659`.
 
 **Expand/contract:** `91783691659` (column + backfill from `data.Anmerkung`), deploy code that no longer reads/writes `data`, then `91783691660` (`DROP COLUMN data`).
 

--- a/docs/en/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
+++ b/docs/en/on-the-future/database-refactor/standardize-database-table-and-field-naming.md
@@ -251,19 +251,19 @@ This approach ensures:
 
 ### Phase 6: Data & Process Tables
 
-| Current             | New (snake_case)            | Reason                                                    |
-| ------------------- | --------------------------- | --------------------------------------------------------- |
-| `closures`          | `closures`                  | Already snake_case                                        |
-| `config`            | `config`                    | Already snake_case                                        |
-| `eventlog`          | `event_log`                 | Event log; verify scope of use (see section 4)            |
-| `imagedata`         | `image_data`                | Image data; move assets to S3 (see section 4)             |
-| `log`               | `log`                       | Split `data` JSON for searchability (see section 4)       |
-| `migrations`        | `migrations`                | Already snake_case                                        |
-| `preferences`       | `scope_preferences` / split | Scope + system settings; rename and split (see section 4) |
-| `process_sequence`  | `process_sequence`          | Already snake_case                                        |
-| `sessiondata`       | `session_data`              | Session data                                              |
-| `source`            | `source`                    | Already snake_case                                        |
-| `overview_calendar` | `overview_calendar`         | Overview calendar (already snake_case)                    |
+| Current             | New (snake_case)            | Reason                                                                                           |
+| ------------------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `closures`          | `closures`                  | Already snake_case                                                                               |
+| `config`            | `config`                    | Already snake_case                                                                               |
+| `eventlog`          | `event_log`                 | Event log; verify scope of use (see section 4)                                                   |
+| `imagedata`         | `image_data`                | Image data; move assets to S3 (see section 4)                                                    |
+| `log`               | `log`                       | `data` JSON promoted to typed search columns; drop `data` via contract migration (see section 4) |
+| `migrations`        | `migrations`                | Already snake_case                                                                               |
+| `preferences`       | `scope_preferences` / split | Scope + system settings; rename and split (see section 4)                                        |
+| `process_sequence`  | `process_sequence`          | Already snake_case                                                                               |
+| `sessiondata`       | `session_data`              | Session data                                                                                     |
+| `source`            | `source`                    | Already snake_case                                                                               |
+| `overview_calendar` | `overview_calendar`         | Overview calendar (already snake_case)                                                           |
 
 ### Phase 7: Service & Provider Tables
 
@@ -898,16 +898,29 @@ array (
 
 #### log
 
-| Current Column | New Column (snake_case) | Reason             |
-| -------------- | ----------------------- | ------------------ |
-| `log_id`       | `log_id`                | Already snake_case |
-| `type`         | `type`                  | Already snake_case |
-| `reference_id` | `reference_id`          | Already snake_case |
-| `ts`           | `ts`                    | Already snake_case |
-| `message`      | `message`               | Already snake_case |
-| `scope_id`     | `scope_id`              | Already snake_case |
-| `data`         | `data`                  | Already snake_case |
-| `user_id`      | `user_id`               | Already snake_case |
+| Current Column      | New Column (snake_case) | Reason                                                  |
+| ------------------- | ----------------------- | ------------------------------------------------------- |
+| `log_id`            | `log_id`                | Already snake_case                                      |
+| `type`              | `type`                  | Already snake_case                                      |
+| `reference_id`      | `reference_id`          | Already snake_case                                      |
+| `ts`                | `ts`                    | Already snake_case                                      |
+| `message`           | `message`               | Already snake_case                                      |
+| `scope_id`          | `scope_id`              | Already snake_case                                      |
+| `user_id`           | `user_id`               | Already snake_case                                      |
+| `action`            | `action`                | From `data.Aktion`; search column (`91780720002`)       |
+| `display_number`    | `display_number`        | From `data.Terminnummer`                                |
+| `queue_number`      | `queue_number`          | From `data.Wartenummer`                                 |
+| `appointment_at`    | `appointment_at`        | From `data.Terminzeit`                                  |
+| `slot_count`        | `slot_count`            | From `data.Slots`                                       |
+| `citizen_name`      | `citizen_name`          | From `data.Bürger*in`                                   |
+| `services`          | `services`              | From `data.Dienstleistungen`                            |
+| `scope_name`        | `scope_name`            | From `data.Standort`                                    |
+| `citizen_email`     | `citizen_email`         | From `data.E-Mail`                                      |
+| `citizen_phone`     | `citizen_phone`         | From `data.Telefon`                                     |
+| `process_status`    | `process_status`        | From `data.Status`                                      |
+| `db_status`         | `db_status`             | From `data.DB Status`                                   |
+| `citizen_amendment` | `citizen_amendment`     | From `data.Anmerkung` (`91783691659`)                   |
+| `data`              | — (drop)                | Legacy JSON; backfill `91780720006`, drop `91783691660` |
 
 #### migrations
 
@@ -1328,9 +1341,9 @@ Benefits: simpler migrations, easier aggregation, room for new metrics without `
 
 #### Normalize `log.data` (JSON)
 
-The `log` table stores a JSON `data` blob alongside indexed columns (`type`, `scope_id`, `user_id`, `reference_id`). Searching inside JSON is slow and awkward.
+Frequently filtered fields from the JSON blob `data` are promoted to typed columns (`action`, `display_number`, `queue_number`, `appointment_at`, `slot_count`, `citizen_name`, `services`, `scope_name`, `citizen_email`, `citizen_phone`, `process_status`, `db_status`, `citizen_amendment`). Search-column backfill: `91780720006`; `citizen_amendment`: `91783691659`.
 
-**Direction:** promote frequently filtered fields to typed columns; keep `data` only for optional debug payload or drop it once structured columns cover admin search needs.
+**Expand/contract:** `91783691659` (column + backfill from `data.Anmerkung`), deploy code that no longer reads/writes `data`, then `91783691660` (`DROP COLUMN data`).
 
 #### Split and rename `preferences`
 

--- a/zmsadmin/src/Zmsadmin/Search.php
+++ b/zmsadmin/src/Zmsadmin/Search.php
@@ -8,8 +8,8 @@
 namespace BO\Zmsadmin;
 
 use BO\Slim\Render;
-use BO\Zmsdb\Log as LogQuery;
 use BO\Zmsentities\Collection\LogList;
+use BO\Zmsentities\Log as LogEntity;
 use BO\Zmsentities\Collection\ProcessList;
 
 class Search extends BaseController
@@ -250,7 +250,7 @@ class Search extends BaseController
         $list = new LogList();
 
         foreach ($logList as $log) {
-            $log->display = LogQuery::formatDisplayFields($log->getArrayCopy());
+            $log->display = LogEntity::formatDisplayFields($log->getArrayCopy());
 
             if (
                 $bypassScopeFilter

--- a/zmsadmin/src/Zmsadmin/Search.php
+++ b/zmsadmin/src/Zmsadmin/Search.php
@@ -8,6 +8,7 @@
 namespace BO\Zmsadmin;
 
 use BO\Slim\Render;
+use BO\Zmsdb\Log as LogQuery;
 use BO\Zmsentities\Collection\LogList;
 use BO\Zmsentities\Collection\ProcessList;
 
@@ -249,8 +250,7 @@ class Search extends BaseController
         $list = new LogList();
 
         foreach ($logList as $log) {
-            $data = isset($log->data) ? json_decode($log->data, true) : null;
-            $log->data = $data;
+            $log->display = LogQuery::formatDisplayFields($log->getArrayCopy());
 
             if (
                 $bypassScopeFilter

--- a/zmsadmin/templates/block/search/searchresults.twig
+++ b/zmsadmin/templates/block/search/searchresults.twig
@@ -111,7 +111,7 @@
                         <th colspan="7">Log-Ergebnisse:</th>
                     </tr>
                     {% for log in logList %}
-                        {% set data = log.data %}
+                        {% set data = log.display %}
                         <tr>
                             <td>{{ log.reference }}</td>
                             <td>{{log.ts|date('d.m.Y, H:i:s')}}&nbsp;Uhr</td>

--- a/zmsdb/migrations/91783691659-expand-log-citizen-amendment-column.sql
+++ b/zmsdb/migrations/91783691659-expand-log-citizen-amendment-column.sql
@@ -2,7 +2,7 @@
 -- Deploy before code that stops writing `data` and before the contract migration.
 
 ALTER TABLE `log`
-    ADD COLUMN IF NOT EXISTS `citizen_amendment` VARCHAR(512) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS `citizen_amendment` TEXT DEFAULT NULL;
 
 UPDATE `log`
 SET `citizen_amendment` = NULLIF(TRIM(JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.Anmerkung'))), '')

--- a/zmsdb/migrations/91783691659-expand-log-citizen-amendment-column.sql
+++ b/zmsdb/migrations/91783691659-expand-log-citizen-amendment-column.sql
@@ -1,0 +1,14 @@
+-- Expand phase: add citizen_amendment column and backfill from legacy JSON `data`.
+-- Deploy before code that stops writing `data` and before the contract migration.
+
+ALTER TABLE `log`
+    ADD COLUMN IF NOT EXISTS `citizen_amendment` VARCHAR(512) DEFAULT NULL;
+
+UPDATE `log`
+SET `citizen_amendment` = NULLIF(TRIM(JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.Anmerkung'))), '')
+WHERE `type` = 'buerger'
+  AND `data` IS NOT NULL
+  AND `data` != ''
+  AND `citizen_amendment` IS NULL
+  AND JSON_EXTRACT(`data`, '$.Anmerkung') IS NOT NULL
+  AND JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.Anmerkung')) != '';

--- a/zmsdb/migrations/91783691659-expand-log-process-amendment-column.sql
+++ b/zmsdb/migrations/91783691659-expand-log-process-amendment-column.sql
@@ -1,14 +1,14 @@
--- Expand phase: add citizen_amendment column and backfill from legacy JSON `data`.
+-- Expand phase: add process_amendment column and backfill from legacy JSON `data`.
 -- Deploy before code that stops writing `data` and before the contract migration.
 
 ALTER TABLE `log`
-    ADD COLUMN IF NOT EXISTS `citizen_amendment` TEXT DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS `process_amendment` TEXT DEFAULT NULL;
 
 UPDATE `log`
-SET `citizen_amendment` = NULLIF(TRIM(JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.Anmerkung'))), '')
+SET `process_amendment` = NULLIF(TRIM(JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.Anmerkung'))), '')
 WHERE `type` = 'buerger'
   AND `data` IS NOT NULL
   AND `data` != ''
-  AND `citizen_amendment` IS NULL
+  AND `process_amendment` IS NULL
   AND JSON_EXTRACT(`data`, '$.Anmerkung') IS NOT NULL
   AND JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.Anmerkung')) != '';

--- a/zmsdb/migrations/91783691660-contract-drop-log-data-column.sql
+++ b/zmsdb/migrations/91783691660-contract-drop-log-data-column.sql
@@ -1,4 +1,4 @@
--- Contract phase: drop legacy JSON blob after indexed columns and citizen_amendment are in use.
+-- Contract phase: drop legacy JSON blob after indexed columns and process_amendment are in use.
 -- Run only after expand migration 91783691659 and deploy of code that no longer reads/writes `data`.
 
 ALTER TABLE `log`

--- a/zmsdb/migrations/91783691660-contract-drop-log-data-column.sql
+++ b/zmsdb/migrations/91783691660-contract-drop-log-data-column.sql
@@ -1,0 +1,5 @@
+-- Contract phase: drop legacy JSON blob after indexed columns and citizen_amendment are in use.
+-- Run only after expand migration 91783691659 and deploy of code that no longer reads/writes `data`.
+
+ALTER TABLE `log`
+    DROP COLUMN IF EXISTS `data`;

--- a/zmsdb/src/Zmsdb/Log.php
+++ b/zmsdb/src/Zmsdb/Log.php
@@ -52,7 +52,7 @@ class Log extends Base
         'citizen_phone',
         'process_status',
         'db_status',
-        'citizen_amendment',
+        'process_amendment',
     ];
 
     private const ACTION_LABEL_TO_CODE = [
@@ -161,7 +161,7 @@ class Log extends Base
             'citizen_phone' => $process->getFirstClient()->telephone,
             'process_status' => $process->getStatus(),
             'db_status' => $process->dbstatus,
-            'citizen_amendment' => $process->getAmendment(),
+            'process_amendment' => $process->getAmendment(),
         ], static function ($value) {
             return $value !== null && $value !== '';
         });

--- a/zmsdb/src/Zmsdb/Log.php
+++ b/zmsdb/src/Zmsdb/Log.php
@@ -324,12 +324,14 @@ class Log extends Base
 
     private function buildUserActionConditions(int $userAction): array
     {
+        $systemUserPattern = $this->escapeLikeValue('_system_') . '%';
+
         if ($userAction === 1) {
-            return ['(user_id IS NOT NULL AND user_id != \'\' AND user_id NOT LIKE \'_system_%\')'];
+            return ['(user_id IS NOT NULL AND user_id != \'\' AND user_id NOT LIKE \'' . $systemUserPattern . '\')'];
         }
 
         if ($userAction === 2) {
-            return ['(user_id LIKE \'_system_%\')'];
+            return ['(user_id LIKE \'' . $systemUserPattern . '\')'];
         }
 
         return [];

--- a/zmsdb/src/Zmsdb/Log.php
+++ b/zmsdb/src/Zmsdb/Log.php
@@ -127,7 +127,7 @@ class Log extends Base
             $requests = (new Request())->readRequestsByIds($process->getRequestIds());
         }
 
-        $payload = self::buildProcessLogPayload($process, $action, $userAccount, $requests);
+        $payload = self::buildProcessLogPayload($process, $action, $requests);
 
         Log::writeLogEntry(
             $method,
@@ -142,7 +142,6 @@ class Log extends Base
     public static function buildProcessLogPayload(
         \BO\Zmsentities\Process $process,
         string $action,
-        \BO\Zmsentities\Useraccount $userAccount,
         RequestList $requests
     ): array {
         $appointmentAt = $process->getFirstAppointment()->toDateTime();
@@ -242,7 +241,7 @@ class Log extends Base
             $this->buildGeneralSearchConditionList($generalSearch, $params),
             $this->buildScopeIdConditions($scopeIds, $params),
             $this->buildDateConditions($date, $params),
-            $this->buildUserActionConditions($userAction, $params)
+            $this->buildUserActionConditions($userAction)
         );
 
         $sql = 'SELECT * FROM log';
@@ -323,7 +322,7 @@ class Log extends Base
         return ['(ts >= :start AND ts < :end)'];
     }
 
-    private function buildUserActionConditions(int $userAction, array &$params): array
+    private function buildUserActionConditions(int $userAction): array
     {
         if ($userAction === 1) {
             return ['(user_id IS NOT NULL AND user_id != \'\' AND user_id NOT LIKE \'_system_%\')'];

--- a/zmsdb/src/Zmsdb/Log.php
+++ b/zmsdb/src/Zmsdb/Log.php
@@ -52,6 +52,7 @@ class Log extends Base
         'citizen_phone',
         'process_status',
         'db_status',
+        'citizen_amendment',
     ];
 
     private const ACTION_LABEL_TO_CODE = [
@@ -69,6 +70,21 @@ class Log extends Base
         self::ACTION_CANCELED => 'canceled',
     ];
 
+    private const ACTION_CODE_TO_LABEL = [
+        'mail_success' => self::ACTION_MAIL_SUCCESS,
+        'mail_fail' => self::ACTION_MAIL_FAIL,
+        'status_changed' => self::ACTION_STATUS_CHANGE,
+        'reminder_sent' => self::ACTION_SEND_REMINDER,
+        'removed_from_queue' => self::ACTION_REMOVED,
+        'called' => self::ACTION_CALLED,
+        'archived' => self::ACTION_ARCHIVED,
+        'edited' => self::ACTION_EDITED,
+        'redirected' => self::ACTION_REDIRECTED,
+        'created' => self::ACTION_NEW,
+        'deleted' => self::ACTION_DELETED,
+        'canceled' => self::ACTION_CANCELED,
+    ];
+
     public static $operator = 'lib';
 
     public static function writeLogEntry(
@@ -77,7 +93,6 @@ class Log extends Base
         $type = self::PROCESS,
         ?int $scopeId = null,
         ?string $userId = null,
-        ?string $data = null,
         ?array $indexedFields = null
     ) {
         $message .= " [" . static::$operator . "]";
@@ -88,7 +103,6 @@ class Log extends Base
             '`type`=:type',
             '`scope_id`=:scopeId',
             '`user_id`=:userId',
-            '`data`=:dataString',
         ];
         $parameters = [
             'message' => $message . static::backtraceLogEntry(),
@@ -96,7 +110,6 @@ class Log extends Base
             'type' => $type,
             'scopeId' => $scopeId,
             'userId' => $userId,
-            'dataString' => $data,
         ];
 
         if ($indexedFields !== null) {
@@ -130,7 +143,6 @@ class Log extends Base
         }
 
         $payload = self::buildProcessLogPayload($process, $action, $userAccount, $requests);
-        $data = json_encode($payload['display'], JSON_UNESCAPED_UNICODE);
 
         Log::writeLogEntry(
             $method,
@@ -138,7 +150,6 @@ class Log extends Base
             self::PROCESS,
             $process->getScopeId(),
             $userAccount->getId(),
-            $data,
             $payload['indexed']
         );
     }
@@ -150,26 +161,6 @@ class Log extends Base
         RequestList $requests
     ): array {
         $appointmentAt = $process->getFirstAppointment()->toDateTime();
-        $display = array_filter([
-            'Aktion' => $action,
-            'Sachbearbeiter*in' => $userAccount->getId(),
-            'Terminnummer' => $process->getDisplayNumber(),
-            'Wartenummer' => $process->getQueueNumber(),
-            'Terminzeit' => $appointmentAt->format('d.m.Y H:i:s'),
-            'Slots' => $process->getFirstAppointment()->slotCount ?? null,
-            'Bürger*in' => $process->getFirstClient()->familyName,
-            'Dienstleistungen' => implode(', ', array_map(function ($request) {
-                return $request->getName();
-            }, $requests->getAsArray())),
-            'Anmerkung' => $process->getAmendment(),
-            'Standort' => $process->scope->getName(),
-            'E-Mail' => $process->getFirstClient()->email,
-            'Telefon' => $process->getFirstClient()->telephone,
-            'Status' => $process->getStatus(),
-            'DB Status' => $process->dbstatus,
-        ], static function ($value) {
-            return $value !== null && $value !== '';
-        });
 
         $indexed = array_filter([
             'action' => self::actionCodeFromLabel($action),
@@ -186,12 +177,12 @@ class Log extends Base
             'citizen_phone' => $process->getFirstClient()->telephone,
             'process_status' => $process->getStatus(),
             'db_status' => $process->dbstatus,
+            'citizen_amendment' => $process->getAmendment(),
         ], static function ($value) {
             return $value !== null && $value !== '';
         });
 
         return [
-            'display' => $display,
             'indexed' => $indexed,
         ];
     }
@@ -201,46 +192,69 @@ class Log extends Base
         return self::ACTION_LABEL_TO_CODE[$label] ?? null;
     }
 
-    public static function parseLegacyLogData(?string $dataJson): ?array
+    public static function actionLabelFromCode(?string $code): ?string
     {
-        if ($dataJson === null || $dataJson === '') {
+        if ($code === null || $code === '') {
             return null;
         }
 
-        $display = json_decode($dataJson, true);
-        if (!is_array($display)) {
-            return null;
-        }
+        return self::ACTION_CODE_TO_LABEL[$code] ?? null;
+    }
 
-        $actionLabel = $display['Aktion'] ?? null;
-        $appointmentAt = null;
-        if (!empty($display['Terminzeit'])) {
-            $parsed = \DateTimeImmutable::createFromFormat('d.m.Y H:i:s', (string) $display['Terminzeit']);
-            if ($parsed instanceof \DateTimeImmutable) {
-                $appointmentAt = $parsed->format('Y-m-d H:i:s');
+    public static function formatDisplayFields(array $log): array
+    {
+        $display = [];
+        $actionLabel = self::actionLabelFromCode($log['action'] ?? null);
+        if ($actionLabel !== null) {
+            $display['Aktion'] = $actionLabel;
+        }
+        if (!empty($log['user_id'])) {
+            $display['Sachbearbeiter*in'] = $log['user_id'];
+        }
+        if (!empty($log['display_number'])) {
+            $display['Terminnummer'] = $log['display_number'];
+        }
+        if (isset($log['queue_number']) && $log['queue_number'] !== '') {
+            $display['Wartenummer'] = $log['queue_number'];
+        }
+        if (!empty($log['appointment_at'])) {
+            $appointmentAt = \DateTimeImmutable::createFromFormat(
+                'Y-m-d H:i:s',
+                (string) $log['appointment_at']
+            );
+            if ($appointmentAt instanceof \DateTimeImmutable) {
+                $display['Terminzeit'] = $appointmentAt->format('d.m.Y H:i:s');
             }
         }
+        if (isset($log['slot_count']) && $log['slot_count'] !== '') {
+            $display['Slots'] = $log['slot_count'];
+        }
+        if (!empty($log['citizen_name'])) {
+            $display['Bürger*in'] = $log['citizen_name'];
+        }
+        if (!empty($log['services'])) {
+            $display['Dienstleistungen'] = $log['services'];
+        }
+        if (!empty($log['citizen_amendment'])) {
+            $display['Anmerkung'] = $log['citizen_amendment'];
+        }
+        if (!empty($log['scope_name'])) {
+            $display['Standort'] = $log['scope_name'];
+        }
+        if (!empty($log['citizen_email'])) {
+            $display['E-Mail'] = $log['citizen_email'];
+        }
+        if (!empty($log['citizen_phone'])) {
+            $display['Telefon'] = $log['citizen_phone'];
+        }
+        if (!empty($log['process_status'])) {
+            $display['Status'] = $log['process_status'];
+        }
+        if (!empty($log['db_status'])) {
+            $display['DB Status'] = $log['db_status'];
+        }
 
-        return array_filter([
-            'action' => is_string($actionLabel) ? self::actionCodeFromLabel($actionLabel) : null,
-            'display_number' => $display['Terminnummer'] ?? null,
-            'queue_number' => isset($display['Wartenummer']) && $display['Wartenummer'] !== ''
-                ? (int) $display['Wartenummer']
-                : null,
-            'appointment_at' => $appointmentAt,
-            'slot_count' => isset($display['Slots']) && $display['Slots'] !== ''
-                ? (int) $display['Slots']
-                : null,
-            'citizen_name' => $display['Bürger*in'] ?? null,
-            'services' => $display['Dienstleistungen'] ?? null,
-            'scope_name' => $display['Standort'] ?? null,
-            'citizen_email' => $display['E-Mail'] ?? null,
-            'citizen_phone' => $display['Telefon'] ?? null,
-            'process_status' => $display['Status'] ?? null,
-            'db_status' => $display['DB Status'] ?? null,
-        ], static function ($value) {
-            return $value !== null && $value !== '';
-        });
+        return $display;
     }
 
     public function readByProcessId($processId)
@@ -326,18 +340,14 @@ class Log extends Base
 
             $likeValue = '%' . $this->escapeLikeValue((string) $value) . '%';
             if ($field === 'scope_name') {
-                $conditions[] = '(scope_name LIKE :scopeName OR (scope_name IS NULL AND data LIKE :scopeNameLegacy))';
+                $conditions[] = 'scope_name LIKE :scopeName';
                 $params['scopeName'] = $likeValue;
-                $params['scopeNameLegacy'] = '%' . $this->escapeLikeValue('Standort') . '%'
-                    . $this->escapeLikeValue((string) $value) . '%';
                 continue;
             }
 
             if ($field === 'services') {
-                $conditions[] = '(services LIKE :services OR (services IS NULL AND data LIKE :servicesLegacy))';
+                $conditions[] = 'services LIKE :services';
                 $params['services'] = $likeValue;
-                $params['servicesLegacy'] = '%' . $this->escapeLikeValue('Dienstleistungen') . '%'
-                    . $this->escapeLikeValue((string) $value) . '%';
             }
         }
 
@@ -386,35 +396,11 @@ class Log extends Base
     private function buildUserActionConditions(int $userAction, array &$params): array
     {
         if ($userAction === 1) {
-            $params['ua_yes'] = '%Sachbearbeiter*in%';
-            $params['ua_system'] = '%Sachbearbeiter*in\":\"_system_%';
-
-            return ['(
-                (user_id IS NOT NULL AND user_id != \'\' AND user_id NOT LIKE \'_system_%\')
-                OR (
-                    user_id IS NULL
-                    AND data IS NOT NULL
-                    AND data LIKE :ua_yes
-                    AND data NOT LIKE :ua_system
-                )
-            )'];
+            return ['(user_id IS NOT NULL AND user_id != \'\' AND user_id NOT LIKE \'_system_%\')'];
         }
 
         if ($userAction === 2) {
-            $params['ua_yes'] = '%Sachbearbeiter*in%';
-            $params['ua_system'] = '%Sachbearbeiter*in\":\"_system_%';
-
-            return ['(
-                user_id LIKE \'_system_%\'
-                OR (
-                    (user_id IS NULL OR user_id = \'\')
-                    AND (
-                        data IS NULL
-                        OR data LIKE :ua_system
-                        OR data NOT LIKE :ua_yes
-                    )
-                )
-            )'];
+            return ['(user_id LIKE \'_system_%\')'];
         }
 
         return [];

--- a/zmsdb/src/Zmsdb/Log.php
+++ b/zmsdb/src/Zmsdb/Log.php
@@ -70,21 +70,6 @@ class Log extends Base
         self::ACTION_CANCELED => 'canceled',
     ];
 
-    private const ACTION_CODE_TO_LABEL = [
-        'mail_success' => self::ACTION_MAIL_SUCCESS,
-        'mail_fail' => self::ACTION_MAIL_FAIL,
-        'status_changed' => self::ACTION_STATUS_CHANGE,
-        'reminder_sent' => self::ACTION_SEND_REMINDER,
-        'removed_from_queue' => self::ACTION_REMOVED,
-        'called' => self::ACTION_CALLED,
-        'archived' => self::ACTION_ARCHIVED,
-        'edited' => self::ACTION_EDITED,
-        'redirected' => self::ACTION_REDIRECTED,
-        'created' => self::ACTION_NEW,
-        'deleted' => self::ACTION_DELETED,
-        'canceled' => self::ACTION_CANCELED,
-    ];
-
     public static $operator = 'lib';
 
     public static function writeLogEntry(
@@ -194,67 +179,12 @@ class Log extends Base
 
     public static function actionLabelFromCode(?string $code): ?string
     {
-        if ($code === null || $code === '') {
-            return null;
-        }
-
-        return self::ACTION_CODE_TO_LABEL[$code] ?? null;
+        return Entity::actionLabelFromCode($code);
     }
 
     public static function formatDisplayFields(array $log): array
     {
-        $display = [];
-        $actionLabel = self::actionLabelFromCode($log['action'] ?? null);
-        if ($actionLabel !== null) {
-            $display['Aktion'] = $actionLabel;
-        }
-        if (!empty($log['user_id'])) {
-            $display['Sachbearbeiter*in'] = $log['user_id'];
-        }
-        if (!empty($log['display_number'])) {
-            $display['Terminnummer'] = $log['display_number'];
-        }
-        if (isset($log['queue_number']) && $log['queue_number'] !== '') {
-            $display['Wartenummer'] = $log['queue_number'];
-        }
-        if (!empty($log['appointment_at'])) {
-            $appointmentAt = \DateTimeImmutable::createFromFormat(
-                'Y-m-d H:i:s',
-                (string) $log['appointment_at']
-            );
-            if ($appointmentAt instanceof \DateTimeImmutable) {
-                $display['Terminzeit'] = $appointmentAt->format('d.m.Y H:i:s');
-            }
-        }
-        if (isset($log['slot_count']) && $log['slot_count'] !== '') {
-            $display['Slots'] = $log['slot_count'];
-        }
-        if (!empty($log['citizen_name'])) {
-            $display['Bürger*in'] = $log['citizen_name'];
-        }
-        if (!empty($log['services'])) {
-            $display['Dienstleistungen'] = $log['services'];
-        }
-        if (!empty($log['citizen_amendment'])) {
-            $display['Anmerkung'] = $log['citizen_amendment'];
-        }
-        if (!empty($log['scope_name'])) {
-            $display['Standort'] = $log['scope_name'];
-        }
-        if (!empty($log['citizen_email'])) {
-            $display['E-Mail'] = $log['citizen_email'];
-        }
-        if (!empty($log['citizen_phone'])) {
-            $display['Telefon'] = $log['citizen_phone'];
-        }
-        if (!empty($log['process_status'])) {
-            $display['Status'] = $log['process_status'];
-        }
-        if (!empty($log['db_status'])) {
-            $display['DB Status'] = $log['db_status'];
-        }
-
-        return $display;
+        return Entity::formatDisplayFields($log);
     }
 
     public function readByProcessId($processId)

--- a/zmsdb/src/Zmsdb/Query/Log.php
+++ b/zmsdb/src/Zmsdb/Query/Log.php
@@ -42,7 +42,7 @@ class Log extends Base
             'citizen_phone' => 'log.citizen_phone',
             'process_status' => 'log.process_status',
             'db_status' => 'log.db_status',
-            'citizen_amendment' => 'log.citizen_amendment',
+            'process_amendment' => 'log.process_amendment',
         ];
     }
 

--- a/zmsdb/src/Zmsdb/Query/Log.php
+++ b/zmsdb/src/Zmsdb/Query/Log.php
@@ -28,7 +28,6 @@ class Log extends Base
             'reference' => 'log.reference_id',
             'scope_id' => 'log.scope_id',
             'user_id' => 'log.user_id',
-            'data' => 'log.data',
             'message' => 'log.message',
             'ts' => 'log.ts',
             'action' => 'log.action',
@@ -43,6 +42,7 @@ class Log extends Base
             'citizen_phone' => 'log.citizen_phone',
             'process_status' => 'log.process_status',
             'db_status' => 'log.db_status',
+            'citizen_amendment' => 'log.citizen_amendment',
         ];
     }
 

--- a/zmsdb/tests/Zmsdb/LogTest.php
+++ b/zmsdb/tests/Zmsdb/LogTest.php
@@ -23,43 +23,40 @@ class LogTest extends Base
         $this->assertEquals(12345, $logList[0]['reference']);
     }
 
-    public function testParseLegacyLogData()
+    public function testFormatDisplayFields()
     {
-        $json = json_encode([
-            'Aktion' => Query::ACTION_CALLED,
-            'Sachbearbeiter*in' => '_system_citizenapi',
-            'Terminnummer' => '100495',
-            'Wartenummer' => 100495,
-            'Terminzeit' => '24.06.2026 09:50:00',
-            'Slots' => 1,
-            'Bürger*in' => self::CITIZEN_MAX_MUSTERMANN,
-            'Dienstleistungen' => 'Reisepass',
-            'Standort' => 'Bürgerbüro Ruppertstraße (KVR-II/221)',
-            'E-Mail' => 't@t.com',
-            'Status' => 'reserved',
-            'DB Status' => 'free',
-        ], JSON_UNESCAPED_UNICODE);
+        $display = Query::formatDisplayFields([
+            'action' => 'called',
+            'user_id' => '_system_citizenapi',
+            'display_number' => '100495',
+            'queue_number' => 100495,
+            'appointment_at' => '2026-06-24 09:50:00',
+            'slot_count' => 1,
+            'citizen_name' => self::CITIZEN_MAX_MUSTERMANN,
+            'services' => 'Reisepass',
+            'scope_name' => 'Bürgerbüro Ruppertstraße (KVR-II/221)',
+            'citizen_email' => 't@t.com',
+            'process_status' => 'reserved',
+            'db_status' => 'free',
+        ]);
 
-        $parsed = Query::parseLegacyLogData($json);
-        $this->assertSame('called', $parsed['action']);
-        $this->assertSame(self::CITIZEN_MAX_MUSTERMANN, $parsed['citizen_name']);
-        $this->assertSame('100495', $parsed['display_number']);
-        $this->assertSame('2026-06-24 09:50:00', $parsed['appointment_at']);
-        $this->assertSame('Reisepass', $parsed['services']);
+        $this->assertSame(Query::ACTION_CALLED, $display['Aktion']);
+        $this->assertSame(self::CITIZEN_MAX_MUSTERMANN, $display['Bürger*in']);
+        $this->assertSame('100495', $display['Terminnummer']);
+        $this->assertSame('24.06.2026 09:50:00', $display['Terminzeit']);
+        $this->assertSame('Reisepass', $display['Dienstleistungen']);
     }
 
-    public function testParseLegacyLogDataEmptyNumbersStayNull()
+    public function testFormatDisplayFieldsEmptyNumbersStayOmitted()
     {
-        $json = json_encode([
-            'Aktion' => Query::ACTION_EDITED,
-            'Wartenummer' => '',
-            'Slots' => '',
-        ], JSON_UNESCAPED_UNICODE);
+        $display = Query::formatDisplayFields([
+            'action' => 'edited',
+            'queue_number' => '',
+            'slot_count' => '',
+        ]);
 
-        $parsed = Query::parseLegacyLogData($json);
-
-        $this->assertArrayNotHasKey('queue_number', $parsed);
-        $this->assertArrayNotHasKey('slot_count', $parsed);
+        $this->assertArrayNotHasKey('Wartenummer', $display);
+        $this->assertArrayNotHasKey('Slots', $display);
     }
 
     public function testEmptySearchOnlyReturnsProcessLogs()
@@ -78,21 +75,12 @@ class LogTest extends Base
     {
         $referenceId = 987654;
         $citizenName = self::logSearchLabel('UniqueName');
-        $display = [
-            'Aktion' => Query::ACTION_EDITED,
-            'Sachbearbeiter*in' => 'testadmin',
-            'Terminnummer' => '555001',
-            'Bürger*in' => $citizenName,
-            'Dienstleistungen' => 'Reisepass',
-            'Standort' => 'Test Standort',
-        ];
         Query::writeLogEntry(
             'TEST indexed search',
             $referenceId,
             Query::PROCESS,
             141,
             'testadmin',
-            json_encode($display, JSON_UNESCAPED_UNICODE),
             [
                 'action' => 'edited',
                 'display_number' => '555001',
@@ -126,10 +114,6 @@ class LogTest extends Base
             Query::PROCESS,
             141,
             'testadmin',
-            json_encode([
-                'Aktion' => Query::ACTION_EDITED,
-                'Dienstleistungen' => $serviceName,
-            ], JSON_UNESCAPED_UNICODE),
             [
                 'action' => 'edited',
                 'services' => $serviceName,
@@ -160,7 +144,6 @@ class LogTest extends Base
             Query::PROCESS,
             172,
             'testadmin',
-            json_encode(['Aktion' => Query::ACTION_EDITED, 'Bürger*in' => self::CITIZEN_MAX_MUSTERMANN], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => self::CITIZEN_MAX_MUSTERMANN]
         );
         Query::writeLogEntry(
@@ -169,7 +152,6 @@ class LogTest extends Base
             Query::PROCESS,
             172,
             'testadmin',
-            json_encode(['Aktion' => Query::ACTION_EDITED, 'Bürger*in' => self::CITIZEN_ERIKA_MUSTERMANN], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => self::CITIZEN_ERIKA_MUSTERMANN]
         );
         Query::writeLogEntry(
@@ -178,7 +160,6 @@ class LogTest extends Base
             Query::PROCESS,
             172,
             'testadmin',
-            json_encode(['Aktion' => Query::ACTION_EDITED, 'Bürger*in' => $citizenNameMatch], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => $citizenNameMatch]
         );
 
@@ -221,7 +202,6 @@ class LogTest extends Base
             Query::PROCESS,
             $scopeId,
             'testadmin',
-            json_encode(['Aktion' => Query::ACTION_EDITED, 'Bürger*in' => $citizenNameMatch], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => $citizenNameMatch]
         );
         Query::writeLogEntry(
@@ -230,7 +210,6 @@ class LogTest extends Base
             Query::PROCESS,
             $scopeId,
             'testadmin',
-            json_encode(['Aktion' => Query::ACTION_EDITED, 'Bürger*in' => self::CITIZEN_MAX_MUSTERMANN], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => self::CITIZEN_MAX_MUSTERMANN]
         );
         Query::writeLogEntry(
@@ -239,7 +218,6 @@ class LogTest extends Base
             Query::PROCESS,
             $scopeId,
             'testadmin',
-            json_encode(['Aktion' => Query::ACTION_EDITED, 'Bürger*in' => self::CITIZEN_ERIKA_MUSTERMANN], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => self::CITIZEN_ERIKA_MUSTERMANN]
         );
 
@@ -285,20 +263,16 @@ class LogTest extends Base
         );
     }
 
-    public function testUserActionFiltersAreMutuallyExclusiveForLegacyRows()
+    public function testUserActionFiltersAreMutuallyExclusive()
     {
         $humanReferenceId = 987662;
         $systemReferenceId = 987663;
         Query::writeLogEntry(
-            'TEST human legacy user action',
+            'TEST human user action',
             $humanReferenceId,
             Query::PROCESS,
             172,
-            null,
-            json_encode([
-                'Aktion' => Query::ACTION_EDITED,
-                'Sachbearbeiter*in' => 'testadmin',
-            ], JSON_UNESCAPED_UNICODE),
+            'testadmin',
             ['action' => 'edited', 'citizen_name' => self::CITIZEN_MAX_MUSTERMANN]
         );
         Query::writeLogEntry(
@@ -307,10 +281,6 @@ class LogTest extends Base
             Query::PROCESS,
             172,
             '_system_citizenapi',
-            json_encode([
-                'Aktion' => Query::ACTION_EDITED,
-                'Sachbearbeiter*in' => '_system_citizenapi',
-            ], JSON_UNESCAPED_UNICODE),
             ['action' => 'edited', 'citizen_name' => self::CITIZEN_ERIKA_MUSTERMANN]
         );
 

--- a/zmsentities/schema/dereferenced/log.json
+++ b/zmsentities/schema/dereferenced/log.json
@@ -7,8 +7,9 @@
         "ts": "12345678",
         "message": "A simple log entry",
         "scope_id": "50",
-        "user_id": "10",
-        "data": "{'useraccount': 10}"
+        "user_id": "testadmin",
+        "action": "edited",
+        "citizen_name": "Max Mustermann"
     },
     "required": [
         "type",
@@ -40,9 +41,64 @@
             "type": "string",
             "description": "User which performed operation"
         },
-        "data": {
+        "action": {
             "type": "string",
-            "description": "Payload of data"
+            "description": "Machine-readable action code for process log entries"
+        },
+        "display_number": {
+            "type": "string",
+            "description": "Display number of the related process"
+        },
+        "queue_number": {
+            "type": "number",
+            "description": "Queue number of the related process"
+        },
+        "appointment_at": {
+            "type": "string",
+            "description": "Appointment datetime in Y-m-d H:i:s format"
+        },
+        "slot_count": {
+            "type": "number",
+            "description": "Number of booked slots"
+        },
+        "citizen_name": {
+            "type": "string",
+            "description": "Citizen name at the time of the log entry"
+        },
+        "services": {
+            "type": "string",
+            "description": "Comma-separated list of requested services"
+        },
+        "scope_name": {
+            "type": "string",
+            "description": "Scope name at the time of the log entry"
+        },
+        "citizen_email": {
+            "type": "string",
+            "description": "Citizen email at the time of the log entry"
+        },
+        "citizen_phone": {
+            "type": "string",
+            "description": "Citizen phone at the time of the log entry"
+        },
+        "process_status": {
+            "type": "string",
+            "description": "Process status at the time of the log entry"
+        },
+        "db_status": {
+            "type": "string",
+            "description": "Database status at the time of the log entry"
+        },
+        "citizen_amendment": {
+            "type": "string",
+            "description": "Citizen amendment note at the time of the log entry"
+        },
+        "display": {
+            "type": "object",
+            "description": "Human-readable display fields derived from indexed columns",
+            "additionalProperties": {
+                "type": "string"
+            }
         }
     }
 }

--- a/zmsentities/schema/dereferenced/log.json
+++ b/zmsentities/schema/dereferenced/log.json
@@ -89,9 +89,9 @@
             "type": "string",
             "description": "Database status at the time of the log entry"
         },
-        "citizen_amendment": {
+        "process_amendment": {
             "type": "string",
-            "description": "Citizen amendment note at the time of the log entry"
+            "description": "Process amendment note at the time of the log entry"
         },
         "display": {
             "type": "object",

--- a/zmsentities/schema/log.json
+++ b/zmsentities/schema/log.json
@@ -7,8 +7,9 @@
         "ts": "12345678",
         "message": "A simple log entry",
         "scope_id": "50",
-        "user_id": "10",
-        "data": "{'useraccount': 10}"
+        "user_id": "testadmin",
+        "action": "edited",
+        "citizen_name": "Max Mustermann"
     },
     "required": [
         "type",
@@ -40,9 +41,64 @@
             "type": "string",
             "description": "User which performed operation"
         },
-        "data": {
+        "action": {
             "type": "string",
-            "description": "Payload of data"
+            "description": "Machine-readable action code for process log entries"
+        },
+        "display_number": {
+            "type": "string",
+            "description": "Display number of the related process"
+        },
+        "queue_number": {
+            "type": "number",
+            "description": "Queue number of the related process"
+        },
+        "appointment_at": {
+            "type": "string",
+            "description": "Appointment datetime in Y-m-d H:i:s format"
+        },
+        "slot_count": {
+            "type": "number",
+            "description": "Number of booked slots"
+        },
+        "citizen_name": {
+            "type": "string",
+            "description": "Citizen name at the time of the log entry"
+        },
+        "services": {
+            "type": "string",
+            "description": "Comma-separated list of requested services"
+        },
+        "scope_name": {
+            "type": "string",
+            "description": "Scope name at the time of the log entry"
+        },
+        "citizen_email": {
+            "type": "string",
+            "description": "Citizen email at the time of the log entry"
+        },
+        "citizen_phone": {
+            "type": "string",
+            "description": "Citizen phone at the time of the log entry"
+        },
+        "process_status": {
+            "type": "string",
+            "description": "Process status at the time of the log entry"
+        },
+        "db_status": {
+            "type": "string",
+            "description": "Database status at the time of the log entry"
+        },
+        "citizen_amendment": {
+            "type": "string",
+            "description": "Citizen amendment note at the time of the log entry"
+        },
+        "display": {
+            "type": "object",
+            "description": "Human-readable display fields derived from indexed columns",
+            "additionalProperties": {
+                "type": "string"
+            }
         }
     }
 }

--- a/zmsentities/schema/log.json
+++ b/zmsentities/schema/log.json
@@ -89,9 +89,9 @@
             "type": "string",
             "description": "Database status at the time of the log entry"
         },
-        "citizen_amendment": {
+        "process_amendment": {
             "type": "string",
-            "description": "Citizen amendment note at the time of the log entry"
+            "description": "Process amendment note at the time of the log entry"
         },
         "display": {
             "type": "object",

--- a/zmsentities/src/Zmsentities/Log.php
+++ b/zmsentities/src/Zmsentities/Log.php
@@ -6,5 +6,98 @@ class Log extends Schema\Entity
 {
     public const PRIMARY = 'reference';
 
+    public const ACTION_MAIL_SUCCESS = 'E-Mail-Versand erfolgreich';
+    public const ACTION_MAIL_FAIL = 'E-Mail-Versand ist fehlgeschlagen';
+    public const ACTION_STATUS_CHANGE = 'Terminstatus wurde geändert';
+    public const ACTION_SEND_REMINDER = 'Erinnerungsmail wurde gesendet';
+    public const ACTION_REMOVED = 'Termin aus der Warteschlange entfernt';
+    public const ACTION_CALLED = 'Termin wurde aufgerufen';
+    public const ACTION_ARCHIVED = 'Termin wurde archiviert';
+    public const ACTION_EDITED = 'Termin wurde geändert';
+    public const ACTION_REDIRECTED = 'Termin wurde weitergeleitet';
+    public const ACTION_NEW = 'Neuer Termin wurde erstellt';
+    public const ACTION_DELETED = 'Termin wurde gelöscht';
+    public const ACTION_CANCELED = 'Termin wurde abgesagt';
+
+    private const ACTION_CODE_TO_LABEL = [
+        'mail_success' => self::ACTION_MAIL_SUCCESS,
+        'mail_fail' => self::ACTION_MAIL_FAIL,
+        'status_changed' => self::ACTION_STATUS_CHANGE,
+        'reminder_sent' => self::ACTION_SEND_REMINDER,
+        'removed_from_queue' => self::ACTION_REMOVED,
+        'called' => self::ACTION_CALLED,
+        'archived' => self::ACTION_ARCHIVED,
+        'edited' => self::ACTION_EDITED,
+        'redirected' => self::ACTION_REDIRECTED,
+        'created' => self::ACTION_NEW,
+        'deleted' => self::ACTION_DELETED,
+        'canceled' => self::ACTION_CANCELED,
+    ];
+
     public static $schema = "log.json";
+
+    public static function actionLabelFromCode(?string $code): ?string
+    {
+        if ($code === null || $code === '') {
+            return null;
+        }
+
+        return self::ACTION_CODE_TO_LABEL[$code] ?? null;
+    }
+
+    public static function formatDisplayFields(array $log): array
+    {
+        $display = [];
+        $actionLabel = self::actionLabelFromCode($log['action'] ?? null);
+        if ($actionLabel !== null) {
+            $display['Aktion'] = $actionLabel;
+        }
+        if (!empty($log['user_id'])) {
+            $display['Sachbearbeiter*in'] = $log['user_id'];
+        }
+        if (!empty($log['display_number'])) {
+            $display['Terminnummer'] = $log['display_number'];
+        }
+        if (isset($log['queue_number']) && $log['queue_number'] !== '') {
+            $display['Wartenummer'] = $log['queue_number'];
+        }
+        if (!empty($log['appointment_at'])) {
+            $appointmentAt = \DateTimeImmutable::createFromFormat(
+                'Y-m-d H:i:s',
+                (string) $log['appointment_at']
+            );
+            if ($appointmentAt instanceof \DateTimeImmutable) {
+                $display['Terminzeit'] = $appointmentAt->format('d.m.Y H:i:s');
+            }
+        }
+        if (isset($log['slot_count']) && $log['slot_count'] !== '') {
+            $display['Slots'] = $log['slot_count'];
+        }
+        if (!empty($log['citizen_name'])) {
+            $display['Bürger*in'] = $log['citizen_name'];
+        }
+        if (!empty($log['services'])) {
+            $display['Dienstleistungen'] = $log['services'];
+        }
+        if (!empty($log['citizen_amendment'])) {
+            $display['Anmerkung'] = $log['citizen_amendment'];
+        }
+        if (!empty($log['scope_name'])) {
+            $display['Standort'] = $log['scope_name'];
+        }
+        if (!empty($log['citizen_email'])) {
+            $display['E-Mail'] = $log['citizen_email'];
+        }
+        if (!empty($log['citizen_phone'])) {
+            $display['Telefon'] = $log['citizen_phone'];
+        }
+        if (!empty($log['process_status'])) {
+            $display['Status'] = $log['process_status'];
+        }
+        if (!empty($log['db_status'])) {
+            $display['DB Status'] = $log['db_status'];
+        }
+
+        return $display;
+    }
 }

--- a/zmsentities/src/Zmsentities/Log.php
+++ b/zmsentities/src/Zmsentities/Log.php
@@ -34,6 +34,24 @@ class Log extends Schema\Entity
         'canceled' => self::ACTION_CANCELED,
     ];
 
+    private const DISPLAY_TEXT_FIELDS = [
+        'user_id' => 'Sachbearbeiter*in',
+        'display_number' => 'Terminnummer',
+        'citizen_name' => 'Bürger*in',
+        'services' => 'Dienstleistungen',
+        'citizen_amendment' => 'Anmerkung',
+        'scope_name' => 'Standort',
+        'citizen_email' => 'E-Mail',
+        'citizen_phone' => 'Telefon',
+        'process_status' => 'Status',
+        'db_status' => 'DB Status',
+    ];
+
+    private const DISPLAY_OPTIONAL_NUMBER_FIELDS = [
+        'queue_number' => 'Wartenummer',
+        'slot_count' => 'Slots',
+    ];
+
     public static $schema = "log.json";
 
     public static function actionLabelFromCode(?string $code): ?string
@@ -52,52 +70,38 @@ class Log extends Schema\Entity
         if ($actionLabel !== null) {
             $display['Aktion'] = $actionLabel;
         }
-        if (!empty($log['user_id'])) {
-            $display['Sachbearbeiter*in'] = $log['user_id'];
-        }
-        if (!empty($log['display_number'])) {
-            $display['Terminnummer'] = $log['display_number'];
-        }
-        if (isset($log['queue_number']) && $log['queue_number'] !== '') {
-            $display['Wartenummer'] = $log['queue_number'];
-        }
-        if (!empty($log['appointment_at'])) {
-            $appointmentAt = \DateTimeImmutable::createFromFormat(
-                'Y-m-d H:i:s',
-                (string) $log['appointment_at']
-            );
-            if ($appointmentAt instanceof \DateTimeImmutable) {
-                $display['Terminzeit'] = $appointmentAt->format('d.m.Y H:i:s');
+
+        foreach (self::DISPLAY_TEXT_FIELDS as $column => $label) {
+            if (!empty($log[$column])) {
+                $display[$label] = $log[$column];
             }
         }
-        if (isset($log['slot_count']) && $log['slot_count'] !== '') {
-            $display['Slots'] = $log['slot_count'];
+
+        foreach (self::DISPLAY_OPTIONAL_NUMBER_FIELDS as $column => $label) {
+            if (isset($log[$column]) && $log[$column] !== '') {
+                $display[$label] = $log[$column];
+            }
         }
-        if (!empty($log['citizen_name'])) {
-            $display['Bürger*in'] = $log['citizen_name'];
-        }
-        if (!empty($log['services'])) {
-            $display['Dienstleistungen'] = $log['services'];
-        }
-        if (!empty($log['citizen_amendment'])) {
-            $display['Anmerkung'] = $log['citizen_amendment'];
-        }
-        if (!empty($log['scope_name'])) {
-            $display['Standort'] = $log['scope_name'];
-        }
-        if (!empty($log['citizen_email'])) {
-            $display['E-Mail'] = $log['citizen_email'];
-        }
-        if (!empty($log['citizen_phone'])) {
-            $display['Telefon'] = $log['citizen_phone'];
-        }
-        if (!empty($log['process_status'])) {
-            $display['Status'] = $log['process_status'];
-        }
-        if (!empty($log['db_status'])) {
-            $display['DB Status'] = $log['db_status'];
+
+        $appointmentAt = self::formatAppointmentAtDisplay($log['appointment_at'] ?? null);
+        if ($appointmentAt !== null) {
+            $display['Terminzeit'] = $appointmentAt;
         }
 
         return $display;
+    }
+
+    private static function formatAppointmentAtDisplay($appointmentAt): ?string
+    {
+        if (empty($appointmentAt)) {
+            return null;
+        }
+
+        $parsed = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', (string) $appointmentAt);
+        if (!$parsed instanceof \DateTimeImmutable) {
+            return null;
+        }
+
+        return $parsed->format('d.m.Y H:i:s');
     }
 }

--- a/zmsentities/src/Zmsentities/Log.php
+++ b/zmsentities/src/Zmsentities/Log.php
@@ -39,7 +39,7 @@ class Log extends Schema\Entity
         'display_number' => 'Terminnummer',
         'citizen_name' => 'Bürger*in',
         'services' => 'Dienstleistungen',
-        'citizen_amendment' => 'Anmerkung',
+        'process_amendment' => 'Anmerkung',
         'scope_name' => 'Standort',
         'citizen_email' => 'E-Mail',
         'citizen_phone' => 'Telefon',


### PR DESCRIPTION
Stop writing and reading the legacy log.data blob, add citizen_amendment with expand/contract migrations, and render admin log search from indexed columns.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log entries now use structured, searchable fields for actions, appointments, citizens, services, and process details.
  * Log details display consistent, human-readable action labels and formatted appointment times.
  * Log search and filtering continue to support relevant scope and user-action criteria.

* **Bug Fixes**
  * Improved log-detail rendering by removing reliance on legacy log data.

* **Documentation**
  * Updated database migration guidance and schema documentation for the standardized log structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->