### PR TITLE
fix(ZMS): declare App::SECURE_TOKEN on Slim Application

### DIFF
--- a/zmsslim/src/Slim/Application.php
+++ b/zmsslim/src/Slim/Application.php
@@ -33,11 +33,14 @@ class Application
     public const bool DEBUG = false;
     const DEBUGLEVEL = ZMS_DEBUGLEVEL;
     const SESSION_DURATION = ZMS_SESSION_DURATION;
-    /**
-     * Token for X-Token / config API. Modules override from ZMS_CONFIG_SECURE_TOKEN.
-     * Declared here so the monorepo Psalm scan resolves \App::SECURE_TOKEN.
-     */
     const SECURE_TOKEN = '';
+    const CONFIG_SECURE_TOKEN = '';
+    const RIGHTSCHECK_ENABLED = true;
+    const JSON_COMPRESS_LEVEL = 1;
+    const HTTP_BASE_URL = '';
+    const CLIENTKEY = '';
+    const MAINTENANCE_MODE_ENABLED = false;
+    const ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME = '';
     const LOG_ERRORS = true;
     const LOG_DETAILS = true;
 /**

--- a/zmsslim/src/Slim/Application.php
+++ b/zmsslim/src/Slim/Application.php
@@ -33,6 +33,11 @@ class Application
     public const bool DEBUG = false;
     const DEBUGLEVEL = ZMS_DEBUGLEVEL;
     const SESSION_DURATION = ZMS_SESSION_DURATION;
+    /**
+     * Token for X-Token / config API. Modules override from ZMS_CONFIG_SECURE_TOKEN.
+     * Declared here so the monorepo Psalm scan resolves \App::SECURE_TOKEN.
+     */
+    const SECURE_TOKEN = '';
     const LOG_ERRORS = true;
     const LOG_DETAILS = true;
 /**


### PR DESCRIPTION
## Summary
- Psalm code scanning [alert 42019](https://github.com/it-at-m/eappointment/security/code-scanning/42019) reports `App::SECURE_TOKEN` as undefined in `StatusGet`.
- The monorepo Psalm scan collapses several `class App` definitions, so inherited module constants are not visible on `\App`.
- Declare the missing constants on `\BO\Slim\Application` (empty/safe defaults). Modules still override them. Call sites stay on `\App::…`.

Also covers the other open Psalm `UndefinedConstant` alerts for `\App::`:
- `SECURE_TOKEN` (ConfigGet / ConfigUpdate / AvailabilityListByScope)
- `CONFIG_SECURE_TOKEN`, `CLIENTKEY`, `HTTP_BASE_URL`, `JSON_COMPRESS_LEVEL`
- `RIGHTSCHECK_ENABLED`
- `MAINTENANCE_MODE_ENABLED`, `ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME`

## Test plan
- [ ] Confirm `GET /status/` with `X-Token` still authenticates against `ZMS_CONFIG_SECURE_TOKEN`
- [ ] After merge to `next`, check that the listed Psalm `UndefinedConstant` alerts close on the next dead-code run