### PR TITLE
fix(ZMSKVR-166): keep calldisplay up when a scope id is missing

### DIFF
--- a/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayGet.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayGet.php
@@ -9,6 +9,7 @@ namespace BO\Zmsbackend\Calldisplay\Api;
 
 use BO\Slim\Render;
 use BO\Mellon\Validator;
+use BO\Zmsbackend\Calldisplay\Helper\CalldisplayCollections;
 use BO\Zmsbackend\Calldisplay\Service\Calldisplay as Query;
 use BO\Zmsentities\Calldisplay as Entity;
 
@@ -42,22 +43,16 @@ class CalldisplayGet extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
+    /**
+     * @SuppressWarnings(NPathComplexity)
+     */
     protected function testScopeAndCluster($calldisplay)
     {
-        if (! $calldisplay->hasScopeList() && ! $calldisplay->hasClusterList()) {
-            throw new \BO\Zmsbackend\Calldisplay\Exception\ScopeAndClusterNotFound();
-        }
-        foreach ($calldisplay->getClusterList() as $cluster) {
-            $cluster = (new \BO\Zmsbackend\Cluster\Service\Cluster())->readEntity($cluster->id);
-            if (! $cluster) {
-                throw new \BO\Zmsbackend\Cluster\Exception\ClusterNotFound();
+        CalldisplayCollections::retainExisting(
+            $calldisplay,
+            static function ($scopeRef) {
+                return (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($scopeRef->getId());
             }
-        }
-        foreach ($calldisplay->getScopeList() as $scope) {
-            $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($scope->id);
-            if (! $scope) {
-                throw new \BO\Zmsbackend\Scope\Exception\ScopeNotFound();
-            }
-        }
+        );
     }
 }

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayGet.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayGet.php
@@ -34,25 +34,12 @@ class CalldisplayGet extends \BO\Zmsbackend\Api\BaseController
         $input = Validator::input()->isJson()->assertValid()->getValue();
         $entity = new Entity($input);
 
-        $this->testScopeAndCluster($entity);
+        CalldisplayCollections::prepareForGet($entity);
         $message = \BO\Zmsbackend\Api\Response\Message::create($request);
         $message->data = $query->readResolvedEntity($entity, \App::getNow(), $resolveReferences);
 
         $response = Render::withLastModified($response, time(), '0');
         $response = Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
         return $response;
-    }
-
-    /**
-     * @SuppressWarnings(NPathComplexity)
-     */
-    protected function testScopeAndCluster($calldisplay)
-    {
-        CalldisplayCollections::retainExisting(
-            $calldisplay,
-            static function ($scopeRef) {
-                return (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($scopeRef->getId());
-            }
-        );
     }
 }

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayQueue.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayQueue.php
@@ -9,6 +9,7 @@ namespace BO\Zmsbackend\Calldisplay\Api;
 
 use BO\Slim\Render;
 use BO\Mellon\Validator;
+use BO\Zmsbackend\Calldisplay\Helper\CalldisplayCollections;
 
 /**
  * @SuppressWarnings(Coupling)
@@ -50,24 +51,22 @@ class CalldisplayQueue extends \BO\Zmsbackend\Api\BaseController
 
     protected $scopeCache = [];
 
+    /**
+     * @SuppressWarnings(NPathComplexity)
+     */
     protected function testScopeAndCluster($calldisplay, $resolveReferences)
     {
-        if (! $calldisplay->hasScopeList() && ! $calldisplay->hasClusterList()) {
-            throw new \BO\Zmsbackend\Calldisplay\Exception\ScopeAndClusterNotFound();
-        }
-        foreach ($calldisplay->getClusterList() as $cluster) {
-            $cluster = (new \BO\Zmsbackend\Cluster\Service\Cluster())->readEntity($cluster->getId());
-            if (! $cluster) {
-                throw new \BO\Zmsbackend\Cluster\Exception\ClusterNotFound();
-            }
-        }
-        foreach ($calldisplay->getScopeList() as $scope) {
-            $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readWithWorkstationCount($scope->getId(), \App::$now, $resolveReferences);
-            if (! $scope) {
-                throw new \BO\Zmsbackend\Scope\Exception\ScopeNotFound();
-            }
-            $this->scopeCache[$scope->getId()] = $scope;
-        }
+        $this->scopeCache = CalldisplayCollections::retainExisting(
+            $calldisplay,
+            static function ($scopeRef) use ($resolveReferences) {
+                return (new \BO\Zmsbackend\Scope\Service\Scope())->readWithWorkstationCount(
+                    $scopeRef->getId(),
+                    \App::$now,
+                    $resolveReferences
+                );
+            },
+            'Calldisplay queue'
+        );
     }
 
     protected function readCalculatedQueueListFromScope($scope, $resolveReferences)

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayQueue.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayQueue.php
@@ -32,14 +32,12 @@ class CalldisplayQueue extends \BO\Zmsbackend\Api\BaseController
 
         $input = Validator::input()->isJson()->assertValid()->getValue();
         $calldisplay = (new \BO\Zmsentities\Calldisplay($input))->withOutClusterDuplicates();
