### PR TITLE
fix(ZMSKVR-1213): restore Wegezeiten in Wartestatistik (2025-04-23..2026-01-23)

### DIFF
--- a/zmsbackend/migrations/91785021213-restore-waiting-waytimes-from-archive-2025-04-23-to-2026-01-23.sql
+++ b/zmsbackend/migrations/91785021213-restore-waiting-waytimes-from-archive-2025-04-23-to-2026-01-23.sql
@@ -1,0 +1,162 @@
+-- ZMSKVR-1213: restore Wegezeiten in wartenrstatistik for 2025-04-23 .. 2026-01-23
+-- Background:
+--   From muc23 (~2025-04-23) until muc36 (2026-01-23), CalculateDailyWaitingStatisticByCron
+--   divided archive way_time by 60 once too often (ZMSKVR-431). Values were stored as
+--   hours:minutes instead of minutes:seconds in the waiting statistic.
+-- Strategy (same pattern as 91770274084 / 91757926126):
+--   1) Aggregate avg way times from buergerarchiv for the closed date range
+--   2) Ensure wartenrstatistik rows exist for those scope/date pairs
+--   3) Update only hour_*_way_time_* columns (leave counts / waiting times untouched)
+--   Uses current column names after 91775568666 / 91775568667.
+
+SET @start_date := '2025-04-23';
+SET @end_date := '2026-01-23';
+
+DROP TEMPORARY TABLE IF EXISTS tmp_ba_raw;
+DROP TEMPORARY TABLE IF EXISTS tmp_ba_agg;
+DROP TEMPORARY TABLE IF EXISTS tmp_pivot;
+
+CREATE TEMPORARY TABLE tmp_ba_raw ENGINE=Aria AS
+SELECT
+  StandortID AS scope_id,
+  Datum      AS datum,
+  HOUR(STR_TO_DATE(`Timestamp`, '%H:%i:%s')) AS bucket_hour,
+  CASE WHEN mitTermin = 1 THEN 'termin' ELSE 'spontan' END AS type,
+  COALESCE(way_time, 0) AS way_minutes
+FROM buergerarchiv
+WHERE Datum >= @start_date
+  AND Datum <= @end_date
+  AND (nicht_erschienen IS NULL OR nicht_erschienen = 0);
+
+CREATE TEMPORARY TABLE tmp_ba_agg ENGINE=Aria AS
+SELECT
+  scope_id,
+  datum,
+  bucket_hour,
+  type,
+  ROUND(AVG(COALESCE(way_minutes, 0)), 2) AS avg_way_minutes
+FROM tmp_ba_raw
+GROUP BY scope_id, datum, bucket_hour, type;
+
+CREATE TEMPORARY TABLE tmp_pivot ENGINE=Aria AS
+SELECT
+  scope_id,
+  datum,
+
+  /* avg way: spontaneous */
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 0 THEN avg_way_minutes END) AS hour_00_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 1 THEN avg_way_minutes END) AS hour_01_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 2 THEN avg_way_minutes END) AS hour_02_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 3 THEN avg_way_minutes END) AS hour_03_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 4 THEN avg_way_minutes END) AS hour_04_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 5 THEN avg_way_minutes END) AS hour_05_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 6 THEN avg_way_minutes END) AS hour_06_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 7 THEN avg_way_minutes END) AS hour_07_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 8 THEN avg_way_minutes END) AS hour_08_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour= 9 THEN avg_way_minutes END) AS hour_09_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=10 THEN avg_way_minutes END) AS hour_10_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=11 THEN avg_way_minutes END) AS hour_11_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=12 THEN avg_way_minutes END) AS hour_12_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=13 THEN avg_way_minutes END) AS hour_13_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=14 THEN avg_way_minutes END) AS hour_14_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=15 THEN avg_way_minutes END) AS hour_15_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=16 THEN avg_way_minutes END) AS hour_16_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=17 THEN avg_way_minutes END) AS hour_17_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=18 THEN avg_way_minutes END) AS hour_18_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=19 THEN avg_way_minutes END) AS hour_19_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=20 THEN avg_way_minutes END) AS hour_20_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=21 THEN avg_way_minutes END) AS hour_21_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=22 THEN avg_way_minutes END) AS hour_22_way_time_spontaneous,
+  MAX(CASE WHEN type='spontan' AND bucket_hour=23 THEN avg_way_minutes END) AS hour_23_way_time_spontaneous,
+
+  /* avg way: appointment */
+  MAX(CASE WHEN type='termin' AND bucket_hour= 0 THEN avg_way_minutes END) AS hour_00_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 1 THEN avg_way_minutes END) AS hour_01_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 2 THEN avg_way_minutes END) AS hour_02_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 3 THEN avg_way_minutes END) AS hour_03_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 4 THEN avg_way_minutes END) AS hour_04_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 5 THEN avg_way_minutes END) AS hour_05_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 6 THEN avg_way_minutes END) AS hour_06_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 7 THEN avg_way_minutes END) AS hour_07_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 8 THEN avg_way_minutes END) AS hour_08_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour= 9 THEN avg_way_minutes END) AS hour_09_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=10 THEN avg_way_minutes END) AS hour_10_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=11 THEN avg_way_minutes END) AS hour_11_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=12 THEN avg_way_minutes END) AS hour_12_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=13 THEN avg_way_minutes END) AS hour_13_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=14 THEN avg_way_minutes END) AS hour_14_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=15 THEN avg_way_minutes END) AS hour_15_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=16 THEN avg_way_minutes END) AS hour_16_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=17 THEN avg_way_minutes END) AS hour_17_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=18 THEN avg_way_minutes END) AS hour_18_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=19 THEN avg_way_minutes END) AS hour_19_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=20 THEN avg_way_minutes END) AS hour_20_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=21 THEN avg_way_minutes END) AS hour_21_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=22 THEN avg_way_minutes END) AS hour_22_way_time_appointment,
+  MAX(CASE WHEN type='termin' AND bucket_hour=23 THEN avg_way_minutes END) AS hour_23_way_time_appointment
+
+FROM tmp_ba_agg
+GROUP BY scope_id, datum;
+
+INSERT INTO wartenrstatistik (standortid, datum)
+SELECT scope_id, datum FROM tmp_pivot
+ON DUPLICATE KEY UPDATE datum = VALUES(datum);
+
+UPDATE wartenrstatistik w
+JOIN tmp_pivot p ON p.scope_id = w.standortid AND p.datum = w.datum
+SET
+  /* avg way: spontaneous */
+  w.hour_00_way_time_spontaneous = COALESCE(p.hour_00_way_time_spontaneous, 0),
+  w.hour_01_way_time_spontaneous = COALESCE(p.hour_01_way_time_spontaneous, 0),
+  w.hour_02_way_time_spontaneous = COALESCE(p.hour_02_way_time_spontaneous, 0),
+  w.hour_03_way_time_spontaneous = COALESCE(p.hour_03_way_time_spontaneous, 0),
+  w.hour_04_way_time_spontaneous = COALESCE(p.hour_04_way_time_spontaneous, 0),
+  w.hour_05_way_time_spontaneous = COALESCE(p.hour_05_way_time_spontaneous, 0),
+  w.hour_06_way_time_spontaneous = COALESCE(p.hour_06_way_time_spontaneous, 0),
+  w.hour_07_way_time_spontaneous = COALESCE(p.hour_07_way_time_spontaneous, 0),
+  w.hour_08_way_time_spontaneous = COALESCE(p.hour_08_way_time_spontaneous, 0),
+  w.hour_09_way_time_spontaneous = COALESCE(p.hour_09_way_time_spontaneous, 0),
+  w.hour_10_way_time_spontaneous = COALESCE(p.hour_10_way_time_spontaneous, 0),
+  w.hour_11_way_time_spontaneous = COALESCE(p.hour_11_way_time_spontaneous, 0),
+  w.hour_12_way_time_spontaneous = COALESCE(p.hour_12_way_time_spontaneous, 0),
+  w.hour_13_way_time_spontaneous = COALESCE(p.hour_13_way_time_spontaneous, 0),
+  w.hour_14_way_time_spontaneous = COALESCE(p.hour_14_way_time_spontaneous, 0),
+  w.hour_15_way_time_spontaneous = COALESCE(p.hour_15_way_time_spontaneous, 0),
+  w.hour_16_way_time_spontaneous = COALESCE(p.hour_16_way_time_spontaneous, 0),
+  w.hour_17_way_time_spontaneous = COALESCE(p.hour_17_way_time_spontaneous, 0),
+  w.hour_18_way_time_spontaneous = COALESCE(p.hour_18_way_time_spontaneous, 0),
+  w.hour_19_way_time_spontaneous = COALESCE(p.hour_19_way_time_spontaneous, 0),
+  w.hour_20_way_time_spontaneous = COALESCE(p.hour_20_way_time_spontaneous, 0),
+  w.hour_21_way_time_spontaneous = COALESCE(p.hour_21_way_time_spontaneous, 0),
+  w.hour_22_way_time_spontaneous = COALESCE(p.hour_22_way_time_spontaneous, 0),
+  w.hour_23_way_time_spontaneous = COALESCE(p.hour_23_way_time_spontaneous, 0),
+
+  /* avg way: appointment */
+  w.hour_00_way_time_appointment = COALESCE(p.hour_00_way_time_appointment, 0),
+  w.hour_01_way_time_appointment = COALESCE(p.hour_01_way_time_appointment, 0),
+  w.hour_02_way_time_appointment = COALESCE(p.hour_02_way_time_appointment, 0),
+  w.hour_03_way_time_appointment = COALESCE(p.hour_03_way_time_appointment, 0),
+  w.hour_04_way_time_appointment = COALESCE(p.hour_04_way_time_appointment, 0),
+  w.hour_05_way_time_appointment = COALESCE(p.hour_05_way_time_appointment, 0),
+  w.hour_06_way_time_appointment = COALESCE(p.hour_06_way_time_appointment, 0),
+  w.hour_07_way_time_appointment = COALESCE(p.hour_07_way_time_appointment, 0),
+  w.hour_08_way_time_appointment = COALESCE(p.hour_08_way_time_appointment, 0),
+  w.hour_09_way_time_appointment = COALESCE(p.hour_09_way_time_appointment, 0),
+  w.hour_10_way_time_appointment = COALESCE(p.hour_10_way_time_appointment, 0),
+  w.hour_11_way_time_appointment = COALESCE(p.hour_11_way_time_appointment, 0),
+  w.hour_12_way_time_appointment = COALESCE(p.hour_12_way_time_appointment, 0),
+  w.hour_13_way_time_appointment = COALESCE(p.hour_13_way_time_appointment, 0),
+  w.hour_14_way_time_appointment = COALESCE(p.hour_14_way_time_appointment, 0),
+  w.hour_15_way_time_appointment = COALESCE(p.hour_15_way_time_appointment, 0),
+  w.hour_16_way_time_appointment = COALESCE(p.hour_16_way_time_appointment, 0),
+  w.hour_17_way_time_appointment = COALESCE(p.hour_17_way_time_appointment, 0),
+  w.hour_18_way_time_appointment = COALESCE(p.hour_18_way_time_appointment, 0),
+  w.hour_19_way_time_appointment = COALESCE(p.hour_19_way_time_appointment, 0),
+  w.hour_20_way_time_appointment = COALESCE(p.hour_20_way_time_appointment, 0),
+  w.hour_21_way_time_appointment = COALESCE(p.hour_21_way_time_appointment, 0),
+  w.hour_22_way_time_appointment = COALESCE(p.hour_22_way_time_appointment, 0),
+  w.hour_23_way_time_appointment = COALESCE(p.hour_23_way_time_appointment, 0);
+
+DROP TEMPORARY TABLE IF EXISTS tmp_ba_raw;
+DROP TEMPORARY TABLE IF EXISTS tmp_ba_agg;
+DROP TEMPORARY TABLE IF EXISTS tmp_pivot;

