### PR TITLE
feat(GH): add actionlint and fix existing workflow findings

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,13 @@
+# Workflow for scanning GitHub workflows with actionlint
+name: Actionlint
+
+on:
+  # Runs on pull requests
+  pull_request:
+
+jobs:
+  actionlint:
+    name: Run actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: it-at-m/lhm_actions/action-templates/actions/action-actionlint@7bed7092684c0bcc176811016aed27b532aa5f51 # v1.4.0

--- a/.github/workflows/build-api-docs.yaml
+++ b/.github/workflows/build-api-docs.yaml
@@ -69,4 +69,4 @@ jobs:
       - name: Set job result
         id: set-result
         if: always()
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -7,12 +7,10 @@ on:
         description: 'Name of the coverage reports artifact'
         required: true
         type: string
-        default: 'coverage-reports'
       api_docs_artifact:
         description: 'Name of the API documentation artifact'
         required: true
         type: string
-        default: 'api-docs'
       git_commit:
         description: 'Git commit hash'
         required: true

--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Set job result
         id: set-result
         if: always()
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
 
     strategy:
       fail-fast: false
@@ -181,7 +181,7 @@ jobs:
       - name: Set job result
         id: set-result
         if: always()
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
 
   zmsclient-test:
     runs-on: ubuntu-latest
@@ -234,4 +234,4 @@ jobs:
       - name: Set job result
         id: set-result
         if: always()
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
         working-directory: ${{ matrix.project }}
 
       - name: Cache Composer dependencies
@@ -176,7 +176,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache-monorepo
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
         working-directory: zmsbackend
 
       - name: Cache Composer dependencies

--- a/.github/workflows/zmsautomation-workflow.yaml
+++ b/.github/workflows/zmsautomation-workflow.yaml
@@ -285,16 +285,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          REF_TYPE="branch"
           REF_NAME="${{ matrix.branch }}"
 
           SANITIZED="$(echo "$REF_NAME" | sed 's/[\/:]/-/g')"
           PHP_TAG="branch-${SANITIZED}"
           BRANCH_SLUG="$SANITIZED"
 
-          echo "branch_name=$REF_NAME" >> "$GITHUB_OUTPUT"
-          echo "branch_slug=$BRANCH_SLUG" >> "$GITHUB_OUTPUT"
-          echo "php_tag=$PHP_TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "branch_name=$REF_NAME"
+            echo "branch_slug=$BRANCH_SLUG"
+            echo "php_tag=$PHP_TAG"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Pull prebuilt PHP module images
         shell: bash
@@ -456,6 +457,8 @@ jobs:
           if ! docker exec -u root "$WEB_CONT" bash -lc 'test -d /var/www/html/zmslayout/js && test -d /var/www/html/zmslayout/scss'; then
             echo "zmslayout not on bind mount; streaming via tar"
             docker exec -u root "$WEB_CONT" bash -lc "mkdir -p /var/www/html/zmslayout"
+            # WEB_CONT is passed via env so the inner shell can expand it.
+            # shellcheck disable=SC2016
             retry 3 10 env WEB_CONT="$WEB_CONT" bash -c 'tar cf - -C ./zmslayout . | docker exec -i -u root "$WEB_CONT" tar -xf - -C /var/www/html/zmslayout/'
           fi
 

--- a/.github/workflows/zmscitizenview-coverage.yaml
+++ b/.github/workflows/zmscitizenview-coverage.yaml
@@ -115,4 +115,4 @@ jobs:
       - name: Set job result
         id: set-result
         if: always()
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/actionlint.yml` using LHM `action-actionlint` **v1.4.0** (same pin as Trivy), so PRs lint GitHub workflows.
- Fix current findings so the new check is green: quote `$GITHUB_OUTPUT`, drop unused `workflow_call` defaults, and clean a few zmsautomation shellcheck issues.
- v1.4.0 ships actionlint 1.7.12, which allows 25 `workflow_dispatch` inputs (GitHub’s current limit). v1.2.4 would fail on zmsautomation’s 13 inputs.

## Test plan
- [x] Confirm **Actionlint** runs on this PR and passes
- [x] Spot-check that zmsautomation / deploy-pages / php-unit-tests YAML still look correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for workflow files on pull requests.
  * Improved workflow reliability when handling output paths and environment values.
  * Updated deployment configuration to require explicit artifact names.
  * Simplified workflow output handling and removed an unused value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->