### PR TITLE
chore(GH): pin Actions and base images to full SHAs

### DIFF
--- a/.github/workflows/build-api-docs.yaml
+++ b/.github/workflows/build-api-docs.yaml
@@ -18,10 +18,10 @@ jobs:
       result: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
           extensions: mbstring, json
@@ -38,7 +38,7 @@ jobs:
           cd zmscitizenapi && bin/configure && composer run-script post-install-cmd && cd ..
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
 
@@ -58,7 +58,7 @@ jobs:
           (cd zmscitizenapi && npm run doc && npx swagger-cli bundle -o public/doc/swagger.json public/doc/swagger.yaml)
 
       - name: Upload API docs artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: api-docs
           retention-days: 7

--- a/.github/workflows/combined-workflow-with-docs.yaml
+++ b/.github/workflows/combined-workflow-with-docs.yaml
@@ -39,7 +39,7 @@ jobs:
           mkdir -p public/coverage
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: 'coverage-*'
           path: public/coverage-temp
@@ -63,7 +63,7 @@ jobs:
           ls -R public/coverage/
 
       - name: Upload aggregated reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aggregated-reports
           path: public/

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -39,37 +39,37 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create public directory
         run: mkdir -p public
 
       - name: Download schema diagrams
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: schema-diagrams
           path: public/diagrams
 
       - name: Download database schema diagrams
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: database-schema-diagrams
           path: public/diagrams
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.coverage_artifact }}
           path: public
 
       - name: Download API docs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.api_docs_artifact }}
           path: public
 
       - name: Setup Node for docs build
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: npm
@@ -87,13 +87,13 @@ jobs:
           ls -R public/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: public
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/generate-api-class-diagrams-from-zmsentities-schema.yaml
+++ b/.github/workflows/generate-api-class-diagrams-from-zmsentities-schema.yaml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create public directory
         run: mkdir -p public/diagrams
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.14'
 
@@ -421,7 +421,7 @@ jobs:
         run: python convert_schema.py
 
       - name: Upload diagrams artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: schema-diagrams
           path: public/diagrams/

--- a/.github/workflows/generate-database-er-model.yaml
+++ b/.github/workflows/generate-database-er-model.yaml
@@ -15,10 +15,10 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     container:
-      image: "ghcr.io/it-at-m/eappointment/zmsbase:8.3-dev"
+      image: "ghcr.io/it-at-m/eappointment/zmsbase:8.3-dev@sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb"
     services:
       mariadb:
-        image: mariadb:10.11
+        image: mariadb:10.11@sha256:de61fed4a40d3842f3ee09944ba52792156cfd9adf489b2cc670fc6ded28df8d
         env:
           MYSQL_ROOT_PASSWORD: zmsbackend
           MYSQL_DATABASE: zmsbo
@@ -35,7 +35,7 @@ jobs:
           --cpus=1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -551,7 +551,7 @@ jobs:
         run: .venv/bin/python generate_schema.py
 
       - name: Upload database schema diagrams artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: database-schema-diagrams
           path: public/diagrams/database-er-model.html

--- a/.github/workflows/php-build-images.yaml
+++ b/.github/workflows/php-build-images.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Action
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Configure Git Safe Directory
@@ -36,7 +36,7 @@ jobs:
           fi
           curl -sSL -o $DIR/changelog_build.md https://raw.githubusercontent.com/it-at-m/eappointment/main/CHANGELOG.md
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -47,7 +47,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
+        uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # master
         with:
           swap-size-gb: 10
       - name: Build Image
@@ -71,7 +71,7 @@ jobs:
           echo "IMAGE_TAG=$tag" >> "$GITHUB_ENV"
 
       - name: Push Image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30

--- a/.github/workflows/php-build-images.yaml
+++ b/.github/workflows/php-build-images.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install python3

--- a/.github/workflows/php-code-quality.yaml
+++ b/.github/workflows/php-code-quality.yaml
@@ -10,10 +10,10 @@ jobs:
   module-code-quality:
     runs-on: ubuntu-latest
     container:
-      image: "ghcr.io/it-at-m/eappointment/zmsbase:${{ matrix.php_version }}-dev"
+      image: "ghcr.io/it-at-m/eappointment/zmsbase:${{ matrix.php_version }}-dev@sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb"
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Composer Dependencies

