### PR TITLE
fix(GH): ignore localhost dead links in VitePress docs build

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -624,6 +624,8 @@ export default {
   description: "Technical documentation for it-at-m/eappointment",
   base: SITE_BASE,
   lang: "en-US",
+  // Local-dev URLs (e.g. Vite on :8082) are not reachable during CI docs builds.
+  ignoreDeadLinks: [/^https?:\/\/localhost(?::\d+)?(?:\/|$)/],
   vite: {
     esbuild: {
       target: "es2022",

--- a/docs/de/setup-and-development/local-keycloak-setup.md
+++ b/docs/de/setup-and-development/local-keycloak-setup.md
@@ -63,12 +63,12 @@ Der externe `dbs-login`-Loader ist lokal oft nicht erreichbar. Mit `VITE_USE_LOC
 
 1. Migrationen anwenden (Stack neu starten, damit `init-keycloak` läuft, oder den Service neu erzeugen).
 2. Vite-/citizenview-Prozess neu starten, damit Env und Login-Skripte geladen werden.
-3. Die Startseite [http://localhost:8082/](http://localhost:8082/) oder [http://localhost:8082/webcomponents.html](http://localhost:8082/webcomponents.html) öffnen (oder direkt [appointment-view](http://localhost:8082/appointment-view.html)). Am Kundenschritt mit Login **Anmelden** klicken.
+3. Die Startseite `http://localhost:8082/` oder `http://localhost:8082/webcomponents.html` öffnen (oder direkt `http://localhost:8082/appointment-view.html`). Am Kundenschritt mit Login **Anmelden** klicken.
 4. Am Keycloak-Login anmelden; danach solltest du eingeloggt zurückkommen.
 
 Nach dem Login laufen API-Aufrufe über `/buergeransicht/authenticated/api/citizen/…`. Vite-Dev-Proxy und lokales Gateway brauchen diesen Pfad (siehe `zmscitizenview/vite.config.ts` sowie `.devcontainer` / `.ddev` `local-gateway-application.yml`). Nach dem Pull `refarch-gateway` und den Vite-/citizenview-Prozess neu starten.
 
-Der lokale Login-Shim speichert den Access-Token in `localStorage`, damit [appointment-overview](http://localhost:8082/appointment-overview.html), [appointment-detail](http://localhost:8082/appointment-detail.html) und [appointment-slider](http://localhost:8082/appointment-slider.html) über Tabs hinweg auf derselben Origin eingeloggt bleiben. Tokens enthalten Claim `lhmExtID` (Keycloak-Benutzername) für `my-appointments`. Nach Migration `10_add-citizen-token-mappers.yml` (inkl. `lhmExtID`) erneut einloggen (und bei Bedarf neu buchen).
+Der lokale Login-Shim speichert den Access-Token in `localStorage`, damit `http://localhost:8082/appointment-overview.html`, `http://localhost:8082/appointment-detail.html` und `http://localhost:8082/appointment-slider.html` über Tabs hinweg auf derselben Origin eingeloggt bleiben. Tokens enthalten Claim `lhmExtID` (Keycloak-Benutzername) für `my-appointments`. Nach Migration `10_add-citizen-token-mappers.yml` (inkl. `lhmExtID`) erneut einloggen (und bei Bedarf neu buchen).
 
 | Feld         | Wert       |
 | ------------ | ---------- |

--- a/docs/en/setup-and-development/local-keycloak-setup.md
+++ b/docs/en/setup-and-development/local-keycloak-setup.md
@@ -63,12 +63,12 @@ The external `dbs-login` loader CDN is often unreachable on local networks. With
 
 1. Apply migrations (restart the stack so `init-keycloak` runs, or recreate that service).
 2. Restart the Vite / citizenview process so env and the new login scripts load.
-3. Open the host page index [http://localhost:8082/](http://localhost:8082/) or [http://localhost:8082/webcomponents.html](http://localhost:8082/webcomponents.html) (or [appointment-view](http://localhost:8082/appointment-view.html) directly). On the customer step with login enabled, click **Login**.
+3. Open the host page index `http://localhost:8082/` or `http://localhost:8082/webcomponents.html` (or `http://localhost:8082/appointment-view.html` directly). On the customer step with login enabled, click **Login**.
 4. Sign in on the Keycloak page, then you should return logged in.
 
 After login, API calls use `/buergeransicht/authenticated/api/citizen/…`. The Vite dev proxy and local gateway both need that path (see `zmscitizenview/vite.config.ts` and `.devcontainer` / `.ddev` `local-gateway-application.yml`). Restart `refarch-gateway` and the Vite / citizenview process after pulling these changes.
 
-The local login shim stores the access token in `localStorage` so [appointment-overview](http://localhost:8082/appointment-overview.html), [appointment-detail](http://localhost:8082/appointment-detail.html), and [appointment-slider](http://localhost:8082/appointment-slider.html) stay logged in across tabs on the same origin. Tokens include claim `lhmExtID` (Keycloak username) so `my-appointments` can resolve the user. Re-login (and re-book if needed) after applying migration `10_add-citizen-token-mappers.yml` (includes `lhmExtID`).
+The local login shim stores the access token in `localStorage` so `http://localhost:8082/appointment-overview.html`, `http://localhost:8082/appointment-detail.html`, and `http://localhost:8082/appointment-slider.html` stay logged in across tabs on the same origin. Tokens include claim `lhmExtID` (Keycloak username) so `my-appointments` can resolve the user. Re-login (and re-book if needed) after applying migration `10_add-citizen-token-mappers.yml` (includes `lhmExtID`).
 
 | Field    | Value      |
 | -------- | ---------- |


### PR DESCRIPTION
## Summary
- Convert localhost:8082 markdown links in Keycloak setup docs to inline code
- Ignore localhost dead links in VitePress CI builds

## Test plan
- [x] docs:build succeeds locally
- [x] Deploy Pages passes on main