### PR TITLE
feat(ZMSKVR-1536): teaser for video and phone appointments

### DIFF
--- a/zmscitizenview/src/components/AppointmentOverview/AppointmentCard.vue
+++ b/zmscitizenview/src/components/AppointmentOverview/AppointmentCard.vue
@@ -1,7 +1,7 @@
 <template>
   <muc-card
     class="multiline-text"
-    :tagline="t('appointment')"
+    :tagline="appointmentTypeLabel"
     :title="formatMultilineTitle(appointment)"
     :href="getAppointmentLink()"
   >
@@ -17,10 +17,12 @@
         {{ formatAppointmentDateTime(appointment.timestamp) }}
         {{ t("timeStampSuffix") }} <br />
       </p>
-      <p class="m-teaser-contained-contact__detail">
-        <muc-icon icon="map-pin" />
-        {{ selectedProvider?.address.street }}
-        {{ selectedProvider?.address.house_number }} <br />
+      <p
+        data-test="appointment-location"
+        class="m-teaser-contained-contact__detail"
+      >
+        <muc-icon :icon="locationIcon" />
+        {{ locationText }}
       </p>
       <strong>{{ t("appointmentNumber") }}:</strong>
       {{ appointment.displayNumber ?? appointment.processId }}
@@ -30,15 +32,19 @@
 
 <script setup lang="ts">
 import { MucCard, MucIcon } from "@muenchen/muc-patternlab-vue";
-import { onMounted, ref } from "vue";
+import { computed } from "vue";
 
 import { AppointmentDTO } from "@/api/models/AppointmentDTO";
 import { Office } from "@/api/models/Office";
+import { Service } from "@/api/models/Service";
 import CalendarIcon from "@/components/Common/CalendarIcon.vue";
 import {
   QUERY_PARAM_APPOINTMENT_DISPLAY_NUMBER,
   QUERY_PARAM_APPOINTMENT_ID,
   resolveAgainstCurrentPage,
+  VARIANT_ID_PRESENCE,
+  VARIANT_ID_TELEPHONE,
+  VARIANT_ID_VIDEO,
 } from "@/utils/Constants";
 import { formatAppointmentDateTime } from "@/utils/formatAppointmentDateTime";
 import { formatMultilineTitle } from "@/utils/formatMultilineTitle";
@@ -47,10 +53,66 @@ const props = defineProps<{
   appointment: AppointmentDTO;
   appointmentDetailUrl: string;
   offices: Office[];
+  services: Service[];
   t: (key: string) => string;
 }>();
 
-const selectedProvider = ref<Office>();
+const selectedProvider = computed<Office | undefined>(() =>
+  props.offices.find(
+    (office) => String(office.id) === String(props.appointment.officeId)
+  )
+);
+
+const selectedService = computed<Service | undefined>(() =>
+  props.services.find(
+    (service) => String(service.id) === String(props.appointment.serviceId)
+  )
+);
+
+const variantId = computed<number | null>(
+  () => selectedService.value?.variantId ?? null
+);
+
+const appointmentTypeLabel = computed<string>(() => {
+  if (variantId.value === VARIANT_ID_TELEPHONE) {
+    return props.t(`appointmentTypes.${VARIANT_ID_TELEPHONE}`);
+  }
+
+  if (variantId.value === VARIANT_ID_VIDEO) {
+    return props.t(`appointmentTypes.${VARIANT_ID_VIDEO}`);
+  }
+
+  return props.t(`appointmentTypes.${VARIANT_ID_PRESENCE}`);
+});
+
+const locationIcon = computed<string>(() => {
+  if (variantId.value === VARIANT_ID_TELEPHONE) {
+    return "telephone";
+  }
+
+  if (variantId.value === VARIANT_ID_VIDEO) {
+    return "video-camera";
+  }
+
+  return "map-pin";
+});
+
+const locationText = computed<string>(() => {
+  if (variantId.value === VARIANT_ID_TELEPHONE) {
+    return props.appointment.telephone ?? "";
+  }
+
+  if (variantId.value === VARIANT_ID_VIDEO) {
+    return props.t("appointmentDetailVideoIntroLocation");
+  }
+
+  return [
+    selectedProvider.value?.address.street,
+    selectedProvider.value?.address.house_number,
+  ]
+    .filter(Boolean)
+    .join(" ");
+});
 
 const getAppointmentLink = () => {
   const url = resolveAgainstCurrentPage(props.appointmentDetailUrl);
@@ -66,16 +128,6 @@ const getAppointmentLink = () => {
   }
   return url.toString();
 };
