### PR TITLE
feat(ZMSKVR-1426): hide days without opening hours in Gesamtübersicht

### DIFF
--- a/zmsadmin/js/page/overallCalendar/overallCalendar.js
+++ b/zmsadmin/js/page/overallCalendar/overallCalendar.js
@@ -81,16 +81,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (form) form.addEventListener('submit', handleSubmit);
 
-    const hideEmptyDaysCheckbox = document.getElementById('hide-days-without-opening-hours');
-    if (hideEmptyDaysCheckbox) {
+    const emptyDaysRadios = document.querySelectorAll('input[name="emptyDaysVisibility"]');
+    if (emptyDaysRadios.length) {
         hideDaysWithoutOpeningHours = loadHideEmptyDaysPreference();
-        hideEmptyDaysCheckbox.checked = hideDaysWithoutOpeningHours;
-        hideEmptyDaysCheckbox.addEventListener('change', () => {
-            hideDaysWithoutOpeningHours = hideEmptyDaysCheckbox.checked;
-            saveHideEmptyDaysPreference(hideDaysWithoutOpeningHours);
-            if (calendarCache.length) {
-                renderCalendar();
-            }
+        emptyDaysRadios.forEach(radio => {
+            radio.checked = hideDaysWithoutOpeningHours
+                ? radio.value === 'hide'
+                : radio.value === 'show';
+            radio.addEventListener('change', () => {
+                if (!radio.checked) return;
+                hideDaysWithoutOpeningHours = radio.value === 'hide';
+                saveHideEmptyDaysPreference(hideDaysWithoutOpeningHours);
+                if (calendarCache.length) {
+                    renderCalendar();
+                }
+            });
         });
     }
 

--- a/zmsadmin/js/page/overallCalendar/overallCalendar.js
+++ b/zmsadmin/js/page/overallCalendar/overallCalendar.js
@@ -5,8 +5,10 @@ let autoRefreshTimer = null;
 let currentRequest = null;
 let SCOPE_COLORS = {};
 let CLOSURES = new Set();
+let hideDaysWithoutOpeningHours = false;
 const STEP_MIN = 5;
 const MAX_DAYS = 14;
+const HIDE_EMPTY_DAYS_STORAGE_KEY = 'zmsadmin.overallCalendar.hideDaysWithoutOpeningHours';
 
 function inclusiveDayCount(dateFrom, dateUntil) {
     const from = new Date(dateFrom);
@@ -79,6 +81,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (form) form.addEventListener('submit', handleSubmit);
 
+    const hideEmptyDaysCheckbox = document.getElementById('hide-days-without-opening-hours');
+    if (hideEmptyDaysCheckbox) {
+        hideDaysWithoutOpeningHours = loadHideEmptyDaysPreference();
+        hideEmptyDaysCheckbox.checked = hideDaysWithoutOpeningHours;
+        hideEmptyDaysCheckbox.addEventListener('change', () => {
+            hideDaysWithoutOpeningHours = hideEmptyDaysCheckbox.checked;
+            saveHideEmptyDaysPreference(hideDaysWithoutOpeningHours);
+            if (calendarCache.length) {
+                renderCalendar();
+            }
+        });
+    }
+
     if (refreshButton) {
         refreshButton.addEventListener('click', async () => {
             if (!currentRequest) return;
@@ -88,7 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     fetchCalendar({scopeIds, dateFrom, dateUntil, fullReload: false}),
                     fetchClosures({scopeIds, dateFrom, dateUntil})
                 ]);
-                renderMultiDayCalendar(calendarCache);
+                renderCalendar();
             } catch (error) {
                 alert('Fehler beim Aktualisieren: ' + error.message);
             }
@@ -187,7 +202,7 @@ async function handleSubmit(event) {
             fetchClosures({scopeIds, dateFrom, dateUntil})
         ]);
         SCOPE_COLORS = buildScopeColorMap(calendarCache);
-        renderMultiDayCalendar(calendarCache);
+        renderCalendar();
         startAutoRefresh();
     } catch (error) {
         alert('Fehler beim Laden' + error.message);
@@ -220,7 +235,42 @@ async function fetchIncrementalUpdate() {
     }
 
     await fetchClosures({scopeIds, dateFrom, dateUntil});
-    renderMultiDayCalendar(calendarCache);
+    renderCalendar();
+}
+
+function loadHideEmptyDaysPreference() {
+    try {
+        return localStorage.getItem(HIDE_EMPTY_DAYS_STORAGE_KEY) === '1';
+    } catch (error) {
+        return false;
+    }
+}
+
+function saveHideEmptyDaysPreference(enabled) {
+    try {
+        localStorage.setItem(HIDE_EMPTY_DAYS_STORAGE_KEY, enabled ? '1' : '0');
+    } catch (error) {
+        // Ignore quota / private-mode errors; preference is optional.
+    }
+}
+
+function dayHasOpeningHoursOrAppointments(day) {
+    return (day.scopes || []).some(scope => {
+        const hasOpeningHours = Array.isArray(scope.intervals) && scope.intervals.length > 0;
+        const hasAppointments = Array.isArray(scope.events) && scope.events.length > 0;
+        return hasOpeningHours || hasAppointments;
+    });
+}
+
+function getVisibleDays(days) {
+    if (!hideDaysWithoutOpeningHours) {
+        return days;
+    }
+    return days.filter(dayHasOpeningHoursOrAppointments);
+}
+
+function renderCalendar() {
+    renderMultiDayCalendar(getVisibleDays(calendarCache));
 }
 
 function mergeDelta(deltaDays, deletedProcessIds = []) {

--- a/zmsadmin/js/page/overallCalendar/overallCalendar.js
+++ b/zmsadmin/js/page/overallCalendar/overallCalendar.js
@@ -276,7 +276,6 @@ function getVisibleDays(days) {
     }
     return days.filter(dayHasOpeningHoursOrAppointments);
 }
-}
 
 function renderCalendar() {
     renderMultiDayCalendar(getVisibleDays(calendarCache));

--- a/zmsadmin/js/page/overallCalendar/overallCalendar.js
+++ b/zmsadmin/js/page/overallCalendar/overallCalendar.js
@@ -268,10 +268,14 @@ function dayHasOpeningHoursOrAppointments(day) {
 }
 
 function getVisibleDays(days) {
+    if (!Array.isArray(days)) {
+        return days;
+    }
     if (!hideDaysWithoutOpeningHours) {
         return days;
     }
     return days.filter(dayHasOpeningHoursOrAppointments);
+}
 }
 
 function renderCalendar() {

--- a/zmsadmin/scss/overallCalendar.scss
+++ b/zmsadmin/scss/overallCalendar.scss
@@ -187,6 +187,29 @@ body.no-page-scroll {
   margin-top: 1rem;
 }
 
+.overall-calendar-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem 1.5rem;
+  margin: 10px 0;
+}
+
+.overall-calendar-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  margin: 0;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+}
+
+.overall-calendar-filter input[type="checkbox"] {
+  margin: 0;
+}
+
 .overall-calendar-closed {
   border: 0 !important;
   background: repeating-linear-gradient(

--- a/zmsadmin/scss/overallCalendar.scss
+++ b/zmsadmin/scss/overallCalendar.scss
@@ -198,15 +198,35 @@ body.no-page-scroll {
 
 .overall-calendar-filter {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: .5rem;
+  gap: .5rem 1rem;
   margin: 0;
+  padding: 0;
+  border: 0;
   font-weight: 500;
-  cursor: pointer;
   user-select: none;
 }
 
-.overall-calendar-filter input[type="checkbox"] {
+.overall-calendar-filter-legend {
+  float: left;
+  width: auto;
+  margin: 0 1rem 0 0;
+  padding: 0;
+  font-size: inherit;
+  font-weight: 600;
+}
+
+.overall-calendar-filter label {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  margin: 0;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.overall-calendar-filter input[type="radio"] {
   margin: 0;
 }
 

--- a/zmsadmin/scss/overallCalendar.scss
+++ b/zmsadmin/scss/overallCalendar.scss
@@ -94,7 +94,13 @@ $day-h: 2.2rem;
   z-index: 1;
 }
 
-.overall-calendar-daterange          { display:flex; gap:2rem; margin-bottom:1rem; flex-wrap:wrap; }
+.overall-calendar-daterange {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
 .overall-calendar-datefield          { display:flex; flex-direction:column; gap:.3rem; min-width:100px; }
 .overall-calendar-datefield label    { font-size:.97em; font-weight:500; margin-bottom:2px; color:#444; }
 .overall-calendar-datefield input[type="date"]{
@@ -187,21 +193,13 @@ body.no-page-scroll {
   margin-top: 1rem;
 }
 
-.overall-calendar-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: .75rem 1.5rem;
-  margin: 10px 0;
-}
-
 .overall-calendar-filter {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
+  align-self: flex-end;
   gap: .5rem 1rem;
-  margin: 0;
+  margin: 0 0 .35rem;
   padding: 0;
   border: 0;
   font-weight: 500;

--- a/zmsadmin/scss/overallCalendar.scss
+++ b/zmsadmin/scss/overallCalendar.scss
@@ -99,7 +99,7 @@ $day-h: 2.2rem;
   gap: 2rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: flex-start;
 }
 .overall-calendar-datefield          { display:flex; flex-direction:column; gap:.3rem; min-width:100px; }
 .overall-calendar-datefield label    { font-size:.97em; font-weight:500; margin-bottom:2px; color:#444; }
@@ -194,12 +194,12 @@ body.no-page-scroll {
 }
 
 .overall-calendar-filter {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  align-self: flex-end;
-  gap: .5rem 1rem;
-  margin: 0 0 .35rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: flex-start;
+  gap: .4rem;
+  margin: 0;
   padding: 0;
   border: 0;
   font-weight: 500;
@@ -207,9 +207,9 @@ body.no-page-scroll {
 }
 
 .overall-calendar-filter-legend {
-  float: left;
+  float: none;
   width: auto;
-  margin: 0 1rem 0 0;
+  margin: 0;
   padding: 0;
   font-size: inherit;
   font-weight: 600;

--- a/zmsadmin/templates/page/overallCalendar.twig
+++ b/zmsadmin/templates/page/overallCalendar.twig
@@ -57,6 +57,24 @@
                 <label for="calendar-date-until" class="form-label">Bis</label>
                 <input type="date" id="calendar-date-until" name="calendarDateUntil" class="form-control">
             </div>
+            <fieldset class="overall-calendar-filter"
+                      title="Darstellung der Tage ohne Öffnungszeiten">
+                <legend class="overall-calendar-filter-legend">Tage ohne Öffnungszeiten</legend>
+                <label>
+                    <input type="radio"
+                           name="emptyDaysVisibility"
+                           value="show"
+                           checked>
+                    Alle Tage anzeigen
+                </label>
+                <label>
+                    <input type="radio"
+                           name="emptyDaysVisibility"
+                           value="hide"
+                           id="hide-days-without-opening-hours">
+                    Ausblenden
+                </label>
+            </fieldset>
         </div>
 
         <div class="overall-calendar-actions">
@@ -72,32 +90,12 @@
         </div>
     </form>
 
-    <div class="overall-calendar-toolbar">
-        <fieldset class="overall-calendar-filter"
-                  title="Darstellung der Tage ohne Öffnungszeiten">
-            <legend class="overall-calendar-filter-legend">Tage ohne Öffnungszeiten</legend>
-            <label>
-                <input type="radio"
-                       name="emptyDaysVisibility"
-                       value="show"
-                       checked>
-                Alle Tage anzeigen
-            </label>
-            <label>
-                <input type="radio"
-                       name="emptyDaysVisibility"
-                       value="hide"
-                       id="hide-days-without-opening-hours">
-                Ausblenden
-            </label>
-        </fieldset>
-        <div class="overall-calendar-legend">
-            <strong>Legende:</strong>
-            <span class="overall-calendar-seat overall-calendar-closed" style="display:inline-block; width:80px; height:18px; margin-left:8px; vertical-align:middle;"></span>
-            <span style="margin-right:12px;">gesperrt</span>
-            <span class="overall-calendar-seat overall-calendar-open" style="display:inline-block; width:80px; height:18px; vertical-align:middle;"></span>
-            <span>frei</span>
-        </div>
+    <div class="overall-calendar-legend" style="margin:10px 0;">
+        <strong>Legende:</strong>
+        <span class="overall-calendar-seat overall-calendar-closed" style="display:inline-block; width:80px; height:18px; margin-left:8px; vertical-align:middle;"></span>
+        <span style="margin-right:12px;">gesperrt</span>
+        <span class="overall-calendar-seat overall-calendar-open" style="display:inline-block; width:80px; height:18px; vertical-align:middle;"></span>
+        <span>frei</span>
     </div>
 
     <div class="overall-calendar-wrapper">

--- a/zmsadmin/templates/page/overallCalendar.twig
+++ b/zmsadmin/templates/page/overallCalendar.twig
@@ -72,12 +72,22 @@
         </div>
     </form>
 
-    <div class="overall-calendar-legend" style="margin:10px 0;">
-        <strong>Legende:</strong>
-        <span class="overall-calendar-seat overall-calendar-closed" style="display:inline-block; width:80px; height:18px; margin-left:8px; vertical-align:middle;"></span>
-        <span style="margin-right:12px;">gesperrt</span>
-        <span class="overall-calendar-seat overall-calendar-open" style="display:inline-block; width:80px; height:18px; vertical-align:middle;"></span>
-        <span>frei</span>
+    <div class="overall-calendar-toolbar">
+        <label class="overall-calendar-filter"
+               title="Tage ohne Öffnungszeiten ein- / ausblenden">
+            <input type="checkbox"
+                   id="hide-days-without-opening-hours"
+                   name="hideDaysWithoutOpeningHours"
+                   value="1">
+            Tage ohne Öffnungszeiten ausblenden
+        </label>
+        <div class="overall-calendar-legend">
+            <strong>Legende:</strong>
+            <span class="overall-calendar-seat overall-calendar-closed" style="display:inline-block; width:80px; height:18px; margin-left:8px; vertical-align:middle;"></span>
+            <span style="margin-right:12px;">gesperrt</span>
+            <span class="overall-calendar-seat overall-calendar-open" style="display:inline-block; width:80px; height:18px; vertical-align:middle;"></span>
+            <span>frei</span>
+        </div>
     </div>
 
     <div class="overall-calendar-wrapper">

--- a/zmsadmin/templates/page/overallCalendar.twig
+++ b/zmsadmin/templates/page/overallCalendar.twig
@@ -73,14 +73,24 @@
     </form>
 
     <div class="overall-calendar-toolbar">
-        <label class="overall-calendar-filter"
-               title="Tage ohne Öffnungszeiten ein- / ausblenden">
-            <input type="checkbox"
-                   id="hide-days-without-opening-hours"
-                   name="hideDaysWithoutOpeningHours"
-                   value="1">
-            Tage ohne Öffnungszeiten ausblenden
-        </label>
+        <fieldset class="overall-calendar-filter"
+                  title="Darstellung der Tage ohne Öffnungszeiten">
+            <legend class="overall-calendar-filter-legend">Tage ohne Öffnungszeiten</legend>
+            <label>
+                <input type="radio"
+                       name="emptyDaysVisibility"
+                       value="show"
+                       checked>
+                Alle Tage anzeigen
+            </label>
+            <label>
+                <input type="radio"
+                       name="emptyDaysVisibility"
+                       value="hide"
+                       id="hide-days-without-opening-hours">
+                Ausblenden
+            </label>
+        </fieldset>
         <div class="overall-calendar-legend">
             <strong>Legende:</strong>
             <span class="overall-calendar-seat overall-calendar-closed" style="display:inline-block; width:80px; height:18px; margin-left:8px; vertical-align:middle;"></span>

--- a/zmsadmin/tests/Zmsadmin/OverallCalendarTest.php
+++ b/zmsadmin/tests/Zmsadmin/OverallCalendarTest.php
@@ -27,8 +27,10 @@ class OverallCalendarTest extends Base
 
         $this->assertStringContainsString('Gesamtübersicht', (string)$response->getBody());
         $this->assertStringContainsString('overall-calendar', (string)$response->getBody());
+        $this->assertStringContainsString('emptyDaysVisibility', (string)$response->getBody());
         $this->assertStringContainsString('hide-days-without-opening-hours', (string)$response->getBody());
-        $this->assertStringContainsString('Tage ohne Öffnungszeiten ausblenden', (string)$response->getBody());
+        $this->assertStringContainsString('Tage ohne Öffnungszeiten', (string)$response->getBody());
+        $this->assertStringContainsString('Alle Tage anzeigen', (string)$response->getBody());
         $this->assertEquals(200, $response->getStatusCode());
     }
 

--- a/zmsadmin/tests/Zmsadmin/OverallCalendarTest.php
+++ b/zmsadmin/tests/Zmsadmin/OverallCalendarTest.php
@@ -27,6 +27,8 @@ class OverallCalendarTest extends Base
 
         $this->assertStringContainsString('Gesamtübersicht', (string)$response->getBody());
         $this->assertStringContainsString('overall-calendar', (string)$response->getBody());
+        $this->assertStringContainsString('hide-days-without-opening-hours', (string)$response->getBody());
+        $this->assertStringContainsString('Tage ohne Öffnungszeiten ausblenden', (string)$response->getBody());
         $this->assertEquals(200, $response->getStatusCode());
     }
 


### PR DESCRIPTION
## Summary
- Adds a checkbox in the admin Gesamtübersicht to hide days without configured opening hours
- Days with appointments are still shown even without opening hours; default remains show-all
- Preference is remembered in `localStorage` for the browser session/user

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-page calendar filter to hide days without opening hours (and appointments when applicable).
  * Remembered the selected filter option across visits using browser storage.
  * Kept the hidden-day filtering consistent during auto-refresh and manual updates.

* **Style**
  * Updated the overall calendar date range layout and added styling for the new filter UI (including radio controls and legend).

* **Tests**
  * Extended rendering tests to verify the new filter control and German label text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->