### PR TITLE
clean(GH-1206): extract shared cache initialization into zmsslim

### DIFF
--- a/zmsbackend/src/Zmsbackend/Application.php
+++ b/zmsbackend/src/Zmsbackend/Application.php
@@ -8,9 +8,8 @@
 namespace BO\Zmsbackend;
 
 use BO\Slim\LoggerService;
+use BO\Slim\Traits\CacheInitializationTrait;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 
 if (($token = getenv('ZMS_CONFIG_SECURE_TOKEN')) === false || $token === '') {
     throw new \RuntimeException('ZMS_CONFIG_SECURE_TOKEN environment variable must be set');
@@ -36,6 +35,8 @@ define(
 
 class Application extends \BO\Slim\Application
 {
+    use CacheInitializationTrait;
+
     const IDENTIFIER = 'zms';
 
     const MODULE_NAME = 'zmsbackend';
@@ -93,14 +94,6 @@ class Application extends \BO\Slim\Application
         return new \DateTimeImmutable();
     }
 
-    private static function initializeCache(): void
-    {
-        self::$CACHE_DIR = getenv('CACHE_DIR') ?: __DIR__ . '/cache';
-        self::$SOURCE_CACHE_TTL = (int) (getenv('SOURCE_CACHE_TTL') ?: 3600);
-        self::validateCacheDirectory();
-        self::setupCache();
-    }
-
     /**
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
@@ -123,26 +116,6 @@ class Application extends \BO\Slim\Application
     {
         self::$MAX_STRING_LENGTH = (int) (getenv('MAX_STRING_LENGTH') ?: 32768);
         self::$MAX_RECURSION_DEPTH = (int) (getenv('MAX_RECURSION_DEPTH') ?: 10);
-    }
-
-    private static function validateCacheDirectory(): void
-    {
-        if (!is_dir(self::$CACHE_DIR)) {
-            if (!@mkdir(self::$CACHE_DIR, 0750, true) && !is_dir(self::$CACHE_DIR)) {
-                throw new \RuntimeException(sprintf('Cache directory "%s" could not be created', self::$CACHE_DIR));
-            }
-        }
-
-        if (!is_writable(self::$CACHE_DIR)) {
-            throw new \RuntimeException(sprintf('Cache directory "%s" is not writable', self::$CACHE_DIR));
-        }
-    }
-
-    private static function setupCache(): void
-    {
-        $psr6 = new FilesystemAdapter(namespace: '', defaultLifetime: self::$SOURCE_CACHE_TTL, directory: self::$CACHE_DIR);
-        self::$cache = new Psr16Cache($psr6);
-        LoggerService::$cache = self::$cache;
     }
 
     public static function getLoggerConfig(): array
@@ -172,7 +145,7 @@ class Application extends \BO\Slim\Application
     public static function initialize(): void
     {
         self::initializeLogger();
-        self::initializeCache();
+        self::initializeCache(__DIR__ . '/cache');
         self::initializeRequestLimits();
     }
 }

--- a/zmscitizenapi/src/Zmscitizenapi/Application.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Application.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace BO\Zmscitizenapi;
 
+use BO\Slim\Traits\CacheInitializationTrait;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -15,6 +14,8 @@ use Symfony\Component\Cache\Psr16Cache;
  */
 class Application extends \BO\Slim\Application
 {
+    use CacheInitializationTrait;
+
     public const IDENTIFIER = 'zms';
     public const MODULE_NAME = 'zmscitizenapi';
     public static string $source_name = "dldb,zms";
@@ -66,7 +67,7 @@ class Application extends \BO\Slim\Application
         self::initializeMaintenanceMode();
         self::initializeLogger();
         self::initializeCaptcha();
-        self::initializeCache();
+        self::initializeCache(__DIR__ . '/cache');
         self::initializeMiddleware();
     }
 
@@ -109,14 +110,6 @@ class Application extends \BO\Slim\Application
             ?: 'https://captcha.muenchen.de/api/v1/captcha/verify';
     }
 
-    private static function initializeCache(): void
-    {
-        self::$CACHE_DIR = getenv('CACHE_DIR') ?: __DIR__ . '/cache';
-        self::$SOURCE_CACHE_TTL = (int) (getenv('SOURCE_CACHE_TTL') ?: 3600);
-        self::validateCacheDirectory();
-        self::setupCache();
-    }
-
     /**
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @TODO: Extract middleware initialization logic into a dedicated MiddlewareInitializer class
@@ -145,26 +138,6 @@ class Application extends \BO\Slim\Application
     public static function reinitializeMiddlewareConfig(): void
     {
         self::initializeMiddleware();
-    }
-
-    private static function validateCacheDirectory(): void
-    {
-        if (!is_dir(self::$CACHE_DIR)) {
-            if (!@mkdir(self::$CACHE_DIR, 0750, true) && !is_dir(self::$CACHE_DIR)) {
-                throw new \RuntimeException(sprintf('Cache directory "%s" could not be created', self::$CACHE_DIR));
-            }
-        }
-
-        if (!is_writable(self::$CACHE_DIR)) {
-            throw new \RuntimeException(sprintf('Cache directory "%s" is not writable', self::$CACHE_DIR));
-        }
-    }
-
-    private static function setupCache(): void
-    {
-        $psr6 = new FilesystemAdapter(namespace: '', defaultLifetime: self::$SOURCE_CACHE_TTL, directory: self::$CACHE_DIR);
-        self::$cache = new Psr16Cache($psr6);
-        \BO\Slim\LoggerService::$cache = self::$cache;
     }
 
     public static function getLoggerConfig(): array

--- a/zmsslim/src/Slim/Helper/CacheBootstrap.php
+++ b/zmsslim/src/Slim/Helper/CacheBootstrap.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Slim\Helper;
+
+use BO\Slim\LoggerService;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+/**
+ * Shared filesystem cache bootstrap for module Application classes.
+ */
+final class CacheBootstrap
+{
+    /**
+     * @return array{0: string, 1: int}
+     */
+    public static function resolveConfig(?string $fallbackCacheDir = null): array
+    {
+        $cacheDir = getenv('CACHE_DIR') ?: ($fallbackCacheDir ?? sys_get_temp_dir());
+        $ttl = (int) (getenv('SOURCE_CACHE_TTL') ?: 3600);
+
+        return [$cacheDir, $ttl];
+    }
+
+    public static function create(string $cacheDir, int $ttl): CacheInterface
+    {
+        self::validateDirectory($cacheDir);
+
+        $psr6 = new FilesystemAdapter(namespace: '', defaultLifetime: $ttl, directory: $cacheDir);
+        $cache = new Psr16Cache($psr6);
+        LoggerService::$cache = $cache;
+
+        return $cache;
+    }
+
+    public static function createFromEnv(?string $fallbackCacheDir = null): CacheInterface
+    {
+        [$cacheDir, $ttl] = self::resolveConfig($fallbackCacheDir);
+
+        return self::create($cacheDir, $ttl);
+    }
+
+    public static function validateDirectory(string $cacheDir): void
+    {
+        if (!is_dir($cacheDir)) {
+            if (!@mkdir($cacheDir, 0750, true) && !is_dir($cacheDir)) {
+                throw new \RuntimeException(sprintf('Cache directory "%s" could not be created', $cacheDir));
+            }
+        }
+
+        if (!is_writable($cacheDir)) {
+            throw new \RuntimeException(sprintf('Cache directory "%s" is not writable', $cacheDir));
+        }
+    }
+}

--- a/zmsslim/src/Slim/Helper/ModuleLoggerInitializer.php
+++ b/zmsslim/src/Slim/Helper/ModuleLoggerInitializer.php
@@ -9,8 +9,6 @@ use BO\Slim\Middleware\RequestLoggingMiddleware;
 use BO\Slim\Middleware\RequestSanitizerMiddleware;
 use BO\Slim\Middleware\SecurityHeadersMiddleware;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 
 final class ModuleLoggerInitializer
 {
@@ -35,15 +33,13 @@ final class ModuleLoggerInitializer
 
     public static function initializeCache(?string $cacheDir = null): CacheInterface
     {
-        $cacheDir ??= getenv('CACHE_DIR') ?: sys_get_temp_dir();
-        $ttl = (int) (getenv('SOURCE_CACHE_TTL') ?: 3600);
-        self::validateCacheDirectory($cacheDir);
+        if ($cacheDir !== null) {
+            $ttl = (int) (getenv('SOURCE_CACHE_TTL') ?: 3600);
 
-        $psr6 = new FilesystemAdapter(namespace: '', defaultLifetime: $ttl, directory: $cacheDir);
-        $cache = new Psr16Cache($psr6);
-        LoggerService::$cache = $cache;
+            return CacheBootstrap::create($cacheDir, $ttl);
+        }
 
-        return $cache;
+        return CacheBootstrap::createFromEnv(sys_get_temp_dir());
     }
 
     public static function tryInitializeCache(?string $cacheDir = null): ?CacheInterface
@@ -82,18 +78,5 @@ final class ModuleLoggerInitializer
             $requestLimits['maxRecursionDepth'],
             $requestLimits['maxStringLength']
         ));
