### PR TITLE
fix(ZMSKVR-1201): prevent ProcessReserve slot deadlocks

### DIFF
--- a/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusFree.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusFree.php
@@ -361,7 +361,9 @@ class ProcessStatusFree extends Process
             try {
                 $connection->rollBack();
             } catch (\PDOException $exception) {
-                // Transaction may already have been rolled back by the server.
+                \App::$log->warning('Rollback after deadlock failed', [
+                    'error' => $exception->getMessage(),
+                ]);
             }
         }
         if (!$connection->inTransaction()) {

--- a/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusFree.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusFree.php
@@ -290,6 +290,37 @@ class ProcessStatusFree extends Process
         $resolveReferences = 0,
         $userAccount = null
     ) {
+        $maxAttempts = 3;
+        $attempt = 0;
+        while (true) {
+            try {
+                return $this->writeEntityReservedAttempt(
+                    $process,
+                    $now,
+                    $slotType,
+                    $slotsRequired,
+                    $resolveReferences,
+                    $userAccount
+                );
+            } catch (\BO\Zmsbackend\Exception\Pdo\DeadLockFound $exception) {
+                $attempt++;
+                if ($attempt >= $maxAttempts) {
+                    throw $exception;
+                }
+                $this->resetWriteTransactionAfterDeadlock();
+                usleep(50000 * $attempt);
+            }
+        }
+    }
+
+    protected function writeEntityReservedAttempt(
+        \BO\Zmsentities\Process $process,
+        \DateTimeInterface $now,
+        $slotType = "public",
+        $slotsRequired = 0,
+        $resolveReferences = 0,
+        $userAccount = null
+    ) {
         $process = clone $process;
         $process->status = 'reserved';
         $appointment = $process->getAppointments()->getFirst();
@@ -318,5 +349,23 @@ class ProcessStatusFree extends Process
         }
         $this->writeRequestsToDb($process);
         return $this->readEntity($process->getId(), new \BO\Zmsbackend\Helper\NoAuth(), $resolveReferences);
+    }
+
+    /**
+     * After InnoDB aborts a transaction on deadlock, clear PDO state and start a fresh transaction.
+     */
+    protected function resetWriteTransactionAfterDeadlock(): void
+    {
+        $connection = \BO\Zmsbackend\Connection\Select::getWriteConnection();
+        if ($connection->inTransaction()) {
+            try {
+                $connection->rollBack();
+            } catch (\PDOException $exception) {
+                // Transaction may already have been rolled back by the server.
+            }
+        }
+        if (!$connection->inTransaction()) {
+            $connection->beginTransaction();
+        }
     }
 }

--- a/zmsbackend/src/Zmsbackend/Slot/Repository/Slot.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Repository/Slot.php
@@ -178,6 +178,23 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
     LIMIT 1
 ';
 
+    /**
+     * Lock multiple appointment slots in one statement.
+     * Placeholders for time IN (...) are injected by Slot::lockSlotsForAppointment.
+     * ORDER BY slotID prefers a deterministic primary-key lock order.
+     */
+    const QUERY_SELECT_SLOTS_FOR_UPDATE = '
+    SELECT slotID FROM slot WHERE
+      scopeID = ?
+      AND availabilityID = ?
+      AND year = ?
+      AND month = ?
+      AND day = ?
+      AND time IN (%s)
+    ORDER BY slotID ASC
+    FOR UPDATE
+';
+
     const QUERY_INSERT_ANCESTOR = '
     INSERT INTO slot_hiera SET slotID = :slotID, ancestorID = :ancestorID, ancestorLevel = :ancestorLevel
 ';

--- a/zmsbackend/src/Zmsbackend/Slot/Service/Slot.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Service/Slot.php
@@ -39,8 +39,13 @@ class Slot extends \BO\Zmsbackend\Base
             $appointment->slotCount = ($overwriteSlotsCount >= 1) ? $overwriteSlotsCount : 1;
         }
         $slotList = $availability->getSlotList()->withSlotsForAppointment($appointment, $extendSlotList);
-        foreach ($slotList as $slot) {
-            $this->readByAvailability($slot, $availability, $appointment->toDateTime(), $lockSlots);
+        if ($lockSlots && count($slotList) > 0) {
+            // One FOR UPDATE for all slots avoids row-by-row lock interleaving (deadlocks with calculateSlots).
+            $this->lockSlotsForAppointment($slotList, $availability, $appointment->toDateTime());
+        } else {
+            foreach ($slotList as $slot) {
+                $this->readByAvailability($slot, $availability, $appointment->toDateTime(), false);
+            }
         }
         return $slotList;
     }
@@ -67,6 +72,42 @@ class Slot extends \BO\Zmsbackend\Base
             $data
         );
         return $slotID ? $slotID['slotID'] : false ;
+    }
+
+    /**
+     * Lock all slots required for an appointment in a single SELECT ... FOR UPDATE.
+     * Uses ORDER BY slotID ASC so lock acquisition prefers primary-key order.
+     */
+    protected function lockSlotsForAppointment(
+        Collection $slotList,
+        AvailabilityEntity $availability,
+        \DateTimeInterface $date
+    ): void {
+        $times = [];
+        foreach ($slotList as $slot) {
+            $times[] = $slot->getTimeString();
+        }
+        $times = array_values(array_unique($times));
+        if ($times === []) {
+            return;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($times), '?'));
+        $sql = sprintf(
+            \BO\Zmsbackend\Slot\Repository\Slot::QUERY_SELECT_SLOTS_FOR_UPDATE,
+            $placeholders
+        );
+        $params = array_merge(
+            [
+                $availability->scope->id,
+                $availability->id,
+                $date->format('Y'),
+                $date->format('m'),
+                $date->format('d'),
+            ],
+            $times
+        );
+        $this->fetchAll($sql, $params);
     }
 
     public function hasScopeRelevantChanges(


### PR DESCRIPTION
## Summary
- Lock all appointment slots in one `SELECT … FOR UPDATE` (`ORDER BY slotID`) instead of per-slot locks in `Slot::readByAppointment`, so reserves no longer interleave row locks with minutly/calculateSlots rebuilds.
- Retry `ProcessStatusFree::writeEntityReserved` up to 3 times on `DeadLockFound` after resetting the aborted write transaction.
- Reproduced locally via forced availability rebuild + concurrent multi-slot `POST /process/status/reserved/`; same race after the fix produced 0 API deadlocks.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

## Test plan
- [ ] Unit/API tests for reserve still pass (`zmsbackend` Process/Slot related suites)
- [ ] Manual: bump `oeffnungszeit.version`, run `./cron/cronjob.minutly` while flooding multi-slot reserves on the same scope — expect no `DeadLockFound` / `[API] Fatal Exception` deadlock lines
- [ ] Confirm normal single/multi-slot reserve still succeeds when slots are free
- [ ] Confirm competing reserves still fail with `ProcessReserveFailed` (contention), not 500 deadlocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appointment slot handling by locking all relevant slots together, helping prevent conflicting reservations.
  * Added automatic retries for reservation attempts affected by temporary database deadlocks.
  * Enhanced transaction recovery during failed reservation operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->