### PR TITLE
fix(GH-1345): make slashless zmsapi URLs work without 301

### DIFF
--- a/zmscitizenapi/routing.php
+++ b/zmscitizenapi/routing.php
@@ -20,7 +20,6 @@
  *               $ref: "schema/citizenapi/collections/serviceList.json"
  */
 \App::$slim->get('/services/', '\BO\Zmscitizenapi\Controllers\Service\ServicesListController')->setName("ServicesListController");
-\App::$slim->get('/services', '\BO\Zmscitizenapi\Controllers\Service\ServicesListController')->setName("ServicesListController");
 
 /**
  * @swagger
@@ -41,7 +40,6 @@
  *               $ref: "schema/citizenapi/collections/thinnedScopeList.json"
  */
 \App::$slim->get('/scopes/', '\BO\Zmscitizenapi\Controllers\Scope\ScopesListController')->setName("ScopesListController");
-\App::$slim->get('/scopes', '\BO\Zmscitizenapi\Controllers\Scope\ScopesListController')->setName("ScopesListController");
 
 /**
  * @swagger
@@ -62,7 +60,6 @@
  *               $ref: "schema/citizenapi/collections/officeList.json"
  */
 \App::$slim->get('/offices/', '\BO\Zmscitizenapi\Controllers\Office\OfficesListController')->setName("OfficesListController");
-\App::$slim->get('/offices', '\BO\Zmscitizenapi\Controllers\Office\OfficesListController')->setName("OfficesListController");
 
 /**
  * @swagger
@@ -83,7 +80,6 @@
  *               $ref: "schema/citizenapi/collections/officeServiceAndRelationList.json"
  */
 \App::$slim->get('/offices-and-services/', '\BO\Zmscitizenapi\Controllers\Office\OfficesServicesRelationsController')->setName("OfficesServicesRelationsController");
-\App::$slim->get('/offices-and-services', '\BO\Zmscitizenapi\Controllers\Office\OfficesServicesRelationsController')->setName("OfficesServicesRelationsController");
 
 /**
  * @swagger
@@ -112,7 +108,6 @@
  *         description: Scope not found
  */
 \App::$slim->get('/scope-by-id/', '\BO\Zmscitizenapi\Controllers\Scope\ScopeByIdController')->setName("ScopeByIdController");
-\App::$slim->get('/scope-by-id', '\BO\Zmscitizenapi\Controllers\Scope\ScopeByIdController')->setName("ScopeByIdController");
 
 /**
  * @swagger
@@ -139,7 +134,6 @@
  *               $ref: "schema/citizenapi/collections/serviceList.json"
  */
 \App::$slim->get('/services-by-office/', '\BO\Zmscitizenapi\Controllers\Service\ServiceListByOfficeController')->setName("ServiceListByOfficeController");
-\App::$slim->get('/services-by-office', '\BO\Zmscitizenapi\Controllers\Service\ServiceListByOfficeController')->setName("ServiceListByOfficeController");
 
 /**
  * @swagger
@@ -166,7 +160,6 @@
  *               $ref: "schema/citizenapi/collections/officeList.json"
  */
 \App::$slim->get('/offices-by-service/', '\BO\Zmscitizenapi\Controllers\Office\OfficeListByServiceController')->setName("OfficeListByServiceController");
-\App::$slim->get('/offices-by-service', '\BO\Zmscitizenapi\Controllers\Office\OfficeListByServiceController')->setName("OfficeListByServiceController");
 
 /**
  * @swagger
@@ -198,7 +191,6 @@
  *               $ref: "schema/citizenapi/availableDays.json"
  */
 \App::$slim->get('/available-days/', '\BO\Zmscitizenapi\Controllers\Availability\AvailableDaysListController')->setName("AvailableDaysListController");
-\App::$slim->get('/available-days', '\BO\Zmscitizenapi\Controllers\Availability\AvailableDaysListController')->setName("AvailableDaysListController");
 
 /**
  * @swagger
@@ -230,7 +222,6 @@
  *               $ref: "schema/citizenapi/availableDays.json"
  */
 \App::$slim->get('/available-days-by-office/', '\BO\Zmscitizenapi\Controllers\Availability\AvailableDaysListByOfficeController')->setName("AvailableDaysListByOfficeController");