--- a/zmsbackend/migrations/91785021213-restore-waiting-waytimes-from-archive-2025-04-23-to-2026-01-23.sql
+++ b/zmsbackend/migrations/91785021213-restore-waiting-waytimes-from-archive-2025-04-23-to-2026-01-23.sql
@@ -3,160 +3,202 @@
 --   From muc23 (~2025-04-23) until muc36 (2026-01-23), CalculateDailyWaitingStatisticByCron
 --   divided archive way_time by 60 once too often (ZMSKVR-431). Values were stored as
 --   hours:minutes instead of minutes:seconds in the waiting statistic.
--- Strategy (same pattern as 91770274084 / 91757926126):
---   1) Aggregate avg way times from buergerarchiv for the closed date range
---   2) Ensure wartenrstatistik rows exist for those scope/date pairs
---   3) Update only hour_*_way_time_* columns (leave counts / waiting times untouched)
+-- Strategy (same recover pattern as 91770274084 / 91757926126, batched like log backfills):
+--   Recalculate avg way times from buergerarchiv without /60, in date-window batches
+--   so each UPDATE commits separately (short row locks).
+--   Updates only hour_*_way_time_*; counts / waiting times stay untouched.
 --   Uses current column names after 91775568666 / 91775568667.
+-- Idempotent: re-running recalculates the same averages from buergerarchiv.
 