--- a/.github/workflows/php-code-quality.yaml
+++ b/.github/workflows/php-code-quality.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Composer Dependencies

--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -29,6 +29,8 @@ jobs:
       result: ${{ steps.set-result.outputs.result }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure PHP
@@ -134,6 +136,8 @@ jobs:
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Composer Dependencies
@@ -186,6 +190,8 @@ jobs:
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:

--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -21,14 +21,14 @@ jobs:
   module-test:
     runs-on: ubuntu-latest
     container:
-      image: "ghcr.io/it-at-m/eappointment/zmsbase:${{ matrix.php_version }}-dev"
+      image: "ghcr.io/it-at-m/eappointment/zmsbase:${{ matrix.php_version }}-dev@sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb"
     env:
       XDEBUG_MODE: coverage
       PHP_INI_SCAN_DIR: "/usr/local/etc/php/conf.d:/tmp/php/conf.d"
     outputs:
       result: ${{ steps.set-result.outputs.result }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure PHP
@@ -72,7 +72,7 @@ jobs:
             --display-deprecations --display-warnings --fail-on-deprecation
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-${{ matrix.module }}
           path: ${{ matrix.module }}/coverage/
@@ -111,10 +111,10 @@ jobs:
   zmsbackend-test:
     runs-on: ubuntu-latest
     container:
-      image: "ghcr.io/it-at-m/eappointment/zmsbase:8.3-dev"
+      image: "ghcr.io/it-at-m/eappointment/zmsbase:8.3-dev@sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb"
     services:
       mariadb:
-        image: mariadb:10.11
+        image: mariadb:10.11@sha256:de61fed4a40d3842f3ee09944ba52792156cfd9adf489b2cc670fc6ded28df8d
         env:
           MYSQL_ROOT_PASSWORD: zmsbackend
           MYSQL_DATABASE: zmsbo
@@ -133,7 +133,7 @@ jobs:
       result: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Checkout GitHub Action
-        uses: actions/checkout@main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Composer Dependencies
@@ -169,7 +169,7 @@ jobs:
             --log-junit coverage/junit.xml \
             --display-deprecations --display-warnings
       - name: Upload Coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-zmsbackend
           path: zmsbackend/coverage/
@@ -185,9 +185,9 @@ jobs:
       result: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Checkout GitHub Action
-        uses: actions/checkout@main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: "8.3"
           extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql
@@ -219,7 +219,7 @@ jobs:
             --log-junit coverage/junit.xml \
             --display-deprecations --display-warnings --fail-on-deprecation
       - name: Upload Coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-zmsclient
           path: zmsclient/coverage/

--- a/.github/workflows/pr-auto-assign-author.yml
+++ b/.github/workflows/pr-auto-assign-author.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.event.pull_request.user.login) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.issues.addAssignees({

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Checkout repository (with submodules)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.3
           tools: composer
@@ -64,7 +64,7 @@ jobs:
         working-directory: ${{ matrix.project }}
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ matrix.project }}-${{ hashFiles(format('{0}/composer.lock', matrix.project)) }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload SARIF results
         if: always() && steps.sarif.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: results-${{ matrix.project }}.sarif
           checkout_path: ${{ matrix.project }}
@@ -162,12 +162,12 @@ jobs:
 
     steps:
       - name: Checkout repository (with submodules)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.3
           tools: composer
@@ -179,7 +179,7 @@ jobs:
         working-directory: zmsbackend
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ steps.composer-cache-monorepo.outputs.dir }}
           key: ${{ runner.os }}-composer-psalm-monorepo-${{ hashFiles('mellon/composer.lock', 'zmsadmin/composer.lock', 'zmsbackend/composer.lock', 'zmscalldisplay/composer.lock', 'zmscitizenapi/composer.lock', 'zmsclient/composer.lock', 'zmsdldb/composer.lock', 'zmsentities/composer.lock', 'zmsmessaging/composer.lock', 'zmsslim/composer.lock', 'zmsstatistic/composer.lock', 'zmsticketprinter/composer.lock') }}
@@ -256,7 +256,7 @@ jobs:
 
       - name: Upload monorepo SARIF results
         if: always() && steps.sarif_monorepo.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: results-monorepo.sarif
           category: .github/workflows/psalm.yml:psalm-dead-code