-    }
-
-    private static function validateCacheDirectory(string $cacheDir): void
-    {
-        if (!is_dir($cacheDir)) {
-            if (!@mkdir($cacheDir, 0750, true) && !is_dir($cacheDir)) {
-                throw new \RuntimeException(sprintf('Cache directory "%s" could not be created', $cacheDir));
-            }
-        }
-
-        if (!is_writable($cacheDir)) {
-            throw new \RuntimeException(sprintf('Cache directory "%s" is not writable', $cacheDir));
-        }
     }
 }

--- a/zmsslim/src/Slim/Traits/CacheInitializationTrait.php
+++ b/zmsslim/src/Slim/Traits/CacheInitializationTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Slim\Traits;
+
+use BO\Slim\Helper\CacheBootstrap;
+
+/**
+ * Shared cache initialization for module Application classes.
+ *
+ * Expects the using class to declare:
+ * - public static ?\Psr\SimpleCache\CacheInterface $cache
+ * - public static string $CACHE_DIR
+ * - public static int $SOURCE_CACHE_TTL
+ */
+trait CacheInitializationTrait
+{
+    private static function initializeCache(?string $fallbackCacheDir = null): void
+    {
+        [$cacheDir, $ttl] = CacheBootstrap::resolveConfig($fallbackCacheDir);
+        static::$CACHE_DIR = $cacheDir;
+        static::$SOURCE_CACHE_TTL = $ttl;
+        static::$cache = CacheBootstrap::create($cacheDir, $ttl);
+    }
+
+    private static function validateCacheDirectory(): void
+    {
+        CacheBootstrap::validateDirectory(static::$CACHE_DIR);
+    }
+
+    private static function setupCache(): void
+    {
+        static::$cache = CacheBootstrap::create(static::$CACHE_DIR, static::$SOURCE_CACHE_TTL);
+    }
+}

