### PR TITLE
fix(ZMSKVR-1203): fetch process once on update-appointment

### DIFF
--- a/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentUpdateService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Appointment/AppointmentUpdateService.php
@@ -17,17 +17,18 @@ class AppointmentUpdateService
     {
         $clientData = $this->extractClientData($body);
 
-        $errors = $this->validateClientData($clientData, $authenticatedUser);
-        if (!empty($errors['errors'])) {
-            return $errors;
+        $validation = $this->validateClientData($clientData, $authenticatedUser);
+        if (!empty($validation['errors'])) {
+            return $validation;
         }
 
-        $reservedProcess = $this->getReservedProcess($clientData->processId, $clientData->authKey, $authenticatedUser);
-
-        $updatedProcess = $this->updateProcessWithClientData($reservedProcess, $clientData);
+        $updatedProcess = $this->updateProcessWithClientData($validation['process'], $clientData);
         return $this->saveProcessUpdate($updatedProcess, $authenticatedUser);
     }
 
+    /**
+     * @return array{errors: array, process?: ThinnedProcess}
+     */
     private function validateClientData(object $data, ?AuthenticatedUser $authenticatedUser): array
     {
         $authErrors = ValidationService::validateGetProcessById($data->processId, $data->authKey);
@@ -52,7 +53,10 @@ class AppointmentUpdateService
             return $fieldErrors;
         }
 
-        return ['errors' => []];
+        return [
+            'errors' => [],
+            'process' => $reservedProcess,
+        ];
     }
 
     private function extractClientData(array $body): object

--- a/zmscitizenapi/tests/Zmscitizenapi/Services/Appointment/AppointmentUpdateServiceTest.php
+++ b/zmscitizenapi/tests/Zmscitizenapi/Services/Appointment/AppointmentUpdateServiceTest.php
@@ -181,7 +181,9 @@ class AppointmentUpdateServiceTest extends TestCase
             ];
     
             $result = $this->invokePrivateMethod('validateClientData', [$data, null]);
-            $this->assertEquals(['errors' => []], $result);
+            $this->assertEquals([], $result['errors']);
+            $this->assertArrayHasKey('process', $result);
+            $this->assertInstanceOf(ThinnedProcess::class, $result['process']);
         } finally {
             \App::$http = $originalHttp;
         }


### PR DESCRIPTION
## Summary
- Removes the duplicate `getReservedProcess` / ZMS API GET in `AppointmentUpdateService` for `update-appointment`.
- Validation now returns the fetched process; `processUpdate` reuses it for the subsequent update (one GET + one POST).

Replaces #2952 (branch renamed from `bugfix/...` to `bugfix-...` for CI/workflow compatibility).

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

## Test plan
- [ ] Unit: `AppointmentUpdateServiceTest`
- [ ] Manually call `update-appointment` and confirm only one process GET to zmsapi
- [ ] Verify validation errors still return without update