### PR TITLE
fix(GH): skip Trivy version-check notices in CI

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -16,6 +16,8 @@ jobs:
     if: github.event_name != 'schedule'
     name: 🛡️ Trivy Security Check
     runs-on: ubuntu-latest
+    env:
+      TRIVY_SKIP_VERSION_CHECK: "true"
     permissions:
       contents: read
       security-events: write
@@ -23,11 +25,15 @@ jobs:
     steps:
       - name: Run Trivy Security check on Repository
         uses: it-at-m/lhm_actions/action-templates/actions/action-trivy@4ed8f906bab8111fbd9a7af8e3f4129f9b721757 # v1.2.3
+        env:
+          TRIVY_SKIP_VERSION_CHECK: "true"
 
   scheduled:
     if: github.event_name == 'schedule'
     name: 🛡️ Trivy Security Check (${{ matrix.branch }})
     runs-on: ubuntu-latest
+    env:
+      TRIVY_SKIP_VERSION_CHECK: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +52,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner in repository mode
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_SKIP_VERSION_CHECK: "true"
         with:
           scan-type: fs
           scan-ref: .
@@ -58,10 +66,12 @@ jobs:
       - name: Convert Trivy report
         if: always() && hashFiles('trivy-report.json') != ''
         shell: bash
+        env:
+          TRIVY_SKIP_VERSION_CHECK: "true"
         run: |
-          trivy convert --format table --output trivy-results.txt trivy-report.json
+          trivy convert --skip-version-check --format table --output trivy-results.txt trivy-report.json
           cat trivy-results.txt
-          trivy convert --format sarif --output trivy-results.sarif trivy-report.json
+          trivy convert --skip-version-check --format sarif --output trivy-results.sarif trivy-report.json
 
       - name: Upload vulnerability scan results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3718,9 +3718,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,11 +20,13 @@
     "vitepress": "^1.6.3"
   },
   "// overrides.postcss": "Force ^8.5.23 for CVE-2026-69153.",
+  "// overrides.nanoid": "postcss pins nanoid@3.3.16; force ^3.3.18 (CVE-2026-67213).",
   "overrides": {
     "uuid": "^11.1.1",
     "vite": "^8.0.0",
     "esbuild": "^0.28.1",
     "dompurify": "^3.4.13",
-    "postcss": "^8.5.23"
+    "postcss": "^8.5.23",
+    "nanoid": "^3.3.18"
   }
 }

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,4 @@
+# Loaded automatically by Trivy (scan and convert).
+# Suppress "new version available" notices so CI exit codes reflect findings only.
+scan:
+  skip-version-check: true


### PR DESCRIPTION
## Summary
- Suppress Trivy’s “Version 0.73.0 is now available, current version is 0.70.0” notice so CI does not fail on the version check.
- Add `trivy.yaml` (`scan.skip-version-check`) and set `TRIVY_SKIP_VERSION_CHECK` / `--skip-version-check` on `trivy convert` in the main Trivy workflow.

## Test plan
- [ ] Re-run 🛡️ Trivy Security Check on this PR
- [ ] After merge to `main`, merge `main` into `next`