-SET @start_date := '2025-04-23';
-SET @end_date := '2026-01-23';
+DELIMITER $$
 
-DROP TEMPORARY TABLE IF EXISTS tmp_ba_raw;
-DROP TEMPORARY TABLE IF EXISTS tmp_ba_agg;
-DROP TEMPORARY TABLE IF EXISTS tmp_pivot;
+DROP PROCEDURE IF EXISTS zms_restore_waiting_waytimes_zmskvr_1213$$
 
-CREATE TEMPORARY TABLE tmp_ba_raw ENGINE=Aria AS
-SELECT
-  StandortID AS scope_id,
-  Datum      AS datum,
-  HOUR(STR_TO_DATE(`Timestamp`, '%H:%i:%s')) AS bucket_hour,
-  CASE WHEN mitTermin = 1 THEN 'termin' ELSE 'spontan' END AS type,
-  COALESCE(way_time, 0) AS way_minutes
-FROM buergerarchiv
-WHERE Datum >= @start_date
-  AND Datum <= @end_date
-  AND (nicht_erschienen IS NULL OR nicht_erschienen = 0);
+CREATE PROCEDURE zms_restore_waiting_waytimes_zmskvr_1213(
+    IN p_start_date DATE,
+    IN p_end_date DATE,
+    IN p_batch_days INT UNSIGNED
+)
+proc: BEGIN
+    DECLARE v_from DATE;
+    DECLARE v_to DATE;
 