-        $this->testScopeAndCluster($calldisplay, $resolveReferences);
+        $this->scopeCache = CalldisplayCollections::prepareForQueue($calldisplay, $resolveReferences);
 
         //read full list if no statusList exists
         $queueList = (count($statusList)) ?
             $this->readQueueListByStatus($calldisplay, $statusList, $resolveReferences) :
             $this->readFullQueueList($calldisplay, $resolveReferences);
-
-
 
         $message = \BO\Zmsbackend\Api\Response\Message::create($request);
         $message->data = $queueList->withoutDublicates();
@@ -50,24 +48,6 @@ class CalldisplayQueue extends \BO\Zmsbackend\Api\BaseController
     }
 
     protected $scopeCache = [];
-
-    /**
-     * @SuppressWarnings(NPathComplexity)
-     */
-    protected function testScopeAndCluster($calldisplay, $resolveReferences)
-    {
-        $this->scopeCache = CalldisplayCollections::retainExisting(
-            $calldisplay,
-            static function ($scopeRef) use ($resolveReferences) {
-                return (new \BO\Zmsbackend\Scope\Service\Scope())->readWithWorkstationCount(
-                    $scopeRef->getId(),
-                    \App::$now,
-                    $resolveReferences
-                );
-            },
-            'Calldisplay queue'
-        );
-    }
 
     protected function readCalculatedQueueListFromScope($scope, $resolveReferences)
     {

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Helper/CalldisplayCollections.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Helper/CalldisplayCollections.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace BO\Zmsbackend\Calldisplay\Helper;
+
+use BO\Zmsentities\Calldisplay as Entity;
+use BO\Zmsentities\Collection\ClusterList;
+use BO\Zmsentities\Collection\ScopeList;
+
+/**
+ * Keep calldisplay requests stable when some configured scope/cluster ids no longer exist.
+ */
+class CalldisplayCollections
+{
+    /**
+     * Drop missing clusters/scopes (log each), or throw if nothing valid remains.
+     *
+     * @return array<int|string, mixed> resolved scopes keyed by id (for queue cache)
+     * @SuppressWarnings(NPathComplexity)
+     */
+    public static function retainExisting(Entity $calldisplay, callable $readScope, string $logPrefix = 'Calldisplay'): array
+    {
+        $hadScopes = $calldisplay->hasScopeList();
+        $hadClusters = $calldisplay->hasClusterList();
+        if (! $hadScopes && ! $hadClusters) {
+            throw new \BO\Zmsbackend\Calldisplay\Exception\ScopeAndClusterNotFound();
+        }
+
+        self::keepExistingClusters($calldisplay, $logPrefix);
+        $resolved = self::keepExistingScopes($calldisplay, $readScope, $logPrefix);
+        self::assertHasScopeOrCluster($calldisplay, $hadScopes, $hadClusters);
+
+        return $resolved;
+    }
+
+    private static function keepExistingClusters(Entity $calldisplay, string $logPrefix): void
+    {
+        $clusterList = new ClusterList();
+        foreach ($calldisplay->getClusterList() as $clusterRef) {
+            $cluster = (new \BO\Zmsbackend\Cluster\Service\Cluster())->readEntity($clusterRef->getId());
+            if (! $cluster) {
+                \App::$log->warning($logPrefix . ': skip missing cluster id', [
+                    'clusterId' => $clusterRef->getId(),
+                ]);
+                continue;
+            }
+            $clusterList->addEntity($cluster);
+        }
+        $calldisplay->clusters = $clusterList;
+    }
+
+    private static function keepExistingScopes(Entity $calldisplay, callable $readScope, string $logPrefix): array
+    {
+        $scopeList = new ScopeList();
+        $resolved = [];
+        foreach ($calldisplay->getScopeList() as $scopeRef) {
+            $scope = $readScope($scopeRef);
+            if (! $scope) {
+                \App::$log->warning($logPrefix . ': skip missing scope id', [
+                    'scopeId' => $scopeRef->getId(),
+                ]);
+                continue;
+            }
+            $scopeList->addEntity($scope);
+            $resolved[$scope->getId()] = $scope;
+        }
+        $calldisplay->scopes = $scopeList;
+        return $resolved;
+    }
+
+    private static function assertHasScopeOrCluster(Entity $calldisplay, bool $hadScopes, bool $hadClusters): void
+    {
+        if ($calldisplay->hasScopeList() || $calldisplay->hasClusterList()) {
+            return;
+        }
+        if ($hadScopes && ! $hadClusters) {
+            throw new \BO\Zmsbackend\Scope\Exception\ScopeNotFound();
+        }
+        if ($hadClusters && ! $hadScopes) {
+            throw new \BO\Zmsbackend\Cluster\Exception\ClusterNotFound();
+        }
+        throw new \BO\Zmsbackend\Calldisplay\Exception\ScopeAndClusterNotFound();
+    }
+}

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Helper/CalldisplayCollections.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Helper/CalldisplayCollections.php
@@ -5,69 +5,102 @@ namespace BO\Zmsbackend\Calldisplay\Helper;
 use BO\Zmsentities\Calldisplay as Entity;
 use BO\Zmsentities\Collection\ClusterList;
 use BO\Zmsentities\Collection\ScopeList;
+use BO\Zmsentities\Scope;
 
 /**
- * Keep calldisplay requests stable when some configured scope/cluster ids no longer exist.
+ * Drop missing scope/cluster ids from a calldisplay request so one bad id
+ * cannot take down the whole display.
  */
 class CalldisplayCollections
 {
-    /**
-     * Drop missing clusters/scopes (log each), or throw if nothing valid remains.
-     *
-     * @return array<int|string, mixed> resolved scopes keyed by id (for queue cache)
-     * @SuppressWarnings(NPathComplexity)
-     */
-    public static function retainExisting(Entity $calldisplay, callable $readScope, string $logPrefix = 'Calldisplay'): array
+    public static function prepareForGet(Entity $calldisplay): void
     {
+        self::prepare($calldisplay, 'Calldisplay', 0, false);
+    }
+
+    /**
+     * @return array<int|string, Scope>
+     */
+    public static function prepareForQueue(Entity $calldisplay, int $resolveReferences): array
+    {
+        return self::prepare($calldisplay, 'Calldisplay queue', $resolveReferences, true);
+    }
+
+    /**
+     * @return array<int|string, Scope>
+     */
+    private static function prepare(
+        Entity $calldisplay,
+        string $logPrefix,
+        int $resolveReferences,
+        bool $withWorkstationCount
+    ): array {
         $hadScopes = $calldisplay->hasScopeList();
         $hadClusters = $calldisplay->hasClusterList();
         if (! $hadScopes && ! $hadClusters) {
             throw new \BO\Zmsbackend\Calldisplay\Exception\ScopeAndClusterNotFound();
         }
 
-        self::keepExistingClusters($calldisplay, $logPrefix);
-        $resolved = self::keepExistingScopes($calldisplay, $readScope, $logPrefix);
-        self::assertHasScopeOrCluster($calldisplay, $hadScopes, $hadClusters);
+        self::filterClusters($calldisplay, $logPrefix);
+        $scopeCache = self::filterScopes($calldisplay, $logPrefix, $resolveReferences, $withWorkstationCount);
+        self::assertAnythingLeft($calldisplay, $hadScopes, $hadClusters);
 
-        return $resolved;
+        return $scopeCache;
     }
 
-    private static function keepExistingClusters(Entity $calldisplay, string $logPrefix): void
+    private static function filterClusters(Entity $calldisplay, string $logPrefix): void
     {
         $clusterList = new ClusterList();
+        $clusterService = new \BO\Zmsbackend\Cluster\Service\Cluster();
+
         foreach ($calldisplay->getClusterList() as $clusterRef) {
-            $cluster = (new \BO\Zmsbackend\Cluster\Service\Cluster())->readEntity($clusterRef->getId());
-            if (! $cluster) {
-                \App::$log->warning($logPrefix . ': skip missing cluster id', [
-                    'clusterId' => $clusterRef->getId(),
-                ]);
+            $cluster = $clusterService->readEntity($clusterRef->getId());
+            if ($cluster) {
+                $clusterList->addEntity($cluster);
                 continue;
             }
-            $clusterList->addEntity($cluster);
+            \App::$log->warning($logPrefix . ': skip missing cluster id', [
+                'clusterId' => $clusterRef->getId(),
+            ]);
         }
+
         $calldisplay->clusters = $clusterList;
     }
 
-    private static function keepExistingScopes(Entity $calldisplay, callable $readScope, string $logPrefix): array
-    {
+    /**
+     * @return array<int|string, Scope>
+     */
+    private static function filterScopes(
+        Entity $calldisplay,
+        string $logPrefix,
+        int $resolveReferences,
+        bool $withWorkstationCount
+    ): array {
         $scopeList = new ScopeList();
-        $resolved = [];
+        $scopeCache = [];
+        $scopeService = new \BO\Zmsbackend\Scope\Service\Scope();
+
         foreach ($calldisplay->getScopeList() as $scopeRef) {
-            $scope = $readScope($scopeRef);
-            if (! $scope) {
-                \App::$log->warning($logPrefix . ': skip missing scope id', [
-                    'scopeId' => $scopeRef->getId(),
-                ]);
+            $scopeId = $scopeRef->getId();
+            $scope = $withWorkstationCount
+                ? $scopeService->readWithWorkstationCount($scopeId, \App::$now, $resolveReferences)
+                : $scopeService->readEntity($scopeId);
+
+            if ($scope) {
+                $scopeList->addEntity($scope);
+                $scopeCache[$scope->getId()] = $scope;
                 continue;
             }
-            $scopeList->addEntity($scope);
-            $resolved[$scope->getId()] = $scope;
+            \App::$log->warning($logPrefix . ': skip missing scope id', [
+                'scopeId' => $scopeId,
+            ]);
         }
+
         $calldisplay->scopes = $scopeList;
-        return $resolved;
+        return $scopeCache;
     }
 
-    private static function assertHasScopeOrCluster(Entity $calldisplay, bool $hadScopes, bool $hadClusters): void
+    private static function assertAnythingLeft(Entity $calldisplay, bool $hadScopes, bool $hadClusters): void
     {
         if ($calldisplay->hasScopeList() || $calldisplay->hasClusterList()) {
             return;

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Service/Calldisplay.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Service/Calldisplay.php
@@ -25,11 +25,12 @@ class Calldisplay extends \BO\Zmsbackend\Base
             foreach ($calldisplay->scopes as $entity) {
                 $query = new \BO\Zmsbackend\Scope\Service\Scope();
                 $scope = $query->readEntity($entity['id'], $resolveReferences - 1);
-                /* test in zmsbackend CalldisplayGet
                 if (! $scope) {
-                    throw new \BO\Zmsbackend\Calldisplay\Exception\ScopeNotFound();
+                    \App::$log->warning('Calldisplay: skip missing scope id while resolving', [
+                        'scopeId' => $entity['id'],
+                    ]);
+                    continue;
                 }
-                */
                 $scopeList->addEntity($scope);
             }
             $calldisplay->scopes = $scopeList;
@@ -39,11 +40,12 @@ class Calldisplay extends \BO\Zmsbackend\Base
             foreach ($calldisplay->clusters as $entity) {
                 $query = new \BO\Zmsbackend\Cluster\Service\Cluster();
                 $cluster = $query->readEntity($entity['id'], $resolveReferences);
-                /* test in zmsbackend CalldisplayGet
                 if (! $cluster) {
-                    throw new \BO\Zmsbackend\Calldisplay\Exception\ClusterNotFound();
+                    \App::$log->warning('Calldisplay: skip missing cluster id while resolving', [
+                        'clusterId' => $entity['id'],
+                    ]);
+                    continue;
                 }
-                */
                 $clusterList->addEntity($cluster);
             }
             $calldisplay->clusters = $clusterList;

--- a/zmsbackend/tests/Zmsbackend/Calldisplay/Api/CalldisplayGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Calldisplay/Api/CalldisplayGetTest.php
@@ -72,6 +72,27 @@ class CalldisplayGetTest extends \BO\Zmsbackend\Tests\Api\Base
         ], []);
     }
 
+    public function testSkipsMissingScopeWhenOthersExist()
+    {
+        $this->setWorkstation();
+        $response = $this->render([], [
+            '__body' => '{
+                "scopes": [
+                    {
+                      "id": 999
+                    },
+                    {
+                      "id": 142
+                    }
+                ]
+            }'
+        ], []);
+        $this->assertStringContainsString('calldisplay.json', (string)$response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"id":142', (string)$response->getBody());
+        $this->assertStringNotContainsString('"id":999', (string)$response->getBody());
+    }
+
     public function testNotFoundClusterOrScopeLists()
     {
         $this->setWorkstation();

--- a/zmsbackend/tests/Zmsbackend/Calldisplay/Api/CalldisplayQueueTest.php
+++ b/zmsbackend/tests/Zmsbackend/Calldisplay/Api/CalldisplayQueueTest.php
@@ -78,6 +78,24 @@ class CalldisplayQueueTest extends \BO\Zmsbackend\Tests\Api\Base
         ], []);
     }
 
+    public function testSkipsMissingScopeWhenOthersExist()
+    {
+        $response = $this->render([], [
+            '__body' => '{
+                "scopes": [
+                    {
+                      "id": 999
+                    },
+                    {
+                      "id": 142
+                    }
+                ]
+            }'
+        ], []);
+        $this->assertStringContainsString('queue.json', (string)$response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     public function testNotFoundClusterOrScopeLists()
     {
         $this->expectException('\BO\Zmsbackend\Calldisplay\Exception\ScopeAndClusterNotFound');


### PR DESCRIPTION
## Summary
- Missing Standort/scope (or cluster) IDs in a calldisplay `scopelist` no longer abort the whole request with `ScopeNotFound`.
- Unknown IDs are skipped and logged; valid IDs keep serving.
- Still fails only when **no** valid scope/cluster remains.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

## Test plan
- [x] Unit: `CalldisplayGetTest` / `CalldisplayQueueTest` (including `testSkipsMissingScopeWhenOthersExist`)
- [x] Manual: open calldisplay with a mix of valid + deleted scope IDs, e.g. `?collections[scopelist]=6,99999,9&template=default_counter` — page should load for the valid scopes; warning in logs for the missing id
- [x] Confirm all-invalid list still returns 404 / ScopeNotFound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calldisplay requests now ignore missing scopes or clusters when valid entries remain.
  * Requests continue successfully with only the available scopes and clusters.
  * Clear errors are returned when no valid scope or cluster remains.
  * Missing entries are logged for improved visibility.

* **Tests**
  * Added coverage confirming successful responses when some requested scopes are unavailable.
  * Verified queue responses continue returning HTTP 200 with valid scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->