-\App::$slim->get('/available-days-by-office', '\BO\Zmscitizenapi\Controllers\Availability\AvailableDaysListByOfficeController')->setName("AvailableDaysListByOfficeController");
 
 /**
  * @swagger
@@ -267,7 +258,6 @@
  *               $ref: "schema/citizenapi/availableAppointments.json"
  */
 \App::$slim->get('/available-appointments/', '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListController')->setName("AvailableAppointmentsListController");
-\App::$slim->get('/available-appointments', '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListController')->setName("AvailableAppointmentsListController");
 
 /**
  * @swagger
@@ -304,7 +294,6 @@
  *               $ref: "schema/citizenapi/availableAppointments.json"
  */
 \App::$slim->get('/available-appointments-by-office/', '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListByOfficeController')->setName("AvailableAppointmentsListByOfficeController");
-\App::$slim->get('/available-appointments-by-office', '\BO\Zmscitizenapi\Controllers\Availability\AvailableAppointmentsListByOfficeController')->setName("AvailableAppointmentsListByOfficeController");
 
 /**
  * @swagger
@@ -356,7 +345,6 @@
  *         description: Appointment not found
  */
 \App::$slim->get('/appointment/', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentByIdController')->setName("AppointmentByIdController");
-\App::$slim->get('/appointment', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentByIdController')->setName("AppointmentByIdController");
 
 /**
  * @swagger
@@ -377,7 +365,6 @@
  *               $ref: "schema/citizenapi/captcha/altchaCaptcha.json"
  */
 \App::$slim->get('/captcha-details/', '\BO\Zmscitizenapi\Controllers\Captcha\CaptchaController')->setName("CaptchaController");
-\App::$slim->get('/captcha-details', '\BO\Zmscitizenapi\Controllers\Security\CaptchaController')->setName("CaptchaController");
 
 /**
  * @swagger
@@ -398,7 +385,6 @@
  *               $ref: "schema/citizenapi/captcha/createChallengeResponse.json"
  */
 \App::$slim->get('/captcha-challenge/', '\BO\Zmscitizenapi\Controllers\Captcha\CaptchaChallengeController')->setName("CaptchaChallengeController");
-\App::$slim->get('/captcha-challenge', '\BO\Zmscitizenapi\Controllers\Captcha\CaptchaChallengeController')->setName("CaptchaChallengeController");
 
 /**
  * @swagger
@@ -426,7 +412,6 @@
  *               $ref: "schema/citizenapi/captcha/verifySolutionResponse.json"
  */
 \App::$slim->post('/captcha-verify/', '\BO\Zmscitizenapi\Controllers\Captcha\CaptchaVerifyController')->setName("CaptchaVerifyController");
-\App::$slim->post('/captcha-verify', '\BO\Zmscitizenapi\Controllers\Captcha\CaptchaVerifyController')->setName("CaptchaVerifyController");
 
 /**
  * @swagger
@@ -474,7 +459,6 @@
  *         description: Appointment not found
  */
 \App::$slim->post('/reserve-appointment/', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentReserveController')->setName("AppointmentReserveController");
-\App::$slim->post('/reserve-appointment', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentReserveController')->setName("AppointmentReserveController");
 
 /**
  * @swagger
@@ -522,7 +506,6 @@
  *         description: Appointment not found
  */
 \App::$slim->post('/update-appointment/', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentUpdateController')->setName("AppointmentUpdateController");
-\App::$slim->post('/update-appointment', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentUpdateController')->setName("AppointmentUpdateController");
 
 /**
  * @swagger
@@ -570,7 +553,6 @@
  *         description: Appointment not found
  */
 \App::$slim->post('/confirm-appointment/', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentConfirmController')->setName("AppointmentConfirmController");
-\App::$slim->post('/confirm-appointment', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentConfirmController')->setName("AppointmentConfirmController");
 
 /**
  * @swagger
@@ -618,7 +600,6 @@
  *         description: Appointment not found
  */
 \App::$slim->post('/preconfirm-appointment/', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentPreconfirmController')->setName("AppointmentPreconfirmController");
-\App::$slim->post('/preconfirm-appointment', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentPreconfirmController')->setName("AppointmentPreconfirmController");
 
 /**
  * @swagger
@@ -666,7 +647,6 @@
  *         description: Appointment not found
  */
 \App::$slim->post('/cancel-appointment/', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentCancelController')->setName("AppointmentCancelController");
-\App::$slim->post('/cancel-appointment', '\BO\Zmscitizenapi\Controllers\Appointment\AppointmentCancelController')->setName("AppointmentCancelController");
 
 /**
  * @swagger
@@ -696,7 +676,6 @@
  *         description: Unauthorized (if no user header is present)
  */
 \App::$slim->get('/my-appointments/', '\BO\Zmscitizenapi\Controllers\Appointment\MyAppointmentsController')->setName("MyAppointmentsController");
-\App::$slim->get('/my-appointments', '\BO\Zmscitizenapi\Controllers\Appointment\MyAppointmentsController')->setName("MyAppointmentsController");
 
 // Catch-all route for 404 errors
 \App::$slim->map(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'], '/{routes:.+}', function ($request, $response) {

--- a/zmsslim/src/Slim/Middleware/TrailingSlash.php
+++ b/zmsslim/src/Slim/Middleware/TrailingSlash.php
@@ -30,7 +30,7 @@ class TrailingSlash
 
         // Non-API (HTML apps): permanently redirect to the trailing-slash URL.
         $uri = $uri->withPath($path . '/');
-        if ($request->getHeader('X-Ssl') && 'no' != $request->getHeader('X-Ssl')) {
+        if ($request->hasHeader('X-Ssl') && 'no' !== $request->getHeaderLine('X-Ssl')) {
             $uri = $uri->withScheme('https');
             $uriString = (string)$uri;
         } else {

--- a/zmsslim/src/Slim/Middleware/TrailingSlash.php
+++ b/zmsslim/src/Slim/Middleware/TrailingSlash.php
@@ -17,30 +17,32 @@ class TrailingSlash
         $uri = $request->getUri();
         $path = $uri->getPath();
 
-        if (strpos($path, '/api/') !== false) {
+        $needsTrailingSlash = substr($path, -1) !== '/' && !pathinfo($path, PATHINFO_EXTENSION);
+        if (!$needsTrailingSlash) {
             return $next->handle($request);
         }
 
-        if (substr($path, -1) !== '/' && !pathinfo($path, PATHINFO_EXTENSION)) {
-            // permanently redirect paths without a trailing slash
-            // to their trailing counterpart
-            $uri = $uri->withPath($path . '/');
-            if ($request->getHeader('X-Ssl') && 'no' != $request->getHeader('X-Ssl')) {
-                $uri = $uri->withScheme('https');
-                $uriString = (string)$uri;
-            } else {
-                $uriString = preg_replace('#^https?:#', '', (string)$uri); //Do not force protocol
-            }
-
-            $redirects = \App::$slim->redirect(
-                (string) $request->getUri(),
-                $uriString,
-                StatusCodeInterface::STATUS_MOVED_PERMANENTLY
-            )->getCallable();
-
-            return $redirects();
+        // API paths: rewrite in-place so slashless URLs match routes defined with a trailing slash.
+        // Do not 301 — redirects break POST and are awkward for API clients.
+        if (strpos($path, '/api/') !== false) {
+            return $next->handle($request->withUri($uri->withPath($path . '/')));
         }
 
-        return $next->handle($request);
+        // Non-API (HTML apps): permanently redirect to the trailing-slash URL.
+        $uri = $uri->withPath($path . '/');
+        if ($request->getHeader('X-Ssl') && 'no' != $request->getHeader('X-Ssl')) {
+            $uri = $uri->withScheme('https');
+            $uriString = (string)$uri;
+        } else {
+            $uriString = preg_replace('#^https?:#', '', (string)$uri); //Do not force protocol
+        }
+
+        $redirects = \App::$slim->redirect(
+            (string) $request->getUri(),
+            $uriString,
+            StatusCodeInterface::STATUS_MOVED_PERMANENTLY
+        )->getCallable();
+
+        return $redirects();
     }
 }

--- a/zmsslim/tests/Slim/Middleware/TrailingSlashTest.php
+++ b/zmsslim/tests/Slim/Middleware/TrailingSlashTest.php
@@ -17,7 +17,7 @@ use Slim\Psr7\Uri;
 
 class TrailingSlashTest extends TestCase
 {
-    public function testInvoke()
+    public function testInvokeRedirectsNonApiPaths()
     {
         $uri = new Uri('http', 'localhost', 80, '/admin');
 
@@ -30,5 +30,39 @@ class TrailingSlashTest extends TestCase
         self::assertTrue($response->hasHeader('Location'));
         self::assertSame(StatusCodeInterface::STATUS_MOVED_PERMANENTLY, $response->getStatusCode());
         self::assertContainsEquals('//localhost/admin/', $response->getHeader('Location'));
+    }
+
+    public function testInvokeRewritesApiPathsWithoutRedirect()
+    {
+        $uri = new Uri('http', 'localhost', 80, '/terminvereinbarung/api/2/status');
+
+        $request = new Request('GET', $uri, new Headers([]), [], [], new Stream(fopen('php://temp', 'wb+')));
+        $nextHandler = new RequestHandlerMock();
+
+        $sut = new TrailingSlash();
+        $response = $sut->__invoke($request, $nextHandler);
+
+        self::assertFalse($response->hasHeader('Location'));
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(
+            '/terminvereinbarung/api/2/status/',
+            $nextHandler->getRequest()->getUri()->getPath()
+        );
+    }
+
+    public function testInvokeLeavesApiPathsWithTrailingSlashUnchanged()
+    {
+        $uri = new Uri('http', 'localhost', 80, '/terminvereinbarung/api/2/status/');
+
+        $request = new Request('GET', $uri, new Headers([]), [], [], new Stream(fopen('php://temp', 'wb+')));
+        $nextHandler = new RequestHandlerMock();
+
+        $sut = new TrailingSlash();
+        $sut->__invoke($request, $nextHandler);
+
+        self::assertSame(
+            '/terminvereinbarung/api/2/status/',
+            $nextHandler->getRequest()->getUri()->getPath()
+        );
     }
 }

--- a/zmsslim/tests/Slim/Middleware/TrailingSlashTest.php
+++ b/zmsslim/tests/Slim/Middleware/TrailingSlashTest.php
@@ -32,6 +32,48 @@ class TrailingSlashTest extends TestCase
         self::assertContainsEquals('//localhost/admin/', $response->getHeader('Location'));
     }
 
+    public function testInvokeDoesNotForceHttpsWhenXSslIsNo()
+    {
+        $uri = new Uri('http', 'localhost', 80, '/admin');
+
+        $request = new Request(
+            'GET',
+            $uri,
+            new Headers(['X-Ssl' => ['no']]),
+            [],
+            [],
+            new Stream(fopen('php://temp', 'wb+'))
+        );
+        $nextHandler = new RequestHandlerMock();
+
+        $sut = new TrailingSlash();
+        $response = $sut->__invoke($request, $nextHandler);
+
+        self::assertSame(StatusCodeInterface::STATUS_MOVED_PERMANENTLY, $response->getStatusCode());
+        self::assertContainsEquals('//localhost/admin/', $response->getHeader('Location'));
+    }
+
+    public function testInvokeForcesHttpsWhenXSslIsPresent()
+    {
+        $uri = new Uri('http', 'localhost', 80, '/admin');
+
+        $request = new Request(
+            'GET',
+            $uri,
+            new Headers(['X-Ssl' => ['yes']]),
+            [],
+            [],
+            new Stream(fopen('php://temp', 'wb+'))
+        );
+        $nextHandler = new RequestHandlerMock();
+
+        $sut = new TrailingSlash();
+        $response = $sut->__invoke($request, $nextHandler);
+
+        self::assertSame(StatusCodeInterface::STATUS_MOVED_PERMANENTLY, $response->getStatusCode());
+        self::assertContainsEquals('https://localhost:80/admin/', $response->getHeader('Location'));
+    }
+
     public function testInvokeRewritesApiPathsWithoutRedirect()
     {
         $uri = new Uri('http', 'localhost', 80, '/terminvereinbarung/api/2/status');


### PR DESCRIPTION
## Summary
- For `/api/` paths missing a trailing slash, `TrailingSlash` now rewrites the path in-place instead of skipping or 301-redirecting.
- Slashless URLs like `/terminvereinbarung/api/2/status` now match routes defined with a trailing slash (same response as `/status/`).
- Non-API apps keep the existing 301 redirect behavior.
- Closes #1345

## Test plan
- [x] `zmsslim` unit tests for `TrailingSlash` (redirect, API rewrite, already-slashed API path)
- [x] Local curl: `GET /terminvereinbarung/api/2/status` → 200
- [x] Local curl: `GET /terminvereinbarung/api/2/status/` → 200
- [x] Confirm a non-API path (e.g. admin) still 301s to the trailing-slash URL
- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced consistent trailing-slash handling: non-API paths that need a slash are permanently redirected to the corrected URL.
  * API paths missing a trailing slash are now internally adjusted without issuing a redirect.
  * Existing paths and paths with extensions are left untouched.
  * Redirect targets now respect the `X-Ssl` setting for HTTP/HTTPS behavior.
* **Tests**
  * Expanded middleware tests to cover API vs non-API and `X-Ssl` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->