-CREATE TEMPORARY TABLE tmp_ba_agg ENGINE=Aria AS
-SELECT
-  scope_id,
-  datum,
-  bucket_hour,
-  type,
-  ROUND(AVG(COALESCE(way_minutes, 0)), 2) AS avg_way_minutes
-FROM tmp_ba_raw
-GROUP BY scope_id, datum, bucket_hour, type;
+    IF p_start_date IS NULL THEN
+        SET p_start_date = '2025-04-23';
+    END IF;
 
-CREATE TEMPORARY TABLE tmp_pivot ENGINE=Aria AS
-SELECT
-  scope_id,
-  datum,
+    IF p_end_date IS NULL THEN
+        SET p_end_date = '2026-01-23';
+    END IF;
 
-  /* avg way: spontaneous */
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 0 THEN avg_way_minutes END) AS hour_00_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 1 THEN avg_way_minutes END) AS hour_01_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 2 THEN avg_way_minutes END) AS hour_02_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 3 THEN avg_way_minutes END) AS hour_03_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 4 THEN avg_way_minutes END) AS hour_04_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 5 THEN avg_way_minutes END) AS hour_05_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 6 THEN avg_way_minutes END) AS hour_06_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 7 THEN avg_way_minutes END) AS hour_07_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 8 THEN avg_way_minutes END) AS hour_08_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour= 9 THEN avg_way_minutes END) AS hour_09_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=10 THEN avg_way_minutes END) AS hour_10_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=11 THEN avg_way_minutes END) AS hour_11_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=12 THEN avg_way_minutes END) AS hour_12_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=13 THEN avg_way_minutes END) AS hour_13_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=14 THEN avg_way_minutes END) AS hour_14_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=15 THEN avg_way_minutes END) AS hour_15_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=16 THEN avg_way_minutes END) AS hour_16_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=17 THEN avg_way_minutes END) AS hour_17_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=18 THEN avg_way_minutes END) AS hour_18_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=19 THEN avg_way_minutes END) AS hour_19_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=20 THEN avg_way_minutes END) AS hour_20_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=21 THEN avg_way_minutes END) AS hour_21_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=22 THEN avg_way_minutes END) AS hour_22_way_time_spontaneous,
-  MAX(CASE WHEN type='spontan' AND bucket_hour=23 THEN avg_way_minutes END) AS hour_23_way_time_spontaneous,
+    IF p_batch_days IS NULL OR p_batch_days < 1 THEN
+        SET p_batch_days = 7;
+    END IF;
 
-  /* avg way: appointment */
-  MAX(CASE WHEN type='termin' AND bucket_hour= 0 THEN avg_way_minutes END) AS hour_00_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 1 THEN avg_way_minutes END) AS hour_01_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 2 THEN avg_way_minutes END) AS hour_02_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 3 THEN avg_way_minutes END) AS hour_03_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 4 THEN avg_way_minutes END) AS hour_04_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 5 THEN avg_way_minutes END) AS hour_05_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 6 THEN avg_way_minutes END) AS hour_06_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 7 THEN avg_way_minutes END) AS hour_07_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 8 THEN avg_way_minutes END) AS hour_08_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour= 9 THEN avg_way_minutes END) AS hour_09_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=10 THEN avg_way_minutes END) AS hour_10_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=11 THEN avg_way_minutes END) AS hour_11_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=12 THEN avg_way_minutes END) AS hour_12_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=13 THEN avg_way_minutes END) AS hour_13_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=14 THEN avg_way_minutes END) AS hour_14_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=15 THEN avg_way_minutes END) AS hour_15_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=16 THEN avg_way_minutes END) AS hour_16_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=17 THEN avg_way_minutes END) AS hour_17_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=18 THEN avg_way_minutes END) AS hour_18_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=19 THEN avg_way_minutes END) AS hour_19_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=20 THEN avg_way_minutes END) AS hour_20_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=21 THEN avg_way_minutes END) AS hour_21_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=22 THEN avg_way_minutes END) AS hour_22_way_time_appointment,
-  MAX(CASE WHEN type='termin' AND bucket_hour=23 THEN avg_way_minutes END) AS hour_23_way_time_appointment
+    IF p_start_date > p_end_date THEN
+        LEAVE proc;
+    END IF;
 
