### PR TITLE
feat(ZMSKVR-1500): show appointment when confirm link already activated

### DIFF
--- a/zmsautomation/src/test/java/zms/ataf/ui/pages/citizenview/CitizenViewPage.java
+++ b/zmsautomation/src/test/java/zms/ataf/ui/pages/citizenview/CitizenViewPage.java
@@ -1774,6 +1774,54 @@ public class CitizenViewPage extends BasePage {
     /** Navigate to zmscitizenview confirm page. Prefer URL extracted from mail body (GET /mails/); else build from confirm credentials or booking process. */
     public void openConfirmationDeepLinkInBrowser() {
         CONTEXT.set();
+        String url = resolveConfirmationDeepLinkUrl();
+        ScenarioLogManager.getLogger().info("zmscitizenview: navigating to confirmation URL: {}", url);
+        try {
+            DriverUtil.getDriver().navigate().to(url);
+            // Do not refresh. Same-tab hash routing now handles confirm links (ZMSKVR-1121).
+            // navigate()+refresh() can confirm twice and leave activation-expired UI instead of success.
+        } catch (Exception e) {
+            ScenarioLogManager.getLogger().warn("Navigate to confirm URL", e);
+        }
+        try {
+            Thread.sleep(10000L);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * ZMSKVR-1500: reopen the same confirm deep link after a successful activation.
+     * Leaving the confirm hash first is required so the SPA hash watch re-fires; navigating to the
+     * identical URL does not remount and would leave the first success callout on screen.
+     */
+    public void reopenConfirmationDeepLinkInBrowser() {
+        CONTEXT.set();
+        String confirmUrl = resolveConfirmationDeepLinkUrl();
+        String base = confirmUrl;
+        int hashIdx = base.indexOf('#');
+        if (hashIdx >= 0) {
+            base = base.substring(0, hashIdx);
+        }
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: reopening confirmation deep link (leave hash, then confirm again)");
+        try {
+            DriverUtil.getDriver().navigate().to(base + "#/");
+            Thread.sleep(1000L);
+            DriverUtil.getDriver().navigate().to(confirmUrl);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            ScenarioLogManager.getLogger().warn("Reopen confirm URL", e);
+        }
+        try {
+            Thread.sleep(10000L);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String resolveConfirmationDeepLinkUrl() {
         String url = zms.ataf.rest.steps.CitizenApiSteps.getBookingConfirmUrl();
         if (url != null && !url.isBlank()) {
             ScenarioLogManager.getLogger().info("zmscitizenview: opening confirmation deep link (URL from mail body)");
@@ -1802,20 +1850,7 @@ public class CitizenViewPage extends BasePage {
             }
             url = base + "#/appointment/confirm/" + b64;
         }
-        url = ensureAbsoluteCitizenViewUrl(url);
-        ScenarioLogManager.getLogger().info("zmscitizenview: navigating to confirmation URL: {}", url);
-        try {
-            DriverUtil.getDriver().navigate().to(url);
-            // Do not refresh. Same-tab hash routing now handles confirm links (ZMSKVR-1121).
-            // navigate()+refresh() can confirm twice and leave activation-expired UI instead of success.
-        } catch (Exception e) {
-            ScenarioLogManager.getLogger().warn("Navigate to confirm URL", e);
-        }
-        try {
-            Thread.sleep(10000L);
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-        }
+        return ensureAbsoluteCitizenViewUrl(url);
     }
 
     /** Navigate to the appointment view URL extracted from the confirmation mail (link without /confirm/). */

--- a/zmsautomation/src/test/java/zms/ataf/ui/pages/citizenview/CitizenViewPage.java
+++ b/zmsautomation/src/test/java/zms/ataf/ui/pages/citizenview/CitizenViewPage.java
@@ -1621,6 +1621,19 @@ public class CitizenViewPage extends BasePage {
         ScenarioLogManager.getLogger().info("zmscitizenview: confirmation success callout found");
     }
 
+    /** ZMSKVR-1500: MucBanner success after reopening an already-used confirm deep link. */
+    public void assertAlreadyActivatedAppointmentBannerVisible() {
+        CONTEXT.set();
+        String marker = "Sie haben Ihren Termin bereits aktiviert.";
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: waiting for already-activated MucBanner success ({})", marker);
+        waitWithThreeWindows(() -> shadowDomContainsText(marker), "Already-activated appointment banner");
+        Assert.assertTrue(
+                shadowDomContainsText(marker),
+                "Already-activated MucBanner success not found after reopening confirm link.");
+        ScenarioLogManager.getLogger().info("zmscitizenview: already-activated appointment banner found");
+    }
+
     public void assertSelectedAppointmentCalloutVisible() {
         assertShadowContains(
                 "Ausgewählter Termin",

--- a/zmsautomation/src/test/java/zms/ataf/ui/steps/CitizenViewSteps.java
+++ b/zmsautomation/src/test/java/zms/ataf/ui/steps/CitizenViewSteps.java
@@ -214,6 +214,14 @@ public class CitizenViewSteps {
         page.assertConfirmationSuccessCalloutVisible();
     }
 
+    /** ZMSKVR-1500 */
+    @Then("the already activated appointment banner should be visible in the citizen view")
+    public void theAlreadyActivatedAppointmentBannerShouldBeVisible() {
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: assert already-activated appointment MucBanner success visible");
+        page.assertAlreadyActivatedAppointmentBannerVisible();
+    }
+
     @When("I cancel the appointment in the citizen view")
     public void iCancelTheAppointmentInTheCitizenView() {
         ScenarioLogManager.getLogger().info("zmscitizenview: cancel appointment via Termin absagen");

--- a/zmsautomation/src/test/java/zms/ataf/ui/steps/CitizenViewSteps.java
+++ b/zmsautomation/src/test/java/zms/ataf/ui/steps/CitizenViewSteps.java
@@ -202,6 +202,13 @@ public class CitizenViewSteps {
         page.openConfirmationDeepLinkInBrowser();
     }
 
+    /** ZMSKVR-1500: reopen after success; leaves confirm hash first so the SPA remounts the route. */
+    @When("I reopen the confirmation deep link in the browser")
+    public void iReopenTheConfirmationDeepLinkInTheBrowser() {
+        ScenarioLogManager.getLogger().info("zmscitizenview: reopen confirmation deep link in browser");
+        page.reopenConfirmationDeepLinkInBrowser();
+    }
+
     @When("I open the appointment view deep link in the browser")
     public void iOpenTheAppointmentViewDeepLinkInTheBrowser() {
         ScenarioLogManager.getLogger().info("zmscitizenview: open appointment view deep link in browser");

--- a/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links.feature
+++ b/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links.feature
@@ -1,5 +1,5 @@
 #language: en
-@web @zmscitizenview @ZMSKVR-1124 @ZMSKVR-1500 @executeLocally
+@web @zmscitizenview @ZMSKVR-1124 @executeLocally
 Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 10502, Hauptkalender 10489, Abholung 10492, jump-in)
   As a citizen
   I want to book via the citizen view UI
@@ -47,9 +47,6 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
-    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
-    When I open the confirmation deep link in the browser
-    Then the already activated appointment banner should be visible in the citizen view
     # Second mail fetch: confirmation mail (with appointment view link) exists only after opening the confirm link above
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
@@ -85,9 +82,6 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
-    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
-    When I open the confirmation deep link in the browser
-    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10502 in the citizen view
@@ -121,9 +115,6 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
-    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
-    When I open the confirmation deep link in the browser
-    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10489 in the citizen view
@@ -157,9 +148,6 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
-    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
-    When I open the confirmation deep link in the browser
-    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10492 in the citizen view
@@ -194,9 +182,6 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
-    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
-    When I open the confirmation deep link in the browser
-    Then the already activated appointment banner should be visible in the citizen view
     # Second mail fetch: confirmation mail (with appointment view link) exists only after opening the confirm link above
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
@@ -234,9 +219,6 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
-    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
-    When I open the confirmation deep link in the browser
-    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10489 in the citizen view

--- a/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links.feature
+++ b/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1124_booking_ruppertstrasse_pass_calendar_jumpin_links.feature
@@ -1,5 +1,5 @@
 #language: en
-@web @zmscitizenview @ZMSKVR-1124 @executeLocally
+@web @zmscitizenview @ZMSKVR-1124 @ZMSKVR-1500 @executeLocally
 Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 10502, Hauptkalender 10489, Abholung 10492, jump-in)
   As a citizen
   I want to book via the citizen view UI
@@ -47,6 +47,9 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
+    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
+    When I open the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view
     # Second mail fetch: confirmation mail (with appointment view link) exists only after opening the confirm link above
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
@@ -82,6 +85,9 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
+    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
+    When I open the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10502 in the citizen view
@@ -115,6 +121,9 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
+    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
+    When I open the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10489 in the citizen view
@@ -148,6 +157,9 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
+    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
+    When I open the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10492 in the citizen view
@@ -182,6 +194,9 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
+    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
+    When I open the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view
     # Second mail fetch: confirmation mail (with appointment view link) exists only after opening the confirm link above
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
@@ -219,6 +234,9 @@ Feature: ZMSKVR-1124 Ruppertstraße booking — zmscitizenview (Passkalender 105
     And I fetch the preconfirmation mail for the current process
     And I open the confirmation deep link in the browser
     Then the confirmation success callout should be visible in the citizen view
+    # ZMSKVR-1500: reopening the same confirm link shows MucBanner success (already activated)
+    When I open the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view
     And I fetch the confirmation mail for the current process
     And I open the appointment view deep link in the browser
     And the booking summary should show provider 10489 in the citizen view

--- a/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1500_already_activated_confirm_banner.feature
+++ b/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1500_already_activated_confirm_banner.feature
@@ -1,0 +1,36 @@
+#language: en
+@web @zmscitizenview @ZMSKVR-1500 @executeLocally @jumpin @pickupCalendar
+Feature: ZMSKVR-1500 Already-activated confirm link — MucBanner success
+  As a citizen
+  I want to reopen an already used confirmation deep link
+  So that I see a MucBanner success that my appointment is already activated
+
+  Background:
+    Given the Citizen API is available
+    When I request the offices and services endpoint
+    Then the response status code should be 200
+    And the response should contain offices and services
+
+  Scenario: Reopening confirm link after activation shows already-activated MucBanner
+    Given I open zmscitizenview with jump-in service "10295182" and location "10492"
+    Then the service combination step should be visible
+    And the estimated duration on the service combination step should be 10 minutes
+    When I continue from the service combination step
+    Then provider checkbox 10492 should be visible in the citizen view
+    When I select office 10492 in the citizen view
+    And I wait for appointment slots to be ready in the citizen view
+    And I click Später in the time slot grid if available in the citizen view
+    And I scroll to and highlight the preferred timeslot for office 10492 in the citizen view
+    And I click the highlighted timeslot in the citizen view
+    And I continue after slot selection with Weiter for office 10492 in the citizen view
+    When I enter default contact details in the citizen view
+    Then the booking summary should show provider 10492 in the citizen view
+    When I accept communication in the citizen view
+    And I continue from the preconfirm step in the citizen view
+    Then the preconfirmation callout should be visible with activation time 30 minutes in the citizen view
+    When I sync the booking process from citizen view localStorage
+    And I fetch the preconfirmation mail for the current process
+    And I open the confirmation deep link in the browser
+    Then the confirmation success callout should be visible in the citizen view
+    When I reopen the confirmation deep link in the browser
+    Then the already activated appointment banner should be visible in the citizen view

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -135,15 +135,14 @@
               />
             </div>
             <div v-if="currentView === 3">
-              <muc-callout
+              <muc-banner
                 v-if="appointmentAlreadyActivated"
-                type="info"
-                data-test="appointment-already-activated-callout"
+                variant="content"
+                type="success"
+                data-test="appointment-already-activated-banner"
               >
-                <template #header>
-                  {{ t("appointmentAlreadyActivatedHeader") }}
-                </template>
-              </muc-callout>
+                {{ t("appointmentAlreadyActivatedHeader") }}
+              </muc-banner>
               <appointment-summary
                 v-if="
                   !hasUpdateAppointmentError &&
@@ -360,6 +359,7 @@
 import type { ApiErrorTranslation, ErrorStateMap } from "@/utils/errorHandler";
 
 import {
+  MucBanner,
   MucButton,
   MucCallout,
   MucStepper,

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -1312,13 +1312,30 @@ const runAppointmentFromHash = (hash: string | undefined): void => {
 };
 
 const runConfirmFromHash = (hash: string | undefined): void => {
+  if (!hash || isBookingAppointment.value) {
+    return;
+  }
+
+  // Already showing the activated overview for this confirm link.
   if (
-    !hash ||
-    hash === confirmedAppointmentHash.value ||
-    isBookingAppointment.value ||
-    confirmAppointmentSuccess.value ||
-    appointmentAlreadyActivated.value
+    appointmentAlreadyActivated.value &&
+    hash === confirmedAppointmentHash.value
   ) {
+    return;
+  }
+
+  // Same confirm link opened again after a successful activation in this session
+  // (hash watch re-fired without a full remount — e.g. leave route then reopen).
+  if (
+    confirmAppointmentSuccess.value &&
+    hash === confirmedAppointmentHash.value
+  ) {
+    showAlreadyActivatedAppointment(hash);
+    return;
+  }
+
+  // Duplicate in-flight confirm for the same hash.
+  if (hash === confirmedAppointmentHash.value) {
     return;
   }
 
@@ -1345,6 +1362,7 @@ function showAlreadyActivatedAppointment(hash: string): void {
   // runAppointmentFromHash resets confirm route state; re-apply afterwards.
   runAppointmentFromHash(hash);
   appointmentAlreadyActivated.value = true;
+  confirmedAppointmentHash.value = hash;
 }
 
 function nextConfirmAppointment(

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -60,7 +60,7 @@
         !isInMaintenanceModeComputed &&
         !isInSystemFailureModeComputed &&
         !errorStates.errorStateMap.apiErrorRateLimitExceeded.value &&
-        !confirmAppointmentHash &&
+        (!confirmAppointmentHash || appointmentAlreadyActivated) &&
         !apiErrorAppointmentNotFound &&
         !apiErrorInvalidJumpinLink &&
         currentView < 4
@@ -71,13 +71,21 @@
         ref="stepperRef"
         :step-items="STEPPER_ITEMS"
         :active-item="activeStep"
-        :disable-previous-steps="!!appointmentHash"
+        :disable-previous-steps="
+          !!appointmentHash || appointmentAlreadyActivated
+        "
         @change-step="changeStep"
       />
       <div class="container">
         <div class="m-component__grid">
           <div class="m-component__column">
-            <div v-if="currentView === 0 && !appointmentHash">
+            <div
+              v-if="
+                currentView === 0 &&
+                !appointmentHash &&
+                !appointmentAlreadyActivated
+              "
+            >
               <service-finder
                 :global-state="globalState"
                 :preselected-service-id="serviceId"
@@ -127,6 +135,15 @@
               />
             </div>
             <div v-if="currentView === 3">
+              <muc-callout
+                v-if="appointmentAlreadyActivated"
+                type="info"
+                data-test="appointment-already-activated-callout"
+              >
+                <template #header>
+                  {{ t("appointmentAlreadyActivatedHeader") }}
+                </template>
+              </muc-callout>
               <appointment-summary
                 v-if="
                   !hasUpdateAppointmentError &&
@@ -279,7 +296,11 @@
               </div>
 
               <muc-callout
-                v-if="!confirmAppointmentSuccess && hasConfirmAppointmentError"
+                v-if="
+                  !confirmAppointmentSuccess &&
+                  !appointmentAlreadyActivated &&
+                  hasConfirmAppointmentError
+                "
                 :type="toCalloutType(apiErrorTranslation.errorType)"
               >
                 <template #content>
@@ -527,6 +548,7 @@ const bookingErrorKey = computed(() => {
 });
 
 const confirmAppointmentSuccess = ref<boolean>(false);
+const appointmentAlreadyActivated = ref<boolean>(false);
 const confirmedAppointmentHash = ref<string | null>(null);
 const loadedAppointmentHash = ref<string | null>(null);
 const isLoadingAppointmentFromHash = ref<boolean>(false);
@@ -1147,6 +1169,7 @@ const downloadIcsAppointment = () => {
 
 const resetConfirmRouteState = (): void => {
   confirmAppointmentSuccess.value = false;
+  appointmentAlreadyActivated.value = false;
   confirmedAppointmentHash.value = null;
   isBookingAppointment.value = false;
 };
@@ -1293,7 +1316,8 @@ const runConfirmFromHash = (hash: string | undefined): void => {
     !hash ||
     hash === confirmedAppointmentHash.value ||
     isBookingAppointment.value ||
-    confirmAppointmentSuccess.value
+    confirmAppointmentSuccess.value ||
+    appointmentAlreadyActivated.value
   ) {
     return;
   }
@@ -1313,10 +1337,20 @@ const runConfirmFromHash = (hash: string | undefined): void => {
   clearAllErrors();
   currentView.value = 5;
   isBookingAppointment.value = true;
-  nextConfirmAppointment(appointmentData);
+  nextConfirmAppointment(appointmentData, hash);
 };
 
-function nextConfirmAppointment(appointmentData: AppointmentHash) {
+function showAlreadyActivatedAppointment(hash: string): void {
+  clearContextErrors(errorStateMap.value);
+  // runAppointmentFromHash resets confirm route state; re-apply afterwards.
+  runAppointmentFromHash(hash);
+  appointmentAlreadyActivated.value = true;
+}
+
+function nextConfirmAppointment(
+  appointmentData: AppointmentHash,
+  hash: string
+) {
   confirmAppointment(props.globalState, appointmentData)
     .then((data) => {
       currentView.value = 5;
@@ -1332,10 +1366,21 @@ function nextConfirmAppointment(appointmentData: AppointmentHash) {
       } else {
         const firstErrorCode = (data as any).errors?.[0]?.errorCode ?? "";
 
-        if (
-          firstErrorCode === "processNotPreconfirmedAnymore" ||
-          firstErrorCode === "appointmentNotFound"
-        ) {
+        if (firstErrorCode === "processNotPreconfirmedAnymore") {
+          Promise.resolve(
+            fetchAppointment(props.globalState, appointmentData)
+          ).then((fetched) => {
+            if ((fetched as AppointmentDTO)?.processId != undefined) {
+              showAlreadyActivatedAppointment(hash);
+              return;
+            }
+            handleApiError(
+              "preconfirmationExpired",
+              errorStateMap.value,
+              currentErrorData.value
+            );
+          });
+        } else if (firstErrorCode === "appointmentNotFound") {
           handleApiError(
             "preconfirmationExpired",
             errorStateMap.value,

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -152,6 +152,7 @@
   "appointmentHintHeader": "Hinweis zu Ihrem Termin",
   "appointmentNumber": "Terminnummer",
   "appointmentSuccessfullyBookedHeader": "Ihr Termin wurde gebucht.",
+  "appointmentAlreadyActivatedHeader": "Sie haben Ihren Termin bereits aktiviert.",
   "appointmentSuccessfullyBookedText": "Eine Bestätigung und weitere Informationen zu Ihrem Termin erhalten Sie per E-Mail. Wir freuen uns auf Ihren Besuch.",
   "appointmentSuccessfullyCanceledHeader": "Sie haben Ihren Termin erfolgreich abgesagt.",
   "appointmentSuccessfullyCanceledText": "Danke, dass Sie Ihren Termin für andere freigegeben haben.",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -146,6 +146,7 @@
   "appointmentBookingErrorHeader": "Activation failed.",
   "appointmentBookingErrorText": "Activation failed.",
   "appointmentSuccessfullyBookedHeader": " Your appointment has been booked.",
+  "appointmentAlreadyActivatedHeader": "You have already activated your appointment.",
   "appointmentSuccessfullyBookedText": "You will receive confirmation and further information about your appointment by e-mail. We look forward to your visit.",
   "appointmentSuccessfullyCanceledHeader": "You have successfully cancelled your appointment.",
   "appointmentSuccessfullyCanceledText": "Thank you for cancelling your appointment in favor of others.",

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -535,6 +535,9 @@ describe("AppointmentView", () => {
       mockConfirmAppointment.mockResolvedValueOnce({
         errors: [{ errorCode: "processNotPreconfirmedAnymore" }],
       });
+      vi.mocked(ZMSAppointmentAPI.fetchAppointment).mockResolvedValueOnce({
+        errors: [{ errorCode: "appointmentNotFound" }],
+      } as any);
 
       const appointmentData = {
         id: "test-id",
@@ -553,7 +556,9 @@ describe("AppointmentView", () => {
         expect(mockConfirmAppointment).toHaveBeenCalled();
       });
 
-      expect(wrapper.vm.errorStates.apiErrorPreconfirmationExpired.value).toBe(true);
+      await vi.waitFor(() => {
+        expect(wrapper.vm.errorStates.apiErrorPreconfirmationExpired.value).toBe(true);
+      });
       expect(wrapper.find('[data-test="muc-callout"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="muc-callout"]').attributes("data-type")).toBe("error");
     });
@@ -1250,6 +1255,9 @@ describe("AppointmentView", () => {
         ]
       };
       mockConfirmAppointment.mockResolvedValueOnce(mockErrorResponse);
+      vi.mocked(ZMSAppointmentAPI.fetchAppointment).mockResolvedValueOnce({
+        errors: [{ errorCode: "appointmentNotFound" }],
+      } as any);
 
       const appointmentData = {
         id: "test-id",
@@ -1279,8 +1287,11 @@ describe("AppointmentView", () => {
         },
       );
 
-      expect(wrapper.vm.errorStates.apiErrorPreconfirmationExpired.value).toBe(true);
+      await vi.waitFor(() => {
+        expect(wrapper.vm.errorStates.apiErrorPreconfirmationExpired.value).toBe(true);
+      });
       expect(wrapper.vm.confirmAppointmentSuccess).toBe(false);
+      expect(wrapper.vm.appointmentAlreadyActivated).toBe(false);
 
       const errorCallout = wrapper.find('[data-test="muc-callout"]');
       expect(errorCallout.exists()).toBe(true);
@@ -1288,7 +1299,68 @@ describe("AppointmentView", () => {
 
       expect(errorCallout.text()).toContain(de.apiErrorPreconfirmationExpiredHeader);
       expect(errorCallout.text()).toContain(de.apiErrorPreconfirmationExpiredText);
-  });
+    });
+
+    it("should show already-activated info banner and appointment details when confirm link is reused", async () => {
+      mockConfirmAppointment.mockResolvedValueOnce({
+        errors: [
+          {
+            errorCode: "processNotPreconfirmedAnymore",
+            message: "Process not preconfirmed anymore",
+          },
+        ],
+      });
+      vi.mocked(ZMSAppointmentAPI.fetchAppointment).mockResolvedValue({
+        processId: "test-id",
+        authKey: "test-auth-key",
+        serviceId: "123",
+        officeId: "789",
+        serviceCount: 1,
+        subRequestCounts: [],
+        timestamp: nowUnixSeconds() + 3600,
+      } as any);
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          offices: [
+            {
+              id: "789",
+              name: "Test Provider",
+              address: { street: "Test Street", house_number: "1" },
+            },
+          ],
+          services: [{ id: "123", name: "Test Service" }],
+          relations: [],
+        }),
+      } as any);
+
+      const appointmentData = {
+        id: "test-id",
+        authKey: "test-auth-key",
+        scope: {},
+      };
+      const validHash = btoa(JSON.stringify(appointmentData));
+
+      const wrapper = createWrapper({
+        confirmAppointmentHash: validHash,
+      });
+
+      await vi.waitFor(() => {
+        expect(mockConfirmAppointment).toHaveBeenCalled();
+      });
+      await vi.waitFor(() => {
+        expect(wrapper.vm.appointmentAlreadyActivated).toBe(true);
+        expect(wrapper.vm.currentView).toBe(3);
+      });
+
+      expect(wrapper.vm.errorStates.apiErrorPreconfirmationExpired.value).toBe(
+        false
+      );
+      expect(wrapper.find('[data-test="appointment-summary"]').exists()).toBe(
+        true
+      );
+      expect(wrapper.html()).toContain(de.appointmentAlreadyActivatedHeader);
+    });
 
   it("should display activation expired error when API returns appointmentNotFound", async () => {
     const mockErrorResponse = {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -1370,6 +1370,70 @@ describe("AppointmentView", () => {
       expect(wrapper.html()).toContain(de.appointmentAlreadyActivatedHeader);
     });
 
+    it("should show already-activated banner when the same confirm hash is reopened after success", async () => {
+      mockConfirmAppointment.mockResolvedValueOnce({
+        processId: "test-id",
+        authKey: "test-auth-key",
+        serviceId: "123",
+        officeId: "789",
+        serviceCount: 1,
+        subRequestCounts: [],
+        timestamp: nowUnixSeconds() + 3600,
+      } as any);
+
+      const appointmentData = {
+        id: "test-id",
+        authKey: "test-auth-key",
+        scope: {},
+      };
+      const validHash = btoa(JSON.stringify(appointmentData));
+
+      const wrapper = createWrapper({
+        confirmAppointmentHash: validHash,
+      });
+
+      await vi.waitFor(() => {
+        expect(wrapper.vm.confirmAppointmentSuccess).toBe(true);
+      });
+      expect(mockConfirmAppointment).toHaveBeenCalledTimes(1);
+
+      vi.mocked(ZMSAppointmentAPI.fetchAppointment).mockResolvedValue({
+        processId: "test-id",
+        authKey: "test-auth-key",
+        serviceId: "123",
+        officeId: "789",
+        serviceCount: 1,
+        subRequestCounts: [],
+        timestamp: nowUnixSeconds() + 3600,
+      } as any);
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          offices: [
+            {
+              id: "789",
+              name: "Test Provider",
+              address: { street: "Test Street", house_number: "1" },
+            },
+          ],
+          services: [{ id: "123", name: "Test Service" }],
+          relations: [],
+        }),
+      } as any);
+
+      // Leave confirm route then reopen the same link (SPA hash watch re-fires).
+      await wrapper.setProps({ confirmAppointmentHash: undefined });
+      await nextTick();
+      await wrapper.setProps({ confirmAppointmentHash: validHash });
+
+      await vi.waitFor(() => {
+        expect(wrapper.vm.appointmentAlreadyActivated).toBe(true);
+        expect(wrapper.vm.currentView).toBe(3);
+      });
+      expect(mockConfirmAppointment).toHaveBeenCalledTimes(1);
+      expect(wrapper.html()).toContain(de.appointmentAlreadyActivatedHeader);
+    });
+
   it("should display activation expired error when API returns appointmentNotFound", async () => {
     const mockErrorResponse = {
       errors: [

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -181,6 +181,14 @@ describe("AppointmentView", () => {
             props: ["stepItems", "activeItem", "disablePreviousSteps"],
             emits: ["changeStep"],
           },
+          'muc-banner': {
+            props: ["type", "variant"],
+            template: `
+            <div data-test='muc-banner' :data-type="type" :data-variant="variant">
+              <slot></slot>
+            </div>
+          `
+          },
           'muc-callout': {
             props: ["type", "variant"],
             template: `


### PR DESCRIPTION
## Summary
- When a citizen reopens `#/appointment/confirm/...` for an already activated appointment, show an **info** MucCallout (`Sie haben Ihren Termin bereits aktiviert.`) instead of the expired-activation error.
- Load the appointment and show the overview with reschedule/cancel actions (same as the mail detail / `#/appointment/...` flow).
- If the process can no longer be loaded, keep the existing preconfirmation-expired error.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

## Test plan
- [ ] Open confirm link for a preconfirmed appointment → still activates successfully
- [ ] Reopen the same confirm link after activation → info banner + appointment details + Verschieben/Stornieren
- [ ] Open confirm link for a deleted/expired reservation → expired error unchanged
- [ ] Unit: `AppointmentView.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reopening an appointment confirmation link now clearly indicates when the appointment has already been activated.
  * Added localized “appointment already activated” notifications in German and English.
  * Reused confirmation links now restore the appointment details while preventing duplicate activation.

* **Bug Fixes**
  * Improved handling of expired or no-longer-valid preconfirmation links with clearer error messaging.

* **Tests**
  * Added unit and end-to-end coverage for reused confirmation links, already-activated appointments, and expired confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->