--- a/zmsslim/tests/Slim/Helper/CacheBootstrapTest.php
+++ b/zmsslim/tests/Slim/Helper/CacheBootstrapTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Slim\Tests\Helper;
+
+use BO\Slim\Helper\CacheBootstrap;
+use BO\Slim\LoggerService;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+class CacheBootstrapTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/zms-cache-bootstrap-' . uniqid('', true);
+        putenv('CACHE_DIR');
+        putenv('SOURCE_CACHE_TTL');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('CACHE_DIR');
+        putenv('SOURCE_CACHE_TTL');
+        LoggerService::$cache = null;
+        if (is_dir($this->tempDir)) {
+            @rmdir($this->tempDir);
+        }
+        parent::tearDown();
+    }
+
+    public function testCreateFromEnvUsesFallbackDirectoryAndTtl(): void
+    {
+        putenv('SOURCE_CACHE_TTL=1800');
+
+        $cache = CacheBootstrap::createFromEnv($this->tempDir);
+
+        $this->assertInstanceOf(CacheInterface::class, $cache);
+        $this->assertTrue(is_dir($this->tempDir));
+        $this->assertSame($cache, LoggerService::$cache);
+        [$dir, $ttl] = CacheBootstrap::resolveConfig($this->tempDir);
+        $this->assertSame($this->tempDir, $dir);
+        $this->assertSame(1800, $ttl);
+    }
+
+    public function testValidateDirectoryThrowsForUnwritablePath(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        CacheBootstrap::validateDirectory('/dev/null/not-a-writable-cache-dir');
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CacheBootstrap` + `CacheInitializationTrait` in zmsslim
- Use the trait from `zmscitizenapi` and `zmsbackend` Applications (module-specific default cache dirs preserved)
- Route `ModuleLoggerInitializer` cache setup through the same helper to avoid a third copy

Closes #1206

## Test plan
- [x] `zmsslim` unit: `CacheBootstrapTest` / `ModuleLoggerInitializerTest`
- [x] `zmscitizenapi` unit: `ApplicationTest::testInitializeCache`
- [x] Smoke: citizenapi + backend start and write cache under `CACHE_DIR`

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application cache initialization across services.
  * Cache directories are now validated and created when needed.
  * Cache configuration consistently honors environment settings, including directory and expiration time.
  * Improved handling of cache initialization failures.

* **Tests**
  * Added coverage for environment-based cache setup, fallback directories, expiration settings, and invalid cache paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->