-FROM tmp_ba_agg
-GROUP BY scope_id, datum;
+    SET v_from = p_start_date;
 
-INSERT INTO wartenrstatistik (standortid, datum)
-SELECT scope_id, datum FROM tmp_pivot
-ON DUPLICATE KEY UPDATE datum = VALUES(datum);
+    WHILE v_from <= p_end_date DO
+        SET v_to = LEAST(DATE_ADD(v_from, INTERVAL p_batch_days - 1 DAY), p_end_date);
 
-UPDATE wartenrstatistik w
-JOIN tmp_pivot p ON p.scope_id = w.standortid AND p.datum = w.datum
-SET
-  /* avg way: spontaneous */
-  w.hour_00_way_time_spontaneous = COALESCE(p.hour_00_way_time_spontaneous, 0),
-  w.hour_01_way_time_spontaneous = COALESCE(p.hour_01_way_time_spontaneous, 0),
-  w.hour_02_way_time_spontaneous = COALESCE(p.hour_02_way_time_spontaneous, 0),
-  w.hour_03_way_time_spontaneous = COALESCE(p.hour_03_way_time_spontaneous, 0),
-  w.hour_04_way_time_spontaneous = COALESCE(p.hour_04_way_time_spontaneous, 0),
-  w.hour_05_way_time_spontaneous = COALESCE(p.hour_05_way_time_spontaneous, 0),
-  w.hour_06_way_time_spontaneous = COALESCE(p.hour_06_way_time_spontaneous, 0),
-  w.hour_07_way_time_spontaneous = COALESCE(p.hour_07_way_time_spontaneous, 0),
-  w.hour_08_way_time_spontaneous = COALESCE(p.hour_08_way_time_spontaneous, 0),
-  w.hour_09_way_time_spontaneous = COALESCE(p.hour_09_way_time_spontaneous, 0),
-  w.hour_10_way_time_spontaneous = COALESCE(p.hour_10_way_time_spontaneous, 0),
-  w.hour_11_way_time_spontaneous = COALESCE(p.hour_11_way_time_spontaneous, 0),
-  w.hour_12_way_time_spontaneous = COALESCE(p.hour_12_way_time_spontaneous, 0),
-  w.hour_13_way_time_spontaneous = COALESCE(p.hour_13_way_time_spontaneous, 0),
-  w.hour_14_way_time_spontaneous = COALESCE(p.hour_14_way_time_spontaneous, 0),
-  w.hour_15_way_time_spontaneous = COALESCE(p.hour_15_way_time_spontaneous, 0),
-  w.hour_16_way_time_spontaneous = COALESCE(p.hour_16_way_time_spontaneous, 0),
-  w.hour_17_way_time_spontaneous = COALESCE(p.hour_17_way_time_spontaneous, 0),
-  w.hour_18_way_time_spontaneous = COALESCE(p.hour_18_way_time_spontaneous, 0),
-  w.hour_19_way_time_spontaneous = COALESCE(p.hour_19_way_time_spontaneous, 0),
-  w.hour_20_way_time_spontaneous = COALESCE(p.hour_20_way_time_spontaneous, 0),
-  w.hour_21_way_time_spontaneous = COALESCE(p.hour_21_way_time_spontaneous, 0),
-  w.hour_22_way_time_spontaneous = COALESCE(p.hour_22_way_time_spontaneous, 0),
-  w.hour_23_way_time_spontaneous = COALESCE(p.hour_23_way_time_spontaneous, 0),
+        DROP TEMPORARY TABLE IF EXISTS tmp_ba_raw;
+        DROP TEMPORARY TABLE IF EXISTS tmp_ba_agg;
+        DROP TEMPORARY TABLE IF EXISTS tmp_pivot;
 
