### PR TITLE
fix(ZMSKVR-1457): Vorlauf empty calendar and FA7 accordion chevrons

### DIFF
--- a/zmsbackend/src/Zmsbackend/Calendar/Service/CalendarAvailability.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Service/CalendarAvailability.php
@@ -142,6 +142,51 @@ class CalendarAvailability extends \BO\Zmsbackend\Base
             );
         }
 
+        // Vorlauf / lead time: citizen starts with slotsStartDate=today, but bookable
+        // days may begin later. Snap free-slot + painted month to the first bookable
+        // day in the horizon instead of returning an empty calendar.
+        if (count($responseDays) === 0) {
+            $firstBookableDate = $this->findFirstBookableDateAfter(
+                $calendar,
+                $dayQuery,
+                $slotsRequired,
+                $slotType,
+                $now,
+                (new \DateTimeImmutable($responseStartDate))->modify('-1 day')->format('Y-m-d'),
+                $dayRangeEnd
+            );
+            if ($firstBookableDate !== null) {
+                $slotsStartDate = $firstBookableDate;
+                $slotsEndDate = $firstBookableDate;
+                [$responseStartDate, $responseEndDate] = $this->resolveResponseDaysRange(
+                    $slotsStartDate,
+                    $slotsEndDate,
+                    $dayRangeStart,
+                    $dayRangeEnd
+                );
+                $bookableDays = $this->readBookableDaysForRange(
+                    $calendar,
+                    $dayQuery,
+                    $slotsRequired,
+                    $slotType,
+                    $now,
+                    $responseStartDate,
+                    $responseEndDate,
+                    true
+                );
+                $responseDays = $this->filterDaysInDateRange(
+                    $bookableDays,
+                    $responseStartDate,
+                    $responseEndDate
+                );
+                $slotDays = $this->filterDaysInDateRange(
+                    $bookableDays,
+                    $slotsStartDate,
+                    $slotsEndDate
+                );
+            }
+        }
+
         $calendar->days = $slotDays;
 
         $processList = [];

--- a/zmsbackend/tests/Zmsbackend/Calendar/Api/CalendarAvailabilityGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Calendar/Api/CalendarAvailabilityGetTest.php
@@ -101,7 +101,6 @@ class CalendarAvailabilityGetTest extends \BO\Zmsbackend\Tests\Api\Base
         $now = \App::$now;
         $end = (clone $now)->modify('+2 months');
         $day = $now->format('Y-m-d');
