### PR TITLE
chore(GH): dedupe zmsautomation Maven builds on PRs

### DIFF
--- a/.github/workflows/zmsautomation-maven-build.yml
+++ b/.github/workflows/zmsautomation-maven-build.yml
@@ -3,6 +3,7 @@ name: ☕ zmsautomation-maven-build
 on:
   pull_request:
   push:
+    branches: [main, next]
 
 jobs:
   build:
@@ -17,4 +18,3 @@ jobs:
         with:
           app-path: zmsautomation
           java-version: "21"
-


### PR DESCRIPTION
## Summary
- Restrict `push` triggers for `zmsautomation-maven-build` to `main` and `next`
- Stops duplicate Maven builds on PR branch pushes (`push` + `pull_request`)

## Test plan
- [ ] Open/update a PR that touches zmsautomation and confirm only one `pull_request` Maven build runs
- [ ] Confirm pushes to `main`/`next` still trigger the workflow