### PR TITLE
fix(ZMSKVR-69): number of services is reset after reselection

### DIFF
--- a/zmsadmin/js/block/appointment/index.js
+++ b/zmsadmin/js/block/appointment/index.js
@@ -214,13 +214,21 @@ class View extends RequestView {
     }
 
     onAddRequestCount(event) {
-        $(event.currentTarget).parent().find('.hidden-inputs input:first-child').clone().insertAfter($(event.currentTarget).parent().find('.hidden-inputs input:first-child'));
-        $(event.currentTarget).parent().find('.request-count').text(parseInt($(event.currentTarget).parent().find('.request-count').text()) + 1);
+        const request = $(event.currentTarget).parent();
+        const hiddenInputs = request.find('.hidden-inputs');
+        const count = parseInt(request.find('.request-count').text()) + 1;
+
+        hiddenInputs
+            .find('input:first-child')
+            .clone()
+            .appendTo(hiddenInputs);
+
+        this.updateRequestCount(request, count);
 
         this.addServiceToList($(event.currentTarget), 'serviceListSelected');
         this.removeServiceFromList($(event.currentTarget), 'serviceList');
         this.updateLists(true);
-        this.auralMessage(this.auralMessages.add + ': ' + $(event.currentTarget).parent().find('span').text());
+        this.auralMessage(this.auralMessages.add + ': ' + request.find('span').last().text());
     }
 
     onRemoveRequestCount(event) {
@@ -233,8 +241,8 @@ class View extends RequestView {
         }
 
         if (count > 1) {
-            $(event.currentTarget).parent().find('.request-count').text(count - 1);
             input.remove();
+            this.updateRequestCount($(event.currentTarget).parent(), count - 1);
         }
 
         this.auralMessage(this.auralMessages.remove + ': ' + input.parent().find('span').text());

--- a/zmsadmin/js/block/appointment/index.js
+++ b/zmsadmin/js/block/appointment/index.js
@@ -225,8 +225,6 @@ class View extends RequestView {
 
         this.updateRequestCount(request, count);
 
-        this.addServiceToList($(event.currentTarget), 'serviceListSelected');
-        this.removeServiceFromList($(event.currentTarget), 'serviceList');
         this.updateLists(true);
         this.auralMessage(this.auralMessages.add + ': ' + request.find('span').last().text());
     }

--- a/zmsadmin/js/block/appointment/requests.js
+++ b/zmsadmin/js/block/appointment/requests.js
@@ -76,17 +76,29 @@ class View extends BaseView {
             }
     }
 
+    updateRequestCount(element, count) {
+        element.find('.request-count').text(count);
+        element.find('.minus').attr(
+            'aria-label',
+            `Anzahl der Dienstleistung verringern auf ${count - 1}`
+        );
+        element.find('.plus').attr(
+            'aria-label',
+            `Anzahl der Dienstleistung erhöhen auf ${count + 1}`
+        );
+    }
+
     cleanLists() {
         this.serviceList = this.$main.find('.checkboxselect input:checkbox').map(function () {
             return $(this).val();
         }).toArray();
         this.serviceListSelected = [];
 
-        this.$main.find('.checkboxdeselect li').each(function () {
-            const $request = $(this);
+        this.$main.find('.checkboxdeselect li').each((index, element) => {
+            const request = $(element);
 
-            $request.find('.request-count').text(1);
-            $request.find('.hidden-inputs input:checkbox').slice(1).remove();
+            this.updateRequestCount(request, 1);
+            request.find('.hidden-inputs input:checkbox').slice(1).remove();
         });
 
         this.updateLists(true);

--- a/zmsadmin/js/block/appointment/requests.js
+++ b/zmsadmin/js/block/appointment/requests.js
@@ -81,6 +81,14 @@ class View extends BaseView {
             return $(this).val();
         }).toArray();
         this.serviceListSelected = [];
+
+        this.$main.find('.checkboxdeselect li').each(function () {
+            const $request = $(this);
+
+            $request.find('.request-count').text(1);
+            $request.find('.hidden-inputs input:checkbox').slice(1).remove();
+        });
+
         this.updateLists(true);
     }
 

--- a/zmsadmin/package-lock.json
+++ b/zmsadmin/package-lock.json
@@ -6146,6 +6146,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/zmsadmin/package-lock.json
+++ b/zmsadmin/package-lock.json
@@ -6146,7 +6146,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [ ] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [ ] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [ ] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request counts now reset to 1 when clearing appointment request lists.
  * Removed stale hidden selections to keep request data accurate.
  * Improved increment and decrement controls so displayed counts and selections stay synchronized.

* **Accessibility**
  * Updated control labels to clearly communicate current request counts and available actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->