-
-onMounted(() => {
-  const foundOffice = props.offices.find(
-    (office) => office.id == props.appointment.officeId
-  );
-
-  if (foundOffice) {
-    selectedProvider.value = foundOffice;
-  }
-});
 </script>
 
 <style scoped>

--- a/zmscitizenview/src/components/AppointmentOverview/AppointmentCardViewer.vue
+++ b/zmscitizenview/src/components/AppointmentOverview/AppointmentCardViewer.vue
@@ -23,6 +23,7 @@
           :appointment="appointment"
           :appointment-detail-url="appointmentDetailUrl"
           :offices="offices"
+          :services="services"
           :class="{ 'card-color': displayedOnDetailScreen }"
           class="mobile-card-height"
           :t="t"
@@ -53,6 +54,7 @@
           :appointment="appointment"
           :appointment-detail-url="appointmentDetailUrl"
           :offices="offices"
+          :services="services"
           :class="{ 'card-color': displayedOnDetailScreen }"
           class="mobile-card-height"
           :t="t"
@@ -68,6 +70,7 @@
         :appointment="appointment"
         :appointment-detail-url="appointmentDetailUrl"
         :offices="offices"
+        :services="services"
         :class="{ 'card-color': displayedOnDetailScreen }"
         :t="t"
       />
@@ -89,6 +92,7 @@
         :appointment="appointment"
         :appointment-detail-url="appointmentDetailUrl"
         :offices="offices"
+        :services="services"
         :class="{ 'card-color': displayedOnDetailScreen }"
         :t="t"
       />