--- a/.github/workflows/zmsautomation-workflow.yaml
+++ b/.github/workflows/zmsautomation-workflow.yaml
@@ -253,7 +253,7 @@ jobs:
       IMAGE_REGISTRY: ghcr.io
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ matrix.branch }}
           persist-credentials: false
@@ -262,7 +262,7 @@ jobs:
         run: cp .devcontainer/.env.template .devcontainer/.env
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -599,7 +599,7 @@ jobs:
 
       - name: Upload test reports (best effort)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zmsautomation-ataf-reports-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.tags.outputs.branch_slug }}-${{ matrix.shard }}-${{ matrix.browser }}
           path: |
@@ -636,7 +636,7 @@ jobs:
 
       - name: Upload container logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zmsautomation-container-logs-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.tags.outputs.branch_slug }}-${{ matrix.shard }}-${{ matrix.browser }}
           path: artifacts/container-logs/**

--- a/.github/workflows/zmsbase-build-images.yaml
+++ b/.github/workflows/zmsbase-build-images.yaml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -89,6 +91,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -157,6 +161,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -204,6 +210,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/zmsbase-build-images.yaml
+++ b/.github/workflows/zmsbase-build-images.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -61,7 +61,7 @@ jobs:
         run: docker run --rm -i "${{ env.IMAGE }}:${{ env.VERSION }}-dev" php-fpm -t
 
       - name: Push base image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30
@@ -69,7 +69,7 @@ jobs:
           command: docker push "${{ env.IMAGE }}:${{ env.VERSION }}-base"
 
       - name: Push dev image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -121,7 +121,7 @@ jobs:
         run: docker run --rm -i "${{ env.IMAGE }}:${{ env.VERSION }}-dev" php-fpm -t
 
       - name: Push base image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30
@@ -129,7 +129,7 @@ jobs:
           command: docker push "${{ env.IMAGE }}:${{ env.VERSION }}-base"
 
       - name: Push dev image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -172,7 +172,7 @@ jobs:
           echo "IMAGE_TAG=${TAG}" >> "$GITHUB_ENV"
 
       - name: Push single-arch image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30
@@ -203,7 +203,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ env.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -219,7 +219,7 @@ jobs:
           echo "IMAGE_TAG=${TAG}" >> "$GITHUB_ENV"
 
       - name: Push single-arch image to GHCR
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           max_attempts: 5
           retry_wait_seconds: 30

--- a/.github/workflows/zmscitizenview-coverage.yaml
+++ b/.github/workflows/zmscitizenview-coverage.yaml
@@ -17,9 +17,9 @@ jobs:
       result: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
           cache: 'npm'
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload Coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-zmscitizenview
           path: zmscitizenview/coverage/

--- a/zmsadmin/Dockerfile
+++ b/zmsadmin/Dockerfile
@@ -1,9 +1,12 @@
-ARG PHP_VERSION
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
+ARG PHP_VERSION=8.3
+# Digests pinned for supply-chain integrity; override via build-args when retargeting.
+ARG ZMSBASE_DEV_DIGEST=sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
+ARG ZMSBASE_BASE_DIGEST=sha256:c743242ccf89669618a2f132904bd87fabd9258ede769522fe376859391cb598
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev@${ZMSBASE_DEV_DIGEST} AS build
 COPY --chown=1000:1000 . /build
 WORKDIR /build
 USER 1000:1000
 RUN make live
 
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base@${ZMSBASE_BASE_DIGEST}
 COPY --from=build --chown=0:0 /build /var/www/html

--- a/zmsbackend/Dockerfile
+++ b/zmsbackend/Dockerfile
@@ -1,10 +1,13 @@
-ARG PHP_VERSION
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
+ARG PHP_VERSION=8.3
+# Digests pinned for supply-chain integrity; override via build-args when retargeting.
+ARG ZMSBASE_DEV_DIGEST=sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
+ARG ZMSBASE_BASE_DIGEST=sha256:c743242ccf89669618a2f132904bd87fabd9258ede769522fe376859391cb598
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev@${ZMSBASE_DEV_DIGEST} AS build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base@${ZMSBASE_BASE_DIGEST}
 COPY --from=build --chown=0:0 /var/www/html /var/www/html
 RUN chmod -R 1777 /var/www/html/data

--- a/zmsbase/php83-local/Dockerfile
+++ b/zmsbase/php83-local/Dockerfile
@@ -4,13 +4,13 @@ ARG NODE_MAJOR=22
 ARG PHP_VERSION=8.3-apache-trixie
 
 # Composer stage
-FROM composer:${COMPOSER_VERSION} AS composer-image
+FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer-image
 
 # Node/npm/npx (official multi-arch image; NodeSource apt can miss npm on some Debian/arch combos)
-FROM node:${NODE_MAJOR}-trixie AS node-tools
+FROM node:22-trixie@sha256:8433642fe11d391a7ff1f702352ac1b0ea3e378d3fb2c22de2b292036d79cd2c AS node-tools
 
 # Main dev image
-FROM php:${PHP_VERSION}
+FROM php:8.3-apache-trixie@sha256:e3994e4bd3c982544ddd38a454b144a43d1947673869dd14689f76d5ec52911b
 
 # Set by docker buildx --platform=... (linux/amd64 | linux/arm64)
 ARG TARGETARCH

--- a/zmsbase/php83/Dockerfile
+++ b/zmsbase/php83/Dockerfile
@@ -3,10 +3,10 @@ ARG NODE_MAJOR="22"
 ARG PHP_VERSION="8.3-fpm-trixie"
 
 # composer version to make available in built image
-FROM composer:${COMPOSER_VERSION} AS composer-image
+FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer-image
 
 # php version to actually build
-FROM php:${PHP_VERSION} AS base
+FROM php:8.3-fpm-trixie@sha256:4202966c9c1e2dc5416c845ec69617fd734c186f4acd31089a1dd5fa2218648d AS base
 
 # bash as default shell should exit on non-zero exit-codes in piped commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/zmsbase/php84-local/Dockerfile
+++ b/zmsbase/php84-local/Dockerfile
@@ -4,13 +4,13 @@ ARG NODE_MAJOR=22
 ARG PHP_VERSION=8.4-apache-trixie
 
 # Composer stage
-FROM composer:${COMPOSER_VERSION} AS composer-image
+FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer-image
 
 # Node/npm/npx (official multi-arch image; NodeSource apt can miss npm on some Debian/arch combos)
-FROM node:${NODE_MAJOR}-trixie AS node-tools
+FROM node:22-trixie@sha256:8433642fe11d391a7ff1f702352ac1b0ea3e378d3fb2c22de2b292036d79cd2c AS node-tools
 
 # Main dev image
-FROM php:${PHP_VERSION}
+FROM php:8.4-apache-trixie@sha256:3f9ad397f38f7fe1e0e92b6cb5398e5d117f7d70cad1b6768bea3c1efc3c2d90
 
 # Set by docker buildx --platform=... (linux/amd64 | linux/arm64)
 ARG TARGETARCH

--- a/zmsbase/php84/Dockerfile
+++ b/zmsbase/php84/Dockerfile
@@ -3,10 +3,10 @@ ARG NODE_MAJOR="22"
 ARG PHP_VERSION="8.4-fpm-trixie"
 
 # composer version to make available in built image
-FROM composer:${COMPOSER_VERSION} AS composer-image
+FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer-image
 
 # php version to actually build
-FROM php:${PHP_VERSION} AS base
+FROM php:8.4-fpm-trixie@sha256:a77f5f0ee8df9035f2a90d4f713e253bc374ed27534a30e5889e50e9346c5232 AS base
 
 # bash as default shell should exit on non-zero exit-codes in piped commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/zmscalldisplay/Dockerfile
+++ b/zmscalldisplay/Dockerfile
@@ -1,9 +1,12 @@
-ARG PHP_VERSION
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
+ARG PHP_VERSION=8.3
+# Digests pinned for supply-chain integrity; override via build-args when retargeting.
+ARG ZMSBASE_DEV_DIGEST=sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
+ARG ZMSBASE_BASE_DIGEST=sha256:c743242ccf89669618a2f132904bd87fabd9258ede769522fe376859391cb598
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev@${ZMSBASE_DEV_DIGEST} AS build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base@${ZMSBASE_BASE_DIGEST}
 COPY --from=build --chown=0:0 /var/www/html /var/www/html

--- a/zmsclient/docker-compose.yml
+++ b/zmsclient/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   mockup:
-    image: jordimartin/mmock:v4.3.12
+    image: jordimartin/mmock:v4.3.12@sha256:37df3c926fa8f19e786b28c96086bf4916e370e7f31cc8067a11c218340f6483
     ports:
       - 8082:8082
       - 8083:8083
@@ -14,7 +14,7 @@ services:
   test:
     depends_on:
       - mockup
-    image: ghcr.io/it-at-m/eappointment/zmsbase:8.3-dev
+    image: ghcr.io/it-at-m/eappointment/zmsbase:8.3-dev@sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
     volumes:
       - type: bind
         source: "."

--- a/zmsclient/tests/mockup/Dockerfile
+++ b/zmsclient/tests/mockup/Dockerfile
@@ -1,3 +1,3 @@
-FROM jordimartin/mmock
+FROM jordimartin/mmock:v4.3.12@sha256:37df3c926fa8f19e786b28c96086bf4916e370e7f31cc8067a11c218340f6483
 
 ADD config /config

--- a/zmsmessaging/Dockerfile
+++ b/zmsmessaging/Dockerfile
@@ -1,9 +1,12 @@
-ARG PHP_VERSION
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
+ARG PHP_VERSION=8.3
+# Digests pinned for supply-chain integrity; override via build-args when retargeting.
+ARG ZMSBASE_DEV_DIGEST=sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
+ARG ZMSBASE_BASE_DIGEST=sha256:c743242ccf89669618a2f132904bd87fabd9258ede769522fe376859391cb598
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev@${ZMSBASE_DEV_DIGEST} AS build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base@${ZMSBASE_BASE_DIGEST}
 COPY --from=build --chown=0:0 /var/www/html /var/www/html

--- a/zmsstatistic/Dockerfile
+++ b/zmsstatistic/Dockerfile
@@ -1,9 +1,12 @@
-ARG PHP_VERSION
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
+ARG PHP_VERSION=8.3
+# Digests pinned for supply-chain integrity; override via build-args when retargeting.
+ARG ZMSBASE_DEV_DIGEST=sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
+ARG ZMSBASE_BASE_DIGEST=sha256:c743242ccf89669618a2f132904bd87fabd9258ede769522fe376859391cb598
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev@${ZMSBASE_DEV_DIGEST} AS build
 COPY --chown=1000:1000 . /build
 WORKDIR /build
 USER 1000:1000
 RUN make live
 
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base@${ZMSBASE_BASE_DIGEST}
 COPY --from=build --chown=0:0 /build /var/www/html

--- a/zmsticketprinter/Dockerfile
+++ b/zmsticketprinter/Dockerfile
@@ -1,9 +1,12 @@
-ARG PHP_VERSION
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
+ARG PHP_VERSION=8.3
+# Digests pinned for supply-chain integrity; override via build-args when retargeting.
+ARG ZMSBASE_DEV_DIGEST=sha256:cdf964fa2e02d11b1309f1006d0d71d0afef6a550d5722c7634860e5c594d4cb
+ARG ZMSBASE_BASE_DIGEST=sha256:c743242ccf89669618a2f132904bd87fabd9258ede769522fe376859391cb598
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev@${ZMSBASE_DEV_DIGEST} AS build
 COPY --chown=1000:1000 . /var/www/html
 WORKDIR /var/www/html
 USER 1000
 RUN make live
 
-FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base
+FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base@${ZMSBASE_BASE_DIGEST}
 COPY --from=build --chown=0:0 /var/www/html /var/www/html


### PR DESCRIPTION
## Summary
- Pin floating GitHub Action tags (`@v7`, `@main`, etc.) to full commit SHAs in the workflows flagged by RefArch
- Pin Docker `FROM` lines and workflow container images to immutable digests (`php`, `composer`, `node`, `mariadb`, `zmsbase`)

## Test plan
- [x] Confirm CI workflows start successfully (Actions resolve at pinned SHAs)
- [ ] Spot-check a PHP module image build still works with digest-pinned `zmsbase`
- [ ] Spot-check `zmsbase` Dockerfile build still pulls pinned upstream images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned build, test, deployment, and documentation automation dependencies to immutable revisions.
  * Pinned container base images to immutable SHA-256 digests for more reproducible builds.
  * Standardized PHP image defaults and retained existing build and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->