### PR TITLE
fix(ZMS): type MySQL importer setup flags for Psalm

### DIFF
--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Authority.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Authority extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'id' => 'id',
         'name' => 'name',
         'parent_id' => 'parent_id',
@@ -16,7 +16,7 @@ class Authority extends Base
     ];
 
     #[\Override]
-    protected function setupMapping()
+    protected function setupMapping(): void
     {
         $this->referanceMapping = [
             'meta' => [
@@ -54,13 +54,13 @@ class Authority extends Base
     }
 
     #[\Override]
-    public function preSetupFields()
+    public function preSetupFields(): void
     {
         $this->dataRaw['parent_id'] = ($this->dataRaw['parent_id'] ?? 0);
     }
 
     #[\Override]
-    public function preSetup()
+    public function preSetup(): void
     {
         try {
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityLocation.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityLocation.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class AuthorityLocation extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'authority_id' => 'authority_id',
         'id' => 'location_id',
         'locale' => 'locale'

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityService.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityService.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class AuthorityService extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'service_id' => 'service_id',
         'id' => 'authority_id',
         'locale' => 'locale'

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
@@ -22,25 +22,25 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
     use ItemNeedsUpdateTrait;
     use PDOTrait;
 
-    protected $fieldMapping = [];
+    protected array $fieldMapping = [];
 
-    protected $fields = [];
+    protected array $fields = [];
 
-    protected $referanceMapping = [];
+    protected array $referanceMapping = [];
 
-    protected $preFormatFields = [];
+    protected array $preFormatFields = [];
 
-    protected $references = [];
+    protected array $references = [];
 
-    protected $dataRaw = [];
+    protected array $dataRaw = [];
 
     protected bool $setupFields = true;
     protected bool $setupReferences = true;
 
-    protected $status = 1;
+    protected int $status = 1;
 
-    const STATUS_NEW = 1;
-    const STATUS_OLD = 0;
+    public const int STATUS_NEW = 1;
+    public const int STATUS_OLD = 0;
 
     public function __construct(PDOAccess $mySqlAccess, array $dataRaw = [], bool $setup = true)
     {
@@ -69,20 +69,24 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         PDOAccess $mySqlAccess,
         array $dataRaw = [],
         bool $setup = true
-    ) {
+    ): Base {
         try {
             $className = preg_replace_callback('/[_-]([a-z0-9]*)/i', function ($matches) {
                 return ucfirst($matches[1] ?? '');
             }, $entityName);
             $className = '\\BO\\Zmsdldb\\Importer\\MySQL\\Entity' . $className;
 
-            return new $className($mySqlAccess, $dataRaw, $setup);
+            $entity = new $className($mySqlAccess, $dataRaw, $setup);
+            if (!$entity instanceof Base) {
+                throw new \InvalidArgumentException($className . ' must extend ' . Base::class);
+            }
+            return $entity;
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    public function factory(string $entityName, array $dataRaw = [], bool $setup = true)
+    public function factory(string $entityName, array $dataRaw = [], bool $setup = true): Base
     {
         try {
             return static::entityFactory($entityName, $this->getPDOAccess(), $dataRaw, $setup);
@@ -91,7 +95,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    public function setRawData(array $rawData = [])
+    public function setRawData(array $rawData = []): static
     {
         $this->dataRaw = $rawData;
         return $this;
@@ -102,7 +106,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return $this->dataRaw;
     }
 
-    public function setStatus(int $status = Base::STATUS_NEW)
+    public function setStatus(int $status = Base::STATUS_NEW): void
     {
         $this->status = $status;
     }
@@ -112,7 +116,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return $this->status;
     }
 
-    public function getReferenceMapping($setup = false): array
+    public function getReferenceMapping(bool $setup = false): array
     {
         try {
             if (true === $setup) {
@@ -125,27 +129,27 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    protected function setupPreFormatFields()
+    protected function setupPreFormatFields(): void
     {
     }
 
-    protected function setupMapping()
+    protected function setupMapping(): void
     {
     }
 
-    public function preSetup()
+    public function preSetup(): void
     {
     }
 
-    public function postSetup()
+    public function postSetup(): void
     {
     }
 
-    public function preSetupFields()
+    public function preSetupFields(): void
     {
     }
 
-    public function postSetupFields()
+    public function postSetupFields(): void
     {
     }
 
@@ -169,7 +173,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    protected function getReferenceFields()
+    protected function getReferenceFields(): array
     {
         $referenceFields = array_flip(array_keys(array_filter($this->referanceMapping)));
 
@@ -179,7 +183,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return $referenceFields;
     }
 
-    final public function setupReferences()
+    final public function setupReferences(): bool
     {
         try {
             if (false === $this->setupReferences) {
@@ -221,6 +225,9 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                             $addFields
                         )
                     );
+                    if (!$referencesInstance instanceof Base) {
+                        throw new \InvalidArgumentException($referenceEntityClass . ' must extend ' . Base::class);
+                    }
 
                     $this->addReference($name, $referencesInstance);
                     $position++;
@@ -248,7 +255,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    public function addReference(string $name, Base $reference)
+    public function addReference(string $name, Base $reference): void
     {
         if (array_key_exists($name, $this->referanceMapping)) {
             if (!isset($this->references[$name])) {
@@ -258,7 +265,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    public function getReference(string $name)
+    public function getReference(string $name): EntityCollection
     {
         if (array_key_exists($name, $this->references)) {
             return $this->references[$name];
@@ -335,7 +342,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return $this->fields;
     }
 
-    public function get($key = null, $default = null)
+    public function get(null|array|string $key = null, mixed $default = null): mixed
     {
         if (null === $key) {
             return $this->dataRaw;
@@ -369,7 +376,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return 1 == count($keys) ? $values[$keys[0]] : $values;
     }
 
-    protected static function arrayAccessByDotPerpareKeys(string $key = null): array
+    protected static function arrayAccessByDotPerpareKeys(?string $key = null): array
     {
         if (null === $key) {
             return [];
@@ -386,7 +393,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return $keys;
     }
 
-    public function save()
+    public function save(): bool
     {
         try {
             if (static::STATUS_NEW !== $this->getStatus()) {
@@ -437,7 +444,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function postSave(\PDOStatement $stm, Base $entity)
+    public function postSave(\PDOStatement $stm, Base $entity): void
     {
     }
 

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
@@ -34,8 +34,8 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
 
     protected $dataRaw = [];
 
-    protected $setupFields = true;
-    protected $setupReferences = true;
+    protected bool $setupFields = true;
+    protected bool $setupReferences = true;
 
     protected $status = 1;
 

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
@@ -425,8 +425,6 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
 
                 $stm->execute(array_values($this->fields));
 
-                #$this->postSave($stm, $this);
-
                 if ($stm && 0 < $stm->rowCount()) {
                     return true;
                 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Contact.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Contact.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Contact extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'object_id' => 'object_id',
         'locale' => 'locale',
         'name' => 'name',

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Location extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'id' => 'id',
         'name' => 'name',
         'category.name' => 'category_name',
@@ -26,7 +26,7 @@ class Location extends Base
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     #[\Override]
-    protected function setupMapping()
+    protected function setupMapping(): void
     {
         $this->referanceMapping = [
             'name' => [
@@ -136,7 +136,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function preSetupFields()
+    public function preSetupFields(): void
     {
         #$this->dataRaw['payment'] = [
         #    'payment_info' => $this->dataRaw['payment'],
@@ -150,7 +150,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function preSetup()
+    public function preSetup(): void
     {
         try {
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/LocationService.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/LocationService.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class LocationService extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'location' => 'location_id',
         'service_id' => 'service_id',
         'locale' => 'locale',

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Meta.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Meta.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Meta extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'object_id' => 'object_id',
         'hash' => 'hash',
         'locale' => 'locale',
@@ -16,7 +16,7 @@ class Meta extends Base
     ];
 
     #[\Override]
-    protected function setupMapping()
+    protected function setupMapping(): void
     {
         $this->referanceMapping = [
             /*
@@ -70,7 +70,7 @@ class Meta extends Base
     }
 
     #[\Override]
-    public function postSetupFields()
+    public function postSetupFields(): void
     {
         if (array_key_exists('lastupdate', $this->fields) && !empty($this->fields['lastupdate'])) {
             $this->fields['lastupdate'] = date_format(date_create($this->fields['lastupdate']), 'Y-m-d H:i:s');

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Search.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Search.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Search extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'object_id' => 'object_id',
         'locale' => 'locale',
         'entity_type' => 'entity_type',
@@ -13,7 +13,7 @@ class Search extends Base
     ];
 
     #[\Override]
-    public function postSetupFields()
+    public function postSetupFields(): void
     {
         if (isset($this->fields['search_value']) && !empty($this->fields['search_value'])) {
             if (is_array($this->fields['search_value'])) {
@@ -24,7 +24,7 @@ class Search extends Base
     }
 
     #[\Override]
-    public function postSetup()
+    public function postSetup(): void
     {
         $val = trim($this->fields['search_value']);
         if (empty($val)) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
@@ -6,7 +6,7 @@ use Error;
 
 class Service extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'id' => 'id',
         'name' => 'name',
         'hint' => 'hint',
@@ -31,7 +31,7 @@ class Service extends Base
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     #[\Override]
-    protected function setupMapping()
+    protected function setupMapping(): void
     {
         $this->referanceMapping = [
             'name' => [
@@ -266,7 +266,7 @@ class Service extends Base
     }
 
     #[\Override]
-    public function preSetup()
+    public function preSetup(): void
     {
         try {
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/ServiceInformation.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/ServiceInformation.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class ServiceInformation extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'service_id' => 'service_id',
         'locale' => 'locale',
         'name' => 'name',

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Setting.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Setting.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Setting extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'name' => 'name',
         'value' => 'value',
     ];

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Topic.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class Topic extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'id' => 'id',
         'name' => 'name',
         'meta.locale' => 'locale',
@@ -19,7 +19,7 @@ class Topic extends Base
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     #[\Override]
-    protected function setupMapping()
+    protected function setupMapping(): void
     {
         $this->referanceMapping = [
             'meta' => [
@@ -175,7 +175,7 @@ class Topic extends Base
     }
 
     #[\Override]
-    public function preSetup()
+    public function preSetup(): void
     {
         try {
             $fields = $this->get(['id', 'meta.locale', 'meta.hash']);

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicCluster.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicCluster.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class TopicCluster extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'id' => 'topic_id',
         'parent_id' => 'parent_id',
         'rank' => 'rank'

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicLinks.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicLinks.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class TopicLinks extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'topic_id' => 'topic_id',
         'name' => 'name',
         'locale' => 'locale',
@@ -19,7 +19,7 @@ class TopicLinks extends Base
     ];
 
     #[\Override]
-    public function postSetupFields()
+    public function postSetupFields(): void
     {
         $searchValues = [$this->get('name')];
         /*
@@ -64,32 +64,6 @@ class TopicLinks extends Base
             return $this->deleteWith(
                 array_combine(['topic_id', 'locale'], array_values($this->get('topic_id', 'locale')))
             );
-        } catch (\Exception $e) {
-            throw $e;
-        }
-    }
-
-    #[\Override]
-    public function postSave(\PDOStatement $stm, Base $entity)
-    {
-        return true;
-        try {
-            if ($stm && 0 < $stm->rowCount()) {
-                #$lastInsertId = $pdoConnection->lastInsertId();
-
-                $sql = 'REPLACE INTO ' . static::getTableName() . ' ';
-                $sql .= '(`' . implode('`, `', array_keys($this->fields)) . '`) ';
-
-                $questionMarks = array_fill(0, count($this->fields), '?');
-                $sql .= 'VALUES (' . implode(', ', $questionMarks) . ') ';
-
-                #print_r($sql . \PHP_EOL) ;
-                $stm = $this->getPDOAccess()->prepare($sql);
-
-                $stm->execute(array_values($this->fields));
-
-                return true;
-            }
         } catch (\Exception $e) {
             throw $e;
         }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicService.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicService.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
 class TopicService extends Base
 {
-    protected $fieldMapping = [
+    protected array $fieldMapping = [
         'id' => 'service_id',
         'topic_id' => 'topic_id',
     ];


### PR DESCRIPTION
## Summary
- Psalm reports a pile of `MissingPropertyType` / `MissingReturnType` / `MissingParamType` / `MissingClassConstType` findings on the unused MySQL importer entity `Base.php` (including inherited `$setupFields` / `$dataRaw` on Topic* and other subclasses).
- Declare types on the base class (and child `$fieldMapping` / hook overrides so PHP stays compatible). No behavior change for production; this importer is unused.

## Test plan
- [ ] After merge to `next`, confirm the [Base.php code-scanning alerts](https://github.com/it-at-m/eappointment/security/code-scanning?query=is%3Aopen+branch%3Anext+path%3Azmsdldb%2Fsrc%2FZmsdldb%2FImporter%2FMySQL%2FEntity%2FBase.php) close on the next Psalm dead-code run