@@ -105,6 +109,7 @@ import {
 
 import { AppointmentDTO } from "@/api/models/AppointmentDTO";
 import { Office } from "@/api/models/Office";
+import { Service } from "@/api/models/Service";
 import AddAppointmentCard from "@/components/AppointmentOverview/AddAppointmentCard.vue";
 import AddAppointmentSvg from "@/components/AppointmentOverview/AddAppointmentSvg.vue";
 import AppointmentCard from "@/components/AppointmentOverview/AppointmentCard.vue";
@@ -117,6 +122,7 @@ defineProps<{
   appointmentDetailUrl: string;
   displayedOnDetailScreen: boolean;
   offices: Office[];
+  services: Service[];
   t: (key: string) => string;
 }>();
 </script>

--- a/zmscitizenview/src/components/AppointmentOverview/AppointmentOverviewView.vue
+++ b/zmscitizenview/src/components/AppointmentOverview/AppointmentOverviewView.vue
@@ -200,7 +200,7 @@ onMounted(() => {
       );
 
       offices.value = data.offices;
-      services.value = data.services;
+      services.value = data.services ?? [];
       getMyAppointments(props.globalState).then((data) => {
         if (
           Array.isArray(data) &&

--- a/zmscitizenview/src/components/AppointmentOverview/AppointmentOverviewView.vue
+++ b/zmscitizenview/src/components/AppointmentOverview/AppointmentOverviewView.vue
@@ -102,6 +102,7 @@
           :appointment="appointment"
           :appointment-detail-url="appointmentDetailUrl"
           :offices="offices"
+          :services="services"
           :t="t"
         >
         </appointment-card>
@@ -129,6 +130,7 @@ import { computed, onMounted, ref } from "vue";
 
 import { AppointmentDTO } from "@/api/models/AppointmentDTO";
 import { Office } from "@/api/models/Office";
+import { Service } from "@/api/models/Service";
 import { fetchServicesAndProviders } from "@/api/ZMSAppointmentAPI";
 import { getMyAppointments } from "@/api/ZMSAppointmentUserAPI";
 import AddAppointmentCard from "@/components/AppointmentOverview/AddAppointmentCard.vue";
@@ -158,6 +160,7 @@ const props = defineProps<{
 
 const appointments = ref<AppointmentDTO[]>([]);
 const offices = ref<Office[]>([]);
+const services = ref<Service[]>([]);
 const loading = ref(true);
 const loadingError = ref(false);
 
@@ -197,6 +200,7 @@ onMounted(() => {
       );
 
       offices.value = data.offices;
+      services.value = data.services;
       getMyAppointments(props.globalState).then((data) => {
         if (
           Array.isArray(data) &&

--- a/zmscitizenview/src/components/AppointmentOverview/AppointmentSliderView.vue
+++ b/zmscitizenview/src/components/AppointmentOverview/AppointmentSliderView.vue
@@ -116,6 +116,7 @@
             :appointment-detail-url="appointmentDetailUrl"
             :displayed-on-detail-screen="displayedOnDetailScreen"
             :offices="offices"
+            :services="services"
             :t="t"
           />
           <muc-link
@@ -139,6 +140,7 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import { AppointmentDTO } from "@/api/models/AppointmentDTO";
 import { Office } from "@/api/models/Office";
+import { Service } from "@/api/models/Service";
 import { fetchServicesAndProviders } from "@/api/ZMSAppointmentAPI";
 import { getMyAppointments } from "@/api/ZMSAppointmentUserAPI";
 import ErrorAlert from "@/components/Common/ErrorAlert.vue";
@@ -173,6 +175,7 @@ const resizeSliderContent = ref(false);
 
 const appointments = ref<AppointmentDTO[]>([]);
 const offices = ref<Office[]>([]);
+const services = ref<Service[]>([]);
 
 // API status state
 const isInMaintenanceModeComputed = computed(() => isInMaintenanceMode());
@@ -214,6 +217,7 @@ onMounted(() => {
       );
 
       offices.value = data.offices;
+      services.value = data.services;
       getMyAppointments(props.globalState).then((data) => {
         if (
           Array.isArray(data) &&

--- a/zmscitizenview/src/components/AppointmentOverview/AppointmentSliderView.vue
+++ b/zmscitizenview/src/components/AppointmentOverview/AppointmentSliderView.vue
@@ -217,7 +217,7 @@ onMounted(() => {
       );
 
       offices.value = data.offices;
-      services.value = data.services;
+      services.value = data.services ?? [];
       getMyAppointments(props.globalState).then((data) => {
         if (
           Array.isArray(data) &&

--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -149,6 +149,7 @@
   "appointment": "Termin",
   "appointmentBookingErrorHeader": "Aktivierung fehlgeschlagen",
   "appointmentBookingErrorText": "Aktivierung fehlgeschlagen",
+  "appointmentDetailVideoIntroLocation": "Webex (Online-Meeting)",
   "appointmentHintHeader": "Hinweis zu Ihrem Termin",
   "appointmentNumber": "Terminnummer",
   "appointmentSuccessfullyBookedHeader": "Ihr Termin wurde gebucht.",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -145,6 +145,7 @@
   "appointment": "Appointment",
   "appointmentBookingErrorHeader": "Activation failed.",
   "appointmentBookingErrorText": "Activation failed.",
+  "appointmentDetailVideoIntroLocation": "Webex (online meeting)",
   "appointmentSuccessfullyBookedHeader": " Your appointment has been booked.",
   "appointmentSuccessfullyBookedText": "You will receive confirmation and further information about your appointment by e-mail. We look forward to your visit.",
   "appointmentSuccessfullyCanceledHeader": "You have successfully cancelled your appointment.",

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCard.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCard.spec.ts
@@ -5,6 +5,18 @@ import de from '@/utils/de-DE.json';
 import AppointmentCard from "@/components/AppointmentOverview/AppointmentCard.vue";
 
 describe("AppointmentCard", () => {
+  const translate = (key: string): string => {
+    const value = key.split(".").reduce<unknown>((current, part) => {
+      if (typeof current !== "object" || current === null) {
+        return undefined;
+      }
+
+      return (current as Record<string, unknown>)[part];
+    }, de);
+
+    return typeof value === "string" ? value : key;
+  };
+
   const mockAppointmentDetailUrl = "https://www.muenchen.de/appointment-detail";
 
   const mockAppointment =
@@ -41,7 +53,8 @@ describe("AppointmentCard", () => {
         ],
       };
 
-  const mockProvider = {
+  const mockProvider =
+    {
       id: "1",
       name: "Rathaus Marienplatz",
       address: {
@@ -50,23 +63,32 @@ describe("AppointmentCard", () => {
       },
     };
 
+  const createMockService = (
+    id: string,
+    variantId: number | null
+  ) => ({
+    id,
+    name: "Personalausweis",
+    maxQuantity: 1,
+    parentId: null,
+    variantId,
+  });
+
   const createWrapper = (props = {}, appointment: any) => {
     return mount(AppointmentCard, {
       props: {
         appointment: appointment,
         appointmentDetailUrl: mockAppointmentDetailUrl,
         offices: [],
-        t: (key: string) => {
-          const translations = de as any;
-          return translations[key] || key;
-        },
-
+        services: [],
+        t: translate,
         ...props,
       },
       global: {
         stubs: {
           'muc-icon': {
-            template: "<div data-test='muc-icon'></div>",
+            template:
+              "<span data-test='muc-icon' :data-icon='icon'></span>",
             props: ["icon"],
           },
           'muc-card': {
@@ -87,7 +109,7 @@ describe("AppointmentCard", () => {
     await nextTick();
 
     expect(wrapper.find('[data-test="muc-card"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="muc-card"]').attributes('tagline')).toBe(de.appointment);
+    expect(wrapper.find('[data-test="muc-card"]').attributes('tagline')).toBe(de.appointmentTypes["1"]);
     expect(wrapper.find('[data-test="muc-card"]').attributes('title')).toBe(wrapper.vm.formatMultilineTitle(mockAppointment));
     expect(wrapper.find('.multiline-text').exists()).toBe(true);
     expect(wrapper.text()).toContain(mockProvider.address.street);
@@ -99,10 +121,116 @@ describe("AppointmentCard", () => {
     await nextTick();
 
     expect(wrapper.find('[data-test="muc-card"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="muc-card"]').attributes('tagline')).toBe('Termin');
+    expect(wrapper.find('[data-test="muc-card"]').attributes('tagline')).toBe(de.appointmentTypes["1"]);
     expect(wrapper.find('[data-test="muc-card"]').attributes('title')).toBe(wrapper.vm.formatMultilineTitle(mockAppointmentSubServices));
     expect(wrapper.find('.multiline-text').exists()).toBe(true);
     expect(wrapper.text()).toContain(mockProvider.address.street);
     expect(wrapper.text()).toContain(mockProvider.address.house_number);
   });
+
+  it("renders telephone appointment card", async () => {
+    const appointment = {
+      ...mockAppointment,
+      serviceId: "telephone-service",
+    };
+
+    const wrapper = createWrapper(
+      {
+        offices: [mockProvider],
+        services: [createMockService("telephone-service", 2)],
+      },
+      appointment
+    );
+
+    await nextTick();
+
+    expect(
+      wrapper.find('[data-test="muc-card"]').attributes("tagline")
+    ).toBe(de.appointmentTypes["2"]);
+
+    const location = wrapper.find(
+      '[data-test="appointment-location"]'
+    );
+
+    expect(
+      location.find('[data-test="muc-icon"]').attributes("data-icon")
+    ).toBe("telephone");
+
+    expect(location.text()).toContain(mockAppointment.telephone);
+    expect(location.text()).not.toContain(mockProvider.address.street);
+  });
+
+  it("renders video appointment card", async () => {
+    const appointment = {
+      ...mockAppointment,
+      serviceId: "video-service",
+    };
+
+    const wrapper = createWrapper(
+      {
+        offices: [mockProvider],
+        services: [createMockService("video-service", 3)],
+      },
+      appointment
+    );
+
+    await nextTick();
+
+    expect(
+      wrapper.find('[data-test="muc-card"]').attributes("tagline")
+    ).toBe(de.appointmentTypes["3"]);
+
+    const location = wrapper.find(
+      '[data-test="appointment-location"]'
+    );
+
+    expect(
+      location.find('[data-test="muc-icon"]').attributes("data-icon")
+    ).toBe("video-camera");
+
+    expect(location.text()).toContain(
+      de.appointmentDetailVideoIntroLocation
+    );
+
+    expect(location.text()).not.toContain(mockProvider.address.street);
+  });
+
+  it.each([null, 1, 4, 5, 6, 7])(
+    "renders variant %s as presence appointment",
+    async (variantId) => {
+      const serviceId = `service-${variantId}`;
+
+      const appointment = {
+        ...mockAppointment,
+        serviceId,
+      };
+
+      const wrapper = createWrapper(
+        {
+          offices: [mockProvider],
+          services: [createMockService(serviceId, variantId)],
+        },
+        appointment
+      );
+
+      await nextTick();
+
+      expect(
+        wrapper.find('[data-test="muc-card"]').attributes("tagline")
+      ).toBe(de.appointmentTypes["1"]);
+
+      const location = wrapper.find(
+        '[data-test="appointment-location"]'
+      );
+
+      expect(
+        location.find('[data-test="muc-icon"]').attributes("data-icon")
+      ).toBe("map-pin");
+
+      expect(location.text()).toContain(mockProvider.address.street);
+      expect(location.text()).toContain(
+        mockProvider.address.house_number
+      );
+    }
+  );
 });

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCardViewer.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentCardViewer.spec.ts
@@ -61,6 +61,7 @@ describe("AppointmentCardViewer", () => {
         appointmentDetailUrl: mockAppointmentDetailUrl,
         displayedOnDetailScreen: false,
         offices: [],
+        services: [],
         t: (key: string) => {
           const translations = de as any;
           return translations[key] || key;
@@ -80,7 +81,7 @@ describe("AppointmentCardViewer", () => {
           },
           'appointment-card': {
             template: "<div data-test='appointment-card'></div>",
-            props: ["appointment", "appointmentDetailUrl", "offices", "t"],
+            props: ["appointment", "appointmentDetailUrl", "offices", "services", "t"],
           },
           'add-appointment-card': {
             template: "<div data-test='add-appointment-card'><slot name='content'></slot></div>",

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentOverviewView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentOverviewView.spec.ts
@@ -13,6 +13,8 @@ describe("AppointmentOverviewView", () => {
       status: 200,
       json: async () => ({
         offices: [],
+        services: [],
+        relations: [],
       }),
     }));
   });
@@ -62,7 +64,7 @@ describe("AppointmentOverviewView", () => {
         stubs: {
           'appointment-card': {
             template: "<div data-test='appointment-card'></div>",
-            props: ["appointment", "appointmentDetailUrl", "offices", "t"],
+            props: ["appointment", "appointmentDetailUrl", "offices", "services", "t"],
           },
           'error-alert': {
             template: "<div data-test='error-alert'></div>",

--- a/zmscitizenview/tests/unit/AppointmentOverview/AppointmentSliderView.spec.ts
+++ b/zmscitizenview/tests/unit/AppointmentOverview/AppointmentSliderView.spec.ts
@@ -13,6 +13,8 @@ describe("AppointmentOverviewView", () => {
       status: 200,
       json: async () => ({
         offices: [],
+        services: [],
+        relations: [],
       }),
     }));
     vi.stubGlobal("matchMedia", vi.fn(() => {
@@ -112,6 +114,7 @@ describe("AppointmentOverviewView", () => {
               "appointmentDetailUrl",
               "displayedOnDetailScreen",
               "offices",
+              "services",
               "t"
             ],
           },


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appointment cards now display appointment-specific labels, icons, and location details for telephone, video, and in-person appointments.
  * Video appointments identify Webex as the online meeting location.
  * Location information now reflects the selected service and office.

* **Localization**
  * Added English and German translations for the video appointment location.

* **Tests**
  * Expanded coverage for appointment types, translated labels, icons, contact details, and addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->