-        $monthEnd = (clone $now)->modify('last day of this month')->format('Y-m-d');
         $response = $this->render([], [
             'startDate' => $now->format('Y-m-d'),
             'endDate' => $end->format('Y-m-t'),
@@ -114,16 +113,20 @@ class CalendarAvailabilityGetTest extends \BO\Zmsbackend\Tests\Api\Base
         $body = json_decode((string) $response->getBody(), true);
 
         $this->assertTrue(200 == $response->getStatusCode());
-        $this->assertSame($day, $body['data']['slotsStartDate']);
-        $this->assertSame($day, $body['data']['slotsEndDate']);
+        // Vorlauf: if today is not bookable, slots snap to the first bookable day.
+        $this->assertSame($body['data']['slotsStartDate'], $body['data']['slotsEndDate']);
+        $this->assertGreaterThanOrEqual($day, $body['data']['slotsStartDate']);
 
+        $slotsMonthEnd = (new \DateTimeImmutable($body['data']['slotsStartDate']))
+            ->modify('last day of this month')
+            ->format('Y-m-d');
         foreach ($body['data']['days'] as $entry) {
             $this->assertGreaterThanOrEqual($now->format('Y-m-d'), $entry['date']);
-            $this->assertLessThanOrEqual($monthEnd, $entry['date']);
+            $this->assertLessThanOrEqual($slotsMonthEnd, $entry['date']);
         }
 
         if ($body['data']['nextBookableDate'] !== null) {
-            $this->assertGreaterThan($monthEnd, $body['data']['nextBookableDate']);
+            $this->assertGreaterThan($slotsMonthEnd, $body['data']['nextBookableDate']);
         }
     }
 

--- a/zmsbackend/tests/Zmsbackend/Calendar/Api/CalendarAvailabilityGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Calendar/Api/CalendarAvailabilityGetTest.php
@@ -117,6 +117,10 @@ class CalendarAvailabilityGetTest extends \BO\Zmsbackend\Tests\Api\Base
         $this->assertSame($body['data']['slotsStartDate'], $body['data']['slotsEndDate']);
         $this->assertGreaterThanOrEqual($day, $body['data']['slotsStartDate']);
 
+        $returnedDates = array_column($body['data']['days'], 'date');
+        $this->assertNotEmpty($returnedDates);
+        $this->assertContains($body['data']['slotsStartDate'], $returnedDates);
+
         $slotsMonthEnd = (new \DateTimeImmutable($body['data']['slotsStartDate']))
             ->modify('last day of this month')
             ->format('Y-m-d');

--- a/zmslayout/scss/atoms/list.scss
+++ b/zmslayout/scss/atoms/list.scss
@@ -104,7 +104,7 @@ ul.list--half {
             content:            "\f061";
             display:            inline-block;
             float:              left;
-            font-family:        "Font Awesome 5 Free", "FontAwesome";
+            font-family:        "Font Awesome 7 Free", "FontAwesome";
             font-weight:        900;
             text-indent:        0;
         }

--- a/zmslayout/scss/atoms/table.scss
+++ b/zmslayout/scss/atoms/table.scss
@@ -36,7 +36,7 @@
         justify-content:        space-between;
         &::after {
             content:            "";
-            font-family:        "Font Awesome 5 Free", "FontAwesome";
+            font-family:        "Font Awesome 7 Free", "FontAwesome";
             display:            inline-block;
         }
         &.up::after {content:"\f0d8";}

--- a/zmslayout/scss/molecules/block/accordion.scss
+++ b/zmslayout/scss/molecules/block/accordion.scss
@@ -104,7 +104,7 @@ $activeTriggerBGColor:              lighten($color-object-panel, 5%);
         outline-offset:         -3px;
     }
     &:after {
-        font-family:            "Font Awesome 5 Free", "FontAwesome";
+        font-family:            "Font Awesome 7 Free", "FontAwesome";
         content:                "\f107";
         font-weight:            900;
         font-size:              1.3em;

--- a/zmslayout/scss/molecules/form/form.scss
+++ b/zmslayout/scss/molecules/form/form.scss
@@ -370,7 +370,7 @@ button, input, optgroup, select, textarea {
     &::after {
         z-index:            0; // icon has to be under the input to not block mouseclick
         content:            "\f073";
-        font-family:        "Font Awesome 5 Free", "FontAwesome";
+        font-family:        "Font Awesome 7 Free", "FontAwesome";
         display:            block;
         @include getRem('height', $formInputHeightPx);
         position:           absolute;

--- a/zmslayout/scss/molecules/navigation/breadcrumb.scss
+++ b/zmslayout/scss/molecules/navigation/breadcrumb.scss
@@ -16,7 +16,7 @@
             &::before {
                 color:          $color-blue;
                 content:        "\f054";
-                font-family:    "Font Awesome 5 Free", "FontAwesome";
+                font-family:    "Font Awesome 7 Free", "FontAwesome";
                 font-size:      0.65em;
                 margin:         0 0.5em 0 0;
                 width:          1em;

--- a/zmslayout/scss/molecules/navigation/navigation-primary.scss
+++ b/zmslayout/scss/molecules/navigation/navigation-primary.scss
@@ -125,7 +125,7 @@ $NavigationPrimaryBGColor: $color-white !default;
                     content:        "\f078";
                     float:          right;
                     display:        inline-block;
-                    font-family:    "Font Awesome 5 Free", "FontAwesome";
+                    font-family:    "Font Awesome 7 Free", "FontAwesome";
                     font-weight:    900;
                     font-size:      1.3em;
                 }

--- a/zmslayout/scss/themes/zms/accessibility.scss
+++ b/zmslayout/scss/themes/zms/accessibility.scss
@@ -90,7 +90,7 @@
                     content:        "\f078";
                     float:          right;
                     display:        inline-block;
-                    font-family:    "Font Awesome 5 Free", "FontAwesome";
+                    font-family:    "Font Awesome 7 Free", "FontAwesome";
                     font-weight:    900;
                     font-size:      1.3em;
                 }


### PR DESCRIPTION
## Summary
- Snap `available-calendar` free-slot + painted month to the first bookable day when Vorlauf leaves today empty (e.g. first bookable day in the next month), so citizen UI no longer gets `availableDays: []`.
- Update CSS `::after` icon `font-family` from `"Font Awesome 5 Free"` to `"Font Awesome 7 Free"` so availability accordion open/close chevrons render again after the FA7 upgrade.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [ ] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar availability now automatically advances to the first bookable date when no availability exists in the requested month.
  * Slot ranges and available-day results are recalculated to match the earliest available date.

* **Style**
  * Updated interface icons, navigation indicators, breadcrumbs, accordions, tables, and datepicker controls to use the latest Font Awesome font with fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->