### PR TITLE
feat(ZMSKVR-1349): restrict Status page and protect /status/ with X-Token

### DIFF
--- a/docs/de/operations/monitoring-and-status.md
+++ b/docs/de/operations/monitoring-and-status.md
@@ -14,6 +14,24 @@ GET /terminvereinbarung/api/2/status/
 
 (Host und API-Basispfad je nach Umgebung anpassen.)
 
+### Authentifizierung
+
+Anonymer Zugriff wird abgelehnt (`401`). Aufrufer brauchen **eine** der folgenden Varianten:
+
+| Aufrufer                                             | Auth                                                         |
+| ---------------------------------------------------- | ------------------------------------------------------------ |
+| Admin-UI (Seite „Status“)                            | Eingeloggte Workstation (Seite selbst erfordert `superuser`) |
+| Grafana / Prometheus json_exporter / `status-logger` | Header `X-Token: <ZMS_CONFIG_SECURE_TOKEN>`                  |
+
+Gleicher Token wie bei der Config-API (`ZMS_CONFIG_SECURE_TOKEN` / `App::SECURE_TOKEN`). Beispiel:
+
+```http
+GET /terminvereinbarung/api/2/status/
+X-Token: <Wert von ZMS_CONFIG_SECURE_TOKEN>
+```
+
+`GET /healthcheck/` bleibt ohne Auth für einfache Liveness-Probes.
+
 Die Antwort folgt [`status.json`](https://github.com/it-at-m/eappointment/blob/main/zmsentities/schema/status.json). ReDoc: [zmsbackend API-Referenz](./api-reference.md).
 
 ### Query-Parameter: `includeProcessStats`
@@ -56,7 +74,7 @@ Die OIDC-Zähler unterstützen die Beobachtung von Bürgerlogin und „Meine Ter
 
 Typisches Setup:
 
-1. **`GET /status/`** in Intervallen abfragen (Prometheus `json_exporter`, Skript oder Agent mit JSON-Parsing).
+1. **`GET /status/`** in Intervallen abfragen (Prometheus `json_exporter`, Skript oder Agent mit JSON-Parsing) und Header `X-Token` mit `ZMS_CONFIG_SECURE_TOKEN` mitschicken.
 2. Numerische Felder als Zeitreihen exportieren (z. B. `zms_processes_confirmed`, `zms_mail_queue_oldest_seconds`).
 3. In [Grafana](https://opensource.muenchen.de/software/grafana.html) visualisieren und Schwellwerte alarmieren (Mail-Backlog, `nodeConnections`, `clusterStatus`, …).
 

--- a/docs/en/operations/monitoring-and-status.md
+++ b/docs/en/operations/monitoring-and-status.md
@@ -14,6 +14,24 @@ GET /terminvereinbarung/api/2/status/
 
 (Adjust host and API base path to your environment.)
 
+### Authentication
+
+Anonymous access is denied (`401`). Callers must provide **one** of:
+
+| Caller                                                    | Auth                                                             |
+| --------------------------------------------------------- | ---------------------------------------------------------------- |
+| Admin UI (`/status/` page)                                | Logged-in workstation session (page itself requires `superuser`) |
+| Grafana / Prometheus json_exporter / `status-logger` Cron | Header `X-Token: <ZMS_CONFIG_SECURE_TOKEN>`                      |
+
+Same token as config API (`ZMS_CONFIG_SECURE_TOKEN` / `App::SECURE_TOKEN`). Example:
+
+```http
+GET /terminvereinbarung/api/2/status/
+X-Token: <value of ZMS_CONFIG_SECURE_TOKEN>
+```
+
+`GET /healthcheck/` stays unauthenticated for simple liveness probes.
+
 The response follows [`status.json`](https://github.com/it-at-m/eappointment/blob/main/zmsentities/schema/status.json). ReDoc: [zmsbackend API reference](./api-reference.md).
 
 ### Query parameter: `includeProcessStats`
@@ -56,7 +74,7 @@ OIDC-linked counts help track adoption of citizen login and â€œmy appointmentsâ€
 
 A typical setup:
 
-1. **Scrape** `GET /status/` on an interval (Prometheus `json_exporter`, custom script, or agent that parses JSON).
+1. **Scrape** `GET /status/` on an interval (Prometheus `json_exporter`, custom script, or agent that parses JSON), sending header `X-Token` with `ZMS_CONFIG_SECURE_TOKEN`.
 2. **Expose** numeric fields as time series (for example `zms_processes_confirmed`, `zms_mail_queue_oldest_seconds`).
 3. **Visualize** in [Grafana](https://opensource.muenchen.de/software/grafana.html) with alerts on thresholds (mail backlog, `nodeConnections`, zero `clusterStatus`, etc.).
 

--- a/zmsadmin/src/Zmsadmin/Status.php
+++ b/zmsadmin/src/Zmsadmin/Status.php
@@ -8,6 +8,9 @@
 
 namespace BO\Zmsadmin;
 
+use BO\Zmsentities\Exception\UserAccountMissingLogin;
+use BO\Zmsentities\Exception\UserAccountMissingRights;
+
 /**
  * Handle requests concerning services
  */
@@ -26,8 +29,13 @@ class Status extends BaseController
         try {
             $workstation = \App::$http->readGetResult('/workstation/')->getEntity();
         } catch (\Exception $workstationexception) {
-            $workstation = null;
+            throw new UserAccountMissingLogin();
         }
+
+        if (!$workstation->getUseraccount()->hasPermissions(['superuser'])) {
+            throw new UserAccountMissingRights();
+        }
+
         $result = \App::$http->readGetResult('/status/');
         return \BO\Slim\Render::withHtml(
             $response,

--- a/zmsadmin/src/Zmsadmin/Status.php
+++ b/zmsadmin/src/Zmsadmin/Status.php
@@ -16,6 +16,11 @@ use BO\Zmsentities\Exception\UserAccountMissingRights;
  */
 class Status extends BaseController
 {
+    private const MISSING_LOGIN_TEMPLATES = [
+        'BO\\Zmsentities\\Exception\\UserAccountMissingLogin',
+        'BO\\Zmsbackend\\Workstation\\Exception\\WorkstationNotFound',
+    ];
+
     /**
      * @SuppressWarnings(UnusedFormalParameter)
      * @return \Psr\Http\Message\ResponseInterface
@@ -28,8 +33,11 @@ class Status extends BaseController
     ): \Psr\Http\Message\ResponseInterface {
         try {
             $workstation = \App::$http->readGetResult('/workstation/')->getEntity();
-        } catch (\Exception $workstationexception) {
-            throw new UserAccountMissingLogin();
+        } catch (\BO\Zmsclient\Exception $exception) {
+            if (in_array($exception->template, self::MISSING_LOGIN_TEMPLATES, true)) {
+                throw new UserAccountMissingLogin();
+            }
+            throw $exception;
         }
 
         if (!$workstation->getUseraccount()->hasPermissions(['superuser'])) {

--- a/zmsadmin/templates/layout/main.twig
+++ b/zmsadmin/templates/layout/main.twig
@@ -88,7 +88,9 @@
             <div class="page-footer__right">
             <div class="page-version">
                 <a href="{{ urlGet('changelog', {}, {}) }}" class="version" title="Änderungshistorie anzeigen">Änderungshistorie</a> | <span>Version {{ currentVersion() }}</span>
+                {% if workstation.useraccount.permissions.superuser|default(false) %}
                 <a href="{{ urlGet('status', {}, {}) }}" class="version" title="Betriebsstatus des Systems">Status</a>
+                {% endif %}
                 {% if getSystemStatus('ZMS_ENV') %}<p>{{ getSystemStatus('ZMS_ENV') }}</p>{% endif %}
             </div>
             </div>

--- a/zmsadmin/tests/Zmsadmin/StatusTest.php
+++ b/zmsadmin/tests/Zmsadmin/StatusTest.php
@@ -33,7 +33,7 @@ class StatusTest extends Base
     {
         $this->expectException('\BO\Zmsentities\Exception\UserAccountMissingLogin');
         $exception = new \BO\Zmsclient\Exception();
-        $exception->template = 'BO\Zmsaoi\Exception\Workstation\WorkstationNotFound';
+        $exception->template = 'BO\Zmsentities\Exception\UserAccountMissingLogin';
         $this->setApiCalls(
             [
                 [

--- a/zmsadmin/tests/Zmsadmin/StatusTest.php
+++ b/zmsadmin/tests/Zmsadmin/StatusTest.php
@@ -7,7 +7,6 @@ class StatusTest extends Base
     protected $arguments = [];
     protected $parameters = [];
 
-
     public function testRendering()
     {
         $this->setApiCalls(
@@ -15,7 +14,7 @@ class StatusTest extends Base
                 [
                     'function' => 'readGetResult',
                     'url' => '/workstation/',
-                    'response' => $this->readFixture("GET_workstation_basic.json")
+                    'response' => $this->readFixture("GET_Workstation_Superuser_Resolved1.json")
                 ],
                 [
                     'function' => 'readGetResult',
@@ -32,6 +31,7 @@ class StatusTest extends Base
 
     public function testWithoutWorkstation()
     {
+        $this->expectException('\BO\Zmsentities\Exception\UserAccountMissingLogin');
         $exception = new \BO\Zmsclient\Exception();
         $exception->template = 'BO\Zmsaoi\Exception\Workstation\WorkstationNotFound';
         $this->setApiCalls(
@@ -40,15 +40,24 @@ class StatusTest extends Base
                     'function' => 'readGetResult',
                     'url' => '/workstation/',
                     'exception' => $exception
-                ],
-                [
-                    'function' => 'readGetResult',
-                    'url' => '/status/',
-                    'response' => $this->readFixture("GET_status.json")
                 ]
             ]
         );
-        $response = parent::testRendering();
-        $this->assertStringNotContainsString('(Nur für technische Administration sichtbar)', (string)$response->getBody());
+        parent::testRendering();
+    }
+
+    public function testWithoutSuperuserPermission()
+    {
+        $this->expectException('\BO\Zmsentities\Exception\UserAccountMissingRights');
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'response' => $this->readFixture("GET_workstation_basic.json")
+                ]
+            ]
+        );
+        parent::testRendering();
     }
 }

--- a/zmsautomation/README.md
+++ b/zmsautomation/README.md
@@ -133,6 +133,7 @@ Required environment variables for ATAF tests:
 ### API Endpoints
 - `BASE_URI` - ZMS API base (default in `zmsautomation-test`: `http://web/terminvereinbarung/api/2` for Docker Compose / devcontainer). Use `http://localhost/...` when the test process runs **inside** the `web` container and should hit local Apache only.
 - `CITIZEN_API_BASE_URI` - Citizen API base (default: `http://web/terminvereinbarung/api/citizen`) — **direct** to zms-web. REST steps use this; **refarch-gateway is not used** for those pings.
+- `ZMS_CONFIG_SECURE_TOKEN` - Token for `X-Token` on protected API calls such as `GET /status/` (default: `hash`, same as local `.env`). Required for zmsbackend health checks after ZMSKVR-1349.
 - `ADMIN_BASE_URI` / `STATISTIC_BASE_URI` - Defaults use `http://localhost/terminvereinbarung/.../` (typical when tests run inside the `web` container).
 - `CITIZEN_VIEW_BASE_URI` / `CITIZENVIEW_PORT` - CitizenView / Vite dev server (defaults: port `8082`, base `http://citizenview:8082/`). Override if your stack uses another port (e.g. prebuilt nginx image on `8080`).
 - `REFARCH_GATEWAY_OFFICES_URL` - Optional override for the extra health ping that hits the gateway (default: `http://refarch-gateway:8080/buergeransicht/api/citizen/offices-and-services/`). Same URL path the browser uses; produces lines in gateway logs.

--- a/zmsautomation/src/test/java/config/TestConfig.java
+++ b/zmsautomation/src/test/java/config/TestConfig.java
@@ -85,4 +85,17 @@ public final class TestConfig {
         return getConfigValue("AUTH_TOKEN", "AUTH_TOKEN", null);
     }
 
+    /**
+     * Secure token for endpoints that accept {@code X-Token}
+     * (e.g. {@code GET /status/}, config API). Matches {@code ZMS_CONFIG_SECURE_TOKEN}.
+     * Default: {@code hash} (local ddev / devcontainer).
+     */
+    public static String getSecureToken() {
+        return getConfigValue(
+            "ZMS_CONFIG_SECURE_TOKEN",
+            "ZMS_CONFIG_SECURE_TOKEN",
+            "hash"
+        );
+    }
+
 }

--- a/zmsautomation/src/test/java/zms/ataf/rest/steps/ZmsApiSteps.java
+++ b/zmsautomation/src/test/java/zms/ataf/rest/steps/ZmsApiSteps.java
@@ -48,6 +48,7 @@ public class ZmsApiSteps {
         
         given()
             .baseUri(baseUri)
+            .header("X-Token", TestConfig.getSecureToken())
         .when()
             .get("/status/")
         .then()
@@ -56,8 +57,22 @@ public class ZmsApiSteps {
     
     @When("I make a GET request to {string}")
     public void iMakeAGetRequestTo(String endpoint) {
+        var request = given()
+            .baseUri(baseUri != null ? baseUri : TestConfig.getBaseUri());
+        if ("/status/".equals(endpoint) || endpoint.startsWith("/status/?")) {
+            request.header("X-Token", TestConfig.getSecureToken());
+        }
+        response = request
+        .when()
+            .get(endpoint);
+        CommonApiSteps.setResponse(response);
+    }
+
+    @When("I make a GET request to {string} with the X-Token")
+    public void iMakeAGetRequestToWithTheXToken(String endpoint) {
         response = given()
             .baseUri(baseUri != null ? baseUri : TestConfig.getBaseUri())
+            .header("X-Token", TestConfig.getSecureToken())
         .when()
             .get(endpoint);
         CommonApiSteps.setResponse(response);

--- a/zmsautomation/src/test/resources/features/rest/zmsapi/status.feature
+++ b/zmsautomation/src/test/resources/features/rest/zmsapi/status.feature
@@ -8,6 +8,6 @@ Feature: ZMS API Status Endpoint
     Given the ZMS API is available
 
   Scenario: GET /status/ returns 200 and JSON body
-    When I make a GET request to "/status/"
+    When I make a GET request to "/status/" with the X-Token
     Then the response status code should be 200
     And the response should contain status information

--- a/zmsautomation/zmsautomation-test
+++ b/zmsautomation/zmsautomation-test
@@ -78,6 +78,8 @@ export BASE_URI="${BASE_URI:-http://web/terminvereinbarung/api/2}"
 export CITIZEN_API_BASE_URI="${CITIZEN_API_BASE_URI:-http://web/terminvereinbarung/api/citizen}"
 export ADMIN_BASE_URI="${ADMIN_BASE_URI:-http://localhost/terminvereinbarung/admin/}"
 export STATISTIC_BASE_URI="${STATISTIC_BASE_URI:-http://localhost/terminvereinbarung/statistic/}"
+# Same token as zmsbackend App::SECURE_TOKEN / local .env (ZMSKVR-1349 protects GET /status/)
+export ZMS_CONFIG_SECURE_TOKEN="${ZMS_CONFIG_SECURE_TOKEN:-hash}"
 
 export CITIZENVIEW_PORT="${CITIZENVIEW_PORT:-8082}"
 CITIZENVIEW_BASE_URI="${CITIZENVIEW_BASE_URI:-http://citizenview:${CITIZENVIEW_PORT}}"
@@ -460,6 +462,7 @@ HEALTH_PERTRY_TIMEOUT="${HEALTH_PERTRY_TIMEOUT:-15}"
 
 ZMS_API_HEALTH_URL="$(join_url "${BASE_URI}" "status/")"
 : "${CITIZEN_API_BASE_URI:?CITIZEN_API_BASE_URI must be set}"
+: "${ZMS_CONFIG_SECURE_TOKEN:?ZMS_CONFIG_SECURE_TOKEN must be set}"
 CITIZEN_API_HEALTH_URL="$(join_url "${CITIZEN_API_BASE_URI}" "offices-and-services/")"
 ZMSCITIZENVIEW_HEALTH_URL="${CITIZENVIEW_BASE_URI}"
 REFARCH_GATEWAY_OFFICES_URL="${REFARCH_GATEWAY_OFFICES_URL:-http://refarch-gateway:8080/buergeransicht/api/citizen/offices-and-services/}"
@@ -475,11 +478,13 @@ CITIZEN_API_AVAIL_CALENDAR_URL="$(join_url "${CITIZEN_API_BASE_URI}" "available-
 # one-shot warm-up (ignore exit code)
 curl -sS -o /dev/null --max-time 30 "$CITIZEN_API_HEALTH_URL" || true
 
-wait_http() { # name url
-  local n="$1" u="$2" tries=$(( (HEALTH_MAX_WAIT + HEALTH_INTERVAL - 1)/HEALTH_INTERVAL ))
+wait_http() { # name url [extra curl args...]
+  local n="$1" u="$2"
+  shift 2
+  local tries=$(( (HEALTH_MAX_WAIT + HEALTH_INTERVAL - 1)/HEALTH_INTERVAL ))
   info "Pinging ${n}: ${u}"
   for ((i=1;i<=tries;i++)); do
-    code="$(curl -sS -o /dev/null -w "%{http_code}" --max-time "${HEALTH_PERTRY_TIMEOUT}" --noproxy "localhost,127.0.0.1,::1" "$u" || echo 000)"
+    code="$(curl -sS -o /dev/null -w "%{http_code}" --max-time "${HEALTH_PERTRY_TIMEOUT}" --noproxy "localhost,127.0.0.1,::1" "$@" "$u" || echo 000)"
     # Accept only real HTTP 2xx or 3xx responses.
     [[ "$code" =~ ^[23][0-9][0-9]$ ]] && { info "✓ ${n} responding (${code})"; return 0; }
     (( i<tries )) && { warn "… ${n} not ready (${code}); retry in ${HEALTH_INTERVAL}s (${i}/${tries})"; sleep "${HEALTH_INTERVAL}"; }
@@ -508,7 +513,7 @@ if [[ ! -f "$DLDB_SERVICES_JSON" ]]; then
   warn "citizenapi-available-calendar needs DLDB data (officeId=10502, serviceId=1063441); health checks will fail until import succeeds."
   fail=true
 fi
-wait_http "zmsbackend"                 "$ZMS_API_HEALTH_URL"          || fail=true
+wait_http "zmsbackend"                 "$ZMS_API_HEALTH_URL" -H "X-Token: ${ZMS_CONFIG_SECURE_TOKEN}" || fail=true
 info "citizenapi ping uses direct PHP route (not gateway): ${CITIZEN_API_HEALTH_URL}"
 wait_http "citizenapi"                 "$CITIZEN_API_HEALTH_URL"      || fail=true
 wait_http "citizenapi-available-calendar"  "$CITIZEN_API_AVAIL_CALENDAR_URL"  || fail=true
@@ -703,6 +708,7 @@ while (( attempt <= MAX_UI_RETRIES )); do
     "${PLATFORM_ARGS[@]}" \
     -DBASE_URI="$BASE_URI" \
     -DCITIZEN_API_BASE_URI="$CITIZEN_API_BASE_URI" \
+    -DZMS_CONFIG_SECURE_TOKEN="$ZMS_CONFIG_SECURE_TOKEN" \
     -Dbrowser="${ZMS_BROWSER:-chrome}" \
     -Dtestautomation.browser="${ZMS_BROWSER:-chrome}" \
     -Dwebdriver.gecko.driver="${WEBDRIVER_GECKO_DRIVER:-/usr/local/bin/geckodriver}" \

--- a/zmsbackend/routing.php
+++ b/zmsbackend/routing.php
@@ -5798,6 +5798,11 @@
  *          tags:
  *              - status
  *          parameters:
+ *              -   name: X-Token
+ *                  description: "Required when not logged in (e.g. Grafana / status-logger). Must match ZMS_CONFIG_SECURE_TOKEN."
+ *                  in: header
+ *                  type: string
+ *                  required: false
  *              -   name: includeProcessStats
  *                  description: "Collecting stats about processes slows the request down. For healthcheck, this data might not be necessary. Default is to include the stats, a value of 0 skip the stats."
  *                  in: query
@@ -5807,6 +5812,8 @@
  *                  description: "success"
  *                  schema:
  *                      $ref: "schema/status.json"
+ *              401:
+ *                  description: "missing workstation login and invalid or missing X-Token"
  */
 \App::$slim->get(
     '/status/',

--- a/zmsbackend/src/Zmsbackend/Status/Api/StatusGet.php
+++ b/zmsbackend/src/Zmsbackend/Status/Api/StatusGet.php
@@ -8,7 +8,10 @@
 namespace BO\Zmsbackend\Status\Api;
 
 use BO\Slim\Render;
+use BO\Zmsbackend\Status\Exception\StatusAuthenticationFailed;
 use BO\Zmsbackend\Status\Service\Status;
+use BO\Zmsentities\Exception\UserAccountMissingLogin;
+use BO\Zmsentities\Exception\UserAccountMissingRights;
 
 class StatusGet extends \BO\Zmsbackend\Api\BaseController
 {
@@ -45,17 +48,21 @@ class StatusGet extends \BO\Zmsbackend\Api\BaseController
 
     /**
      * Allow access with a logged-in workstation (admin UI) or X-Token matching
-     * ZMS_CONFIG_SECURE_TOKEN (Grafana / status-logger). Same pattern as ConfigGet.
+     * ZMS_CONFIG_SECURE_TOKEN (Grafana / status-logger). Same idea as ConfigGet,
+     * with strict token comparison and a narrow auth-exception catch.
      */
     private function assertStatusAccess(\Psr\Http\Message\RequestInterface $request): void
     {
         try {
             (new \BO\Zmsbackend\Helper\User($request))->checkPermissions();
-        } catch (\Exception $exception) {
-            $token = $request->getHeader('X-Token');
-            if (\App::SECURE_TOKEN != current($token)) {
-                throw new \BO\Zmsbackend\Status\Exception\StatusAuthentificationFailed();
-            }
+            return;
+        } catch (UserAccountMissingLogin | UserAccountMissingRights $exception) {
+            // Fall through to X-Token for scrapers / unauthenticated callers.
+        }
+
+        $token = $request->getHeaderLine('X-Token');
+        if ($token === '' || !hash_equals((string) \App::SECURE_TOKEN, $token)) {
+            throw new StatusAuthenticationFailed();
         }
     }
 }

--- a/zmsbackend/src/Zmsbackend/Status/Api/StatusGet.php
+++ b/zmsbackend/src/Zmsbackend/Status/Api/StatusGet.php
@@ -22,6 +22,8 @@ class StatusGet extends \BO\Zmsbackend\Api\BaseController
         \Psr\Http\Message\ResponseInterface $response,
         array $args
     ) {
+        $this->assertStatusAccess($request);
+
         $validator = $request->getAttribute('validator');
         $includeProcessStats = $validator->getParameter('includeProcessStats')->isNumber()->setDefault(1)->getValue();
         $status = (new \BO\Zmsbackend\Status\Service\Status())->readEntity(\App::$now, $includeProcessStats);
@@ -39,5 +41,21 @@ class StatusGet extends \BO\Zmsbackend\Api\BaseController
         $response = Render::withLastModified($response, time(), '0');
         $response = Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
         return $response;
+    }
+
+    /**
+     * Allow access with a logged-in workstation (admin UI) or X-Token matching
+     * ZMS_CONFIG_SECURE_TOKEN (Grafana / status-logger). Same pattern as ConfigGet.
+     */
+    private function assertStatusAccess(\Psr\Http\Message\RequestInterface $request): void
+    {
+        try {
+            (new \BO\Zmsbackend\Helper\User($request))->checkPermissions();
+        } catch (\Exception $exception) {
+            $token = $request->getHeader('X-Token');
+            if (\App::SECURE_TOKEN != current($token)) {
+                throw new \BO\Zmsbackend\Status\Exception\StatusAuthentificationFailed();
+            }
+        }
     }
 }

--- a/zmsbackend/src/Zmsbackend/Status/Exception/StatusAuthenticationFailed.php
+++ b/zmsbackend/src/Zmsbackend/Status/Exception/StatusAuthenticationFailed.php
@@ -5,9 +5,9 @@ namespace BO\Zmsbackend\Status\Exception;
 /**
  * Thrown when /status/ is called without a valid workstation login or X-Token.
  */
-class StatusAuthentificationFailed extends \Exception
+class StatusAuthenticationFailed extends \Exception
 {
     protected $code = 401;
 
-    protected $message = 'Authentification failed - access to status not granted';
+    protected $message = 'Authentication failed - access to status not granted';
 }

--- a/zmsbackend/src/Zmsbackend/Status/Exception/StatusAuthentificationFailed.php
+++ b/zmsbackend/src/Zmsbackend/Status/Exception/StatusAuthentificationFailed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BO\Zmsbackend\Status\Exception;
+
+/**
+ * Thrown when /status/ is called without a valid workstation login or X-Token.
+ */
+class StatusAuthentificationFailed extends \Exception
+{
+    protected $code = 401;
+
+    protected $message = 'Authentification failed - access to status not granted';
+}

--- a/zmsbackend/tests/Zmsbackend/Status/Api/StatusGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Status/Api/StatusGetTest.php
@@ -8,8 +8,27 @@ class StatusGetTest extends \BO\Zmsbackend\Tests\Api\Base
 
     public function testRendering()
     {
-        $response = $this->render();
+        $response = $this->render([], [
+            '__header' => [
+                'X-Token' => 'secure-token',
+            ],
+        ], []);
         $this->assertStringContainsString('status.json', (string)$response->getBody());
         $this->assertTrue(200 == $response->getStatusCode());
+    }
+
+    public function testStatusByWorkstationLogin()
+    {
+        $this->setWorkstation();
+        $response = $this->render([], [], []);
+        $this->assertStringContainsString('status.json', (string)$response->getBody());
+        $this->assertTrue(200 == $response->getStatusCode());
+    }
+
+    public function testAuthentificationFailed()
+    {
+        $this->expectException('\BO\Zmsbackend\Status\Exception\StatusAuthentificationFailed');
+        $this->expectExceptionCode(401);
+        $this->render([], [], []);
     }
 }

--- a/zmsbackend/tests/Zmsbackend/Status/Api/StatusGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Status/Api/StatusGetTest.php
@@ -25,10 +25,32 @@ class StatusGetTest extends \BO\Zmsbackend\Tests\Api\Base
         $this->assertTrue(200 == $response->getStatusCode());
     }
 
-    public function testAuthentificationFailed()
+    public function testAuthenticationFailed()
     {
-        $this->expectException('\BO\Zmsbackend\Status\Exception\StatusAuthentificationFailed');
+        $this->expectException('\BO\Zmsbackend\Status\Exception\StatusAuthenticationFailed');
         $this->expectExceptionCode(401);
         $this->render([], [], []);
+    }
+
+    public function testAuthenticationFailedWithEmptyToken()
+    {
+        $this->expectException('\BO\Zmsbackend\Status\Exception\StatusAuthenticationFailed');
+        $this->expectExceptionCode(401);
+        $this->render([], [
+            '__header' => [
+                'X-Token' => '',
+            ],
+        ], []);
+    }
+
+    public function testAuthenticationFailedWithWrongToken()
+    {
+        $this->expectException('\BO\Zmsbackend\Status\Exception\StatusAuthenticationFailed');
+        $this->expectExceptionCode(401);
+        $this->render([], [
+            '__header' => [
+                'X-Token' => 'wrong-token',
+            ],
+        ], []);
     }
 }


### PR DESCRIPTION
## Summary
- Hide the admin footer **Status** link and block the Status page for non-`superuser` users (direct URL → missing rights/login).
- Protect backend `GET /status/` with workstation login **or** `X-Token: $ZMS_CONFIG_SECURE_TOKEN` (same pattern as ConfigGet); anonymous calls get `401`.
- Keep `GET /healthcheck/` public. Document scraper auth for Grafana.

## Ops note
Grafana / json_exporter / status-logger must send `X-Token` with `ZMS_CONFIG_SECURE_TOKEN` after deploy. Deployment chart changes are **not** in this PR (separate `zms-deployment` repo).

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

## Test plan
- [ ] As `system_admin` / superuser: Status link visible; Status page loads
- [ ] As non-superuser: no Status link; direct `/status/` URL denied
- [ ] `GET /status/` without auth → 401
- [ ] `GET /status/` with `X-Token: $ZMS_CONFIG_SECURE_TOKEN` → 200
- [ ] `GET /healthcheck/` still works without token
- [ ] Unit: `StatusGetTest`, `StatusTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication requirements for the `/status/` endpoint using an authenticated admin session or secure token.
  * Added clear `401 Unauthorized` responses for invalid or missing status credentials.
  * Kept `/healthcheck/` available without authentication for liveness monitoring.
  * Updated Grafana monitoring guidance to include secure-token authentication.

* **Bug Fixes**
  * Restricted the system-status link to users with superuser permissions.
  * Improved handling when workstation access or required permissions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->