-  /* avg way: appointment */
-  w.hour_00_way_time_appointment = COALESCE(p.hour_00_way_time_appointment, 0),
-  w.hour_01_way_time_appointment = COALESCE(p.hour_01_way_time_appointment, 0),
-  w.hour_02_way_time_appointment = COALESCE(p.hour_02_way_time_appointment, 0),
-  w.hour_03_way_time_appointment = COALESCE(p.hour_03_way_time_appointment, 0),
-  w.hour_04_way_time_appointment = COALESCE(p.hour_04_way_time_appointment, 0),
-  w.hour_05_way_time_appointment = COALESCE(p.hour_05_way_time_appointment, 0),
-  w.hour_06_way_time_appointment = COALESCE(p.hour_06_way_time_appointment, 0),
-  w.hour_07_way_time_appointment = COALESCE(p.hour_07_way_time_appointment, 0),
-  w.hour_08_way_time_appointment = COALESCE(p.hour_08_way_time_appointment, 0),
-  w.hour_09_way_time_appointment = COALESCE(p.hour_09_way_time_appointment, 0),
-  w.hour_10_way_time_appointment = COALESCE(p.hour_10_way_time_appointment, 0),
-  w.hour_11_way_time_appointment = COALESCE(p.hour_11_way_time_appointment, 0),
-  w.hour_12_way_time_appointment = COALESCE(p.hour_12_way_time_appointment, 0),
-  w.hour_13_way_time_appointment = COALESCE(p.hour_13_way_time_appointment, 0),
-  w.hour_14_way_time_appointment = COALESCE(p.hour_14_way_time_appointment, 0),
-  w.hour_15_way_time_appointment = COALESCE(p.hour_15_way_time_appointment, 0),
-  w.hour_16_way_time_appointment = COALESCE(p.hour_16_way_time_appointment, 0),
-  w.hour_17_way_time_appointment = COALESCE(p.hour_17_way_time_appointment, 0),
-  w.hour_18_way_time_appointment = COALESCE(p.hour_18_way_time_appointment, 0),
-  w.hour_19_way_time_appointment = COALESCE(p.hour_19_way_time_appointment, 0),
-  w.hour_20_way_time_appointment = COALESCE(p.hour_20_way_time_appointment, 0),
-  w.hour_21_way_time_appointment = COALESCE(p.hour_21_way_time_appointment, 0),
-  w.hour_22_way_time_appointment = COALESCE(p.hour_22_way_time_appointment, 0),
-  w.hour_23_way_time_appointment = COALESCE(p.hour_23_way_time_appointment, 0);
+        CREATE TEMPORARY TABLE tmp_ba_raw ENGINE=Aria AS
+        SELECT
+          StandortID AS scope_id,
+          Datum      AS datum,
+          HOUR(STR_TO_DATE(`Timestamp`, '%H:%i:%s')) AS bucket_hour,
+          CASE WHEN mitTermin = 1 THEN 'termin' ELSE 'spontan' END AS type,
+          COALESCE(way_time, 0) AS way_minutes
+        FROM buergerarchiv
+        WHERE Datum >= v_from
+          AND Datum <= v_to
+          AND (nicht_erschienen IS NULL OR nicht_erschienen = 0);
 
