### PR TITLE
Slotzeit-Berechnung über größten gemeinsamen Teiler vereinheitlichen

### DIFF
--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -667,17 +667,32 @@ class Munich
     /**
      * Calculate greatest common divisor for slot times
      */
-    protected function getSlotTime(int $a, int $b): int
+    function getSlotTime($a, $b)
     {
-        $slotTimes = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 25, 30, 60];
-        $slotTime = 1;
+        $a = (int) $a;
+        $b = (int) $b;
 
-        foreach ($slotTimes as $time) {
-            if ($a % $time === 0 && $b % $time === 0) {
-                $slotTime = $time;
-            }
+        if ($a <= 0 || $b <= 0) {
+            return 5;
         }
 
-        return $slotTime;
+        $slotTime = getGreatestCommonDivisor($a, $b);
+
+        if ($slotTime >= 5 && $slotTime % 5 === 0) {
+            return $slotTime;
+        }
+
+        return 5;
+    }
+
+    function getGreatestCommonDivisor($a, $b)
+    {
+        while ($b !== 0) {
+            $tmp = $b;
+            $b = $a % $b;
+            $a = $tmp;
+        }
+
+        return abs($a);
     }
 }

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -667,7 +667,7 @@ class Munich
     /**
      * Calculate greatest common divisor for slot times
      */
-    function getSlotTime($a, $b)
+    protected function getSlotTime($a, $b): int
     {
         $a = (int) $a;
         $b = (int) $b;
@@ -676,7 +676,7 @@ class Munich
             return 5;
         }
 
-        $slotTime = getGreatestCommonDivisor($a, $b);
+        $slotTime = $this->getGreatestCommonDivisor($a, $b);
 
         if ($slotTime >= 5 && $slotTime % 5 === 0) {
             return $slotTime;
@@ -685,7 +685,7 @@ class Munich
         return 5;
     }
 
-    function getGreatestCommonDivisor($a, $b)
+    protected function getGreatestCommonDivisor(int $a, int $b): int
     {
         while ($b !== 0) {
             $tmp = $b;


### PR DESCRIPTION
- 5-Minuten-Raster als fachliches Minimum verwenden
- größte gemeinsame Slotzeit ohne feste Obergrenze berechnen

### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved slot-time calculation for more consistent scheduling.
  - Slot times now use valid five-minute increments and default to five minutes when inputs are invalid or unsupported.
  - Prevents unexpected slot durations such as one, six, or twelve minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->