### PR TITLE
chore(GH): use muc-patternlab-vue beta outside main and tags

### DIFF
--- a/.github/scripts/zmscitizenview-select-patternlab.sh
+++ b/.github/scripts/zmscitizenview-select-patternlab.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Select @muenchen/muc-patternlab-vue channel for zmscitizenview CI installs.
+#
+# - main branch and git tags  → keep the release pin from package.json / lockfile
+# - every other ref (next, feature branches, …) → npm dist-tag "beta"
+# - pull requests targeting main → keep the release pin (matches what will merge)
+#
+# Usage: .github/scripts/zmscitizenview-select-patternlab.sh [app-path]
+set -euo pipefail
+
+APP_PATH="${1:-zmscitizenview}"
+REF="${GITHUB_REF:-}"
+REF_TYPE="${GITHUB_REF_TYPE:-}"
+EVENT_NAME="${GITHUB_EVENT_NAME:-}"
+BASE_REF="${GITHUB_BASE_REF:-}"
+
+use_release=false
+if [[ "${REF}" == "refs/heads/main" || "${REF_TYPE}" == "tag" ]]; then
+  use_release=true
+fi
+if [[ "${EVENT_NAME}" == "pull_request" && "${BASE_REF}" == "main" ]]; then
+  use_release=true
+fi
+
+cd "${APP_PATH}"
+
+if [[ "${use_release}" == "true" ]]; then
+  echo "muc-patternlab-vue: keeping pinned release from package-lock (ref=${REF})"
+  exit 0
+fi
+
+echo "muc-patternlab-vue: switching to npm dist-tag beta (ref=${REF})"
+npm install @muenchen/muc-patternlab-vue@beta \
+  --package-lock-only \
+  --ignore-scripts \
+  --no-fund \
+  --no-audit
+
+# Show what the lockfile will install next (npm ci / action-npm-build).
+node -e '
+const lock = require("./package-lock.json");
+const pkg = lock.packages?.["node_modules/@muenchen/muc-patternlab-vue"];
+console.log("muc-patternlab-vue lock version:", pkg?.version ?? "(missing)");
+'

--- a/.github/workflows/zmscitizenview-coverage.yaml
+++ b/.github/workflows/zmscitizenview-coverage.yaml
@@ -25,6 +25,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: zmscitizenview/package-lock.json
 
+      # package.json keeps the stable pin for main/tags; other refs test against npm "beta".
+      - name: Select muc-patternlab-vue channel
+        run: bash .github/scripts/zmscitizenview-select-patternlab.sh zmscitizenview
+
       - name: Install dependencies
         run: |
           cd zmscitizenview

--- a/.github/workflows/zmscitizenview-maven-node-build.yaml
+++ b/.github/workflows/zmscitizenview-maven-node-build.yaml
@@ -23,6 +23,15 @@ jobs:
           - app-path: zmscitizenview
     steps:
       - uses: it-at-m/lhm_actions/action-templates/actions/action-checkout@e9a8422d740d4e9eaef25cfeeb3a5790da97a7aa # v1.2.4
+      # package.json keeps the stable pin for main/tags; other refs build against npm "beta".
+      - name: Set up Node.js (patternlab channel)
+        if: ${{ !(github.ref == 'refs/heads/main' || github.ref_type == 'tag') }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+      - name: Select muc-patternlab-vue channel
+        if: ${{ !(github.ref == 'refs/heads/main' || github.ref_type == 'tag') }}
+        run: bash .github/scripts/zmscitizenview-select-patternlab.sh "${{ matrix.app-path }}"
       - if: ${{hashFiles(format('./{0}/package.json', matrix.app-path))!=null}}
         id: node
         uses: it-at-m/lhm_actions/action-templates/actions/action-npm-build@e9a8422d740d4e9eaef25cfeeb3a5790da97a7aa # v1.2.4

--- a/zmscitizenview/package.json
+++ b/zmscitizenview/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "serve-loader-test": "npm run build && ws -o -r \"/ -> /resources/loader-test\" -r \"/dist -> ../../dist\""
   },
+  "// @muenchen/muc-patternlab-vue": "Pinned release for main/tags. CI switches to npm dist-tag beta on other branches (.github/scripts/zmscitizenview-select-patternlab.sh).",
   "dependencies": {
     "@muenchen/muc-patternlab-vue": "10.0.2",
     "altcha": "^3.2.1",


### PR DESCRIPTION
## Summary
- Keep `@muenchen/muc-patternlab-vue` pinned for **main** and **tags**
- Other refs (`next`, feature branches) CI-install npm **beta**
- PRs targeting main keep the release pin

<img width="716" height="121" alt="Screenshot 2026-08-05 at 13 24 17" src="https://github.com/user-attachments/assets/4dfcd1ce-3bc7-438e-ad08-b30d578d5953" />


## Follow-up
Merge `main` → `next` after this lands so non-prod picks up the workflow.

## Test plan
- [ ] This branch build log shows switch to `@beta`
- [ ] After merge: `main`/tag keeps pinned release
- [ ] After `main` → `next`: `next` builds beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and coverage checks to test the beta Patternlab release on non-main branches.
  * Main-branch and tagged builds continue using the stable, pinned Patternlab release.
  * Improved reporting of the Patternlab version resolved during builds.

* **Documentation**
  * Added package metadata clarifying the release pinning and branch-specific build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->