-DROP TEMPORARY TABLE IF EXISTS tmp_ba_raw;
-DROP TEMPORARY TABLE IF EXISTS tmp_ba_agg;
-DROP TEMPORARY TABLE IF EXISTS tmp_pivot;
+        CREATE TEMPORARY TABLE tmp_ba_agg ENGINE=Aria AS
+        SELECT
+          scope_id,
+          datum,
+          bucket_hour,
+          type,
+          ROUND(AVG(COALESCE(way_minutes, 0)), 2) AS avg_way_minutes
+        FROM tmp_ba_raw
+        GROUP BY scope_id, datum, bucket_hour, type;
+
+        CREATE TEMPORARY TABLE tmp_pivot ENGINE=Aria AS
+        SELECT
+          scope_id,
+          datum,
+
+          /* avg way: spontaneous */
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 0 THEN avg_way_minutes END) AS hour_00_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 1 THEN avg_way_minutes END) AS hour_01_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 2 THEN avg_way_minutes END) AS hour_02_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 3 THEN avg_way_minutes END) AS hour_03_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 4 THEN avg_way_minutes END) AS hour_04_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 5 THEN avg_way_minutes END) AS hour_05_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 6 THEN avg_way_minutes END) AS hour_06_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 7 THEN avg_way_minutes END) AS hour_07_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 8 THEN avg_way_minutes END) AS hour_08_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour= 9 THEN avg_way_minutes END) AS hour_09_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=10 THEN avg_way_minutes END) AS hour_10_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=11 THEN avg_way_minutes END) AS hour_11_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=12 THEN avg_way_minutes END) AS hour_12_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=13 THEN avg_way_minutes END) AS hour_13_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=14 THEN avg_way_minutes END) AS hour_14_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=15 THEN avg_way_minutes END) AS hour_15_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=16 THEN avg_way_minutes END) AS hour_16_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=17 THEN avg_way_minutes END) AS hour_17_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=18 THEN avg_way_minutes END) AS hour_18_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=19 THEN avg_way_minutes END) AS hour_19_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=20 THEN avg_way_minutes END) AS hour_20_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=21 THEN avg_way_minutes END) AS hour_21_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=22 THEN avg_way_minutes END) AS hour_22_way_time_spontaneous,
+      MAX(CASE WHEN type='spontan' AND bucket_hour=23 THEN avg_way_minutes END) AS hour_23_way_time_spontaneous,
+
+          /* avg way: appointment */
+      MAX(CASE WHEN type='termin' AND bucket_hour= 0 THEN avg_way_minutes END) AS hour_00_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 1 THEN avg_way_minutes END) AS hour_01_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 2 THEN avg_way_minutes END) AS hour_02_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 3 THEN avg_way_minutes END) AS hour_03_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 4 THEN avg_way_minutes END) AS hour_04_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 5 THEN avg_way_minutes END) AS hour_05_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 6 THEN avg_way_minutes END) AS hour_06_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 7 THEN avg_way_minutes END) AS hour_07_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 8 THEN avg_way_minutes END) AS hour_08_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour= 9 THEN avg_way_minutes END) AS hour_09_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=10 THEN avg_way_minutes END) AS hour_10_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=11 THEN avg_way_minutes END) AS hour_11_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=12 THEN avg_way_minutes END) AS hour_12_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=13 THEN avg_way_minutes END) AS hour_13_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=14 THEN avg_way_minutes END) AS hour_14_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=15 THEN avg_way_minutes END) AS hour_15_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=16 THEN avg_way_minutes END) AS hour_16_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=17 THEN avg_way_minutes END) AS hour_17_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=18 THEN avg_way_minutes END) AS hour_18_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=19 THEN avg_way_minutes END) AS hour_19_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=20 THEN avg_way_minutes END) AS hour_20_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=21 THEN avg_way_minutes END) AS hour_21_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=22 THEN avg_way_minutes END) AS hour_22_way_time_appointment,
+      MAX(CASE WHEN type='termin' AND bucket_hour=23 THEN avg_way_minutes END) AS hour_23_way_time_appointment
+
+        FROM tmp_ba_agg
+        GROUP BY scope_id, datum;
+
+        INSERT INTO wartenrstatistik (standortid, datum)
+        SELECT scope_id, datum FROM tmp_pivot
+        ON DUPLICATE KEY UPDATE datum = VALUES(datum);
+
+        UPDATE wartenrstatistik w
+        JOIN tmp_pivot p ON p.scope_id = w.standortid AND p.datum = w.datum
+        SET
+          /* avg way: spontaneous */
+      w.hour_00_way_time_spontaneous = COALESCE(p.hour_00_way_time_spontaneous, 0),
+      w.hour_01_way_time_spontaneous = COALESCE(p.hour_01_way_time_spontaneous, 0),
+      w.hour_02_way_time_spontaneous = COALESCE(p.hour_02_way_time_spontaneous, 0),
+      w.hour_03_way_time_spontaneous = COALESCE(p.hour_03_way_time_spontaneous, 0),
+      w.hour_04_way_time_spontaneous = COALESCE(p.hour_04_way_time_spontaneous, 0),
+      w.hour_05_way_time_spontaneous = COALESCE(p.hour_05_way_time_spontaneous, 0),
+      w.hour_06_way_time_spontaneous = COALESCE(p.hour_06_way_time_spontaneous, 0),
+      w.hour_07_way_time_spontaneous = COALESCE(p.hour_07_way_time_spontaneous, 0),
+      w.hour_08_way_time_spontaneous = COALESCE(p.hour_08_way_time_spontaneous, 0),
+      w.hour_09_way_time_spontaneous = COALESCE(p.hour_09_way_time_spontaneous, 0),
+      w.hour_10_way_time_spontaneous = COALESCE(p.hour_10_way_time_spontaneous, 0),
+      w.hour_11_way_time_spontaneous = COALESCE(p.hour_11_way_time_spontaneous, 0),
+      w.hour_12_way_time_spontaneous = COALESCE(p.hour_12_way_time_spontaneous, 0),
+      w.hour_13_way_time_spontaneous = COALESCE(p.hour_13_way_time_spontaneous, 0),
+      w.hour_14_way_time_spontaneous = COALESCE(p.hour_14_way_time_spontaneous, 0),
+      w.hour_15_way_time_spontaneous = COALESCE(p.hour_15_way_time_spontaneous, 0),
+      w.hour_16_way_time_spontaneous = COALESCE(p.hour_16_way_time_spontaneous, 0),
+      w.hour_17_way_time_spontaneous = COALESCE(p.hour_17_way_time_spontaneous, 0),
+      w.hour_18_way_time_spontaneous = COALESCE(p.hour_18_way_time_spontaneous, 0),
+      w.hour_19_way_time_spontaneous = COALESCE(p.hour_19_way_time_spontaneous, 0),
+      w.hour_20_way_time_spontaneous = COALESCE(p.hour_20_way_time_spontaneous, 0),
+      w.hour_21_way_time_spontaneous = COALESCE(p.hour_21_way_time_spontaneous, 0),
+      w.hour_22_way_time_spontaneous = COALESCE(p.hour_22_way_time_spontaneous, 0),
+      w.hour_23_way_time_spontaneous = COALESCE(p.hour_23_way_time_spontaneous, 0),
+
+          /* avg way: appointment */
+      w.hour_00_way_time_appointment = COALESCE(p.hour_00_way_time_appointment, 0),
+      w.hour_01_way_time_appointment = COALESCE(p.hour_01_way_time_appointment, 0),
+      w.hour_02_way_time_appointment = COALESCE(p.hour_02_way_time_appointment, 0),
+      w.hour_03_way_time_appointment = COALESCE(p.hour_03_way_time_appointment, 0),
+      w.hour_04_way_time_appointment = COALESCE(p.hour_04_way_time_appointment, 0),
+      w.hour_05_way_time_appointment = COALESCE(p.hour_05_way_time_appointment, 0),
+      w.hour_06_way_time_appointment = COALESCE(p.hour_06_way_time_appointment, 0),
+      w.hour_07_way_time_appointment = COALESCE(p.hour_07_way_time_appointment, 0),
+      w.hour_08_way_time_appointment = COALESCE(p.hour_08_way_time_appointment, 0),
+      w.hour_09_way_time_appointment = COALESCE(p.hour_09_way_time_appointment, 0),
+      w.hour_10_way_time_appointment = COALESCE(p.hour_10_way_time_appointment, 0),
+      w.hour_11_way_time_appointment = COALESCE(p.hour_11_way_time_appointment, 0),
+      w.hour_12_way_time_appointment = COALESCE(p.hour_12_way_time_appointment, 0),
+      w.hour_13_way_time_appointment = COALESCE(p.hour_13_way_time_appointment, 0),
+      w.hour_14_way_time_appointment = COALESCE(p.hour_14_way_time_appointment, 0),
+      w.hour_15_way_time_appointment = COALESCE(p.hour_15_way_time_appointment, 0),
+      w.hour_16_way_time_appointment = COALESCE(p.hour_16_way_time_appointment, 0),
+      w.hour_17_way_time_appointment = COALESCE(p.hour_17_way_time_appointment, 0),
+      w.hour_18_way_time_appointment = COALESCE(p.hour_18_way_time_appointment, 0),
+      w.hour_19_way_time_appointment = COALESCE(p.hour_19_way_time_appointment, 0),
+      w.hour_20_way_time_appointment = COALESCE(p.hour_20_way_time_appointment, 0),
+      w.hour_21_way_time_appointment = COALESCE(p.hour_21_way_time_appointment, 0),
+      w.hour_22_way_time_appointment = COALESCE(p.hour_22_way_time_appointment, 0),
+      w.hour_23_way_time_appointment = COALESCE(p.hour_23_way_time_appointment, 0);
+
+        DROP TEMPORARY TABLE IF EXISTS tmp_ba_raw;
+        DROP TEMPORARY TABLE IF EXISTS tmp_ba_agg;
+        DROP TEMPORARY TABLE IF EXISTS tmp_pivot;
+
+        SET v_from = DATE_ADD(v_to, INTERVAL 1 DAY);
+    END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL zms_restore_waiting_waytimes_zmskvr_1213('2025-04-23', '2026-01-23', 7);
+
+DROP PROCEDURE IF EXISTS zms_restore_waiting_waytimes_zmskvr_1213;


