### PR TITLE
fix(ZMSKVR-916): rename Zeit heading to Datum und Uhrzeit

### DIFF
--- a/zmscitizenview/src/utils/de-DE.json
+++ b/zmscitizenview/src/utils/de-DE.json
@@ -273,7 +273,7 @@
   "termsOfUse": "Rechtliche Hinweise",
   "termsOfUseForVideoConsultationLabel": "Nutzungsbedingungen Videoberatung",
   "termsOfUseForVideoConsultationText": "Für die Teilnahme an der Videoberatung stimme ich den <a href=\"https://stadt.muenchen.de/dam/DSGVO/Nutzungsbedingungen-Videoberatung.pdf\" target='_blank' rel='noopener noreferrer' aria-label='Nutzungsbedingungen Videoberatung pdf download'>Nutzungsbedingungen</a> zu.",
-  "time": "Zeit",
+  "time": "Datum und Uhrzeit",
   "timeStampSuffix": "Uhr",
   "upcomingAppointments": "Kommende Termine",
   "updateAppointmentErrorHeader": "Terminupdate fehlgeschlagen",

--- a/zmscitizenview/src/utils/en-US.json
+++ b/zmscitizenview/src/utils/en-US.json
@@ -253,7 +253,7 @@
   "termsOfUse": "Terms of Use",
   "termsOfUseForVideoConsultationLabel": "Terms of Use video consultation",
   "termsOfUseForVideoConsultationText": "To participate in the video consultation, I agree to the <a href=\"https://stadt.muenchen.de/dam/DSGVO/Nutzungsbedingungen-Videoberatung.pdf\" target='_blank' rel='noopener noreferrer' aria-label='Terms of Use video consultation pdf download'>Terms of Use</a>.",
-  "time": "Time",
+  "time": "Date and time",
   "timeStampSuffix": "o´clock",
   "updateAppointmentErrorHeader": "Appointment update failed.",
   "updateAppointmentErrorText": "Appointment update failed.",


### PR DESCRIPTION
## Summary
- Renames the shared `time` i18n label from **Zeit** / **Time** to **Datum und Uhrzeit** / **Date and time**.
- Covers all three ZMSKVR-916 spots via `t("time")`: H2 over calendar/list (Termin), Terminzusammenfassung callout (Termin), and Übersicht heading.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.