### PR DESCRIPTION
## Summary
- Recovers wrong Wegezeiten in `wartenrstatistik` for **2025-04-23 – 2026-01-23** (muc23 → muc36), when cron divided archive way time by 60 once too often ([ZMSKVR-431](https://jira.muenchen.de/browse/ZMSKVR-431)).
- Same recover pattern as `91770274084` / `91757926126`: aggregate from `buergerarchiv`, then write averages — **without** `/60`.
- Batched in **7-day windows** via stored procedure (short locks, like log backfills).
- Updates only `hour_*_way_time_{spontaneous|appointment}`; waiting counts/times stay unchanged.
- Uses current column names after the rename/convert migrations.

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

## Test plan
- [ ] Dry-run SQL on a prod-like dump for a known scope/day in range; compare archive `AVG(way_time)` vs `hour_*_way_time_*` after migration
- [ ] Spot-check Wartestatistik GUI/Excel for a day before 2025-04-23 (unchanged), in-range (fixed to Min:Sec), and after 2026-01-23 (unchanged)
- [ ] Confirm migration is idempotent-ish (re-run yields same way averages from archive)
- [ ] Confirm no change to `hour_*_waiting_count_*` / `hour_*_waiting_time_*`
- [ ] Confirm batches complete without long locks (7-day windows)