### PR TITLE
fix(ZMS): clean remaining Psalm findings in MySQL importer

### DIFF
--- a/zmsdldb/src/Zmsdldb/Importer/MySQL.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL.php
@@ -23,7 +23,7 @@ class MySQL extends Base
     }
 
     #[\Override]
-    public function runImport()
+    public function runImport(): void
     {
         try {
             parent::runImport();
@@ -33,13 +33,13 @@ class MySQL extends Base
         }
     }
     #[\Override]
-    public function preImport()
+    public function preImport(): void
     {
         $this->beginTransaction();
     }
 
     #[\Override]
-    public function postImport()
+    public function postImport(): void
     {
         $this->commit();
     }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Authorities extends Base
 {
-    protected $entityClass = '\\BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Authority';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Authority::class;
 
     #[\Override]
     public function runImport(): bool

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
@@ -7,23 +7,23 @@ use BO\Zmsdldb\Importer\OptionsTrait;
 use BO\Zmsdldb\Importer\PDOTrait;
 use BO\Zmsdldb\Importer\ItemNeedsUpdateTrait;
 use BO\Zmsdldb\Importer\Options;
-use BO\Zmsdldb\Importer\MySQL\Entity\Meta as MetaEntity
-;
+use BO\Zmsdldb\Importer\MySQL\Entity\Meta as MetaEntity;
+use BO\Zmsdldb\Importer\MySQL\Entity\Base as EntityBase;
 
 abstract class Base implements Options
 {
     use PDOTrait;
     use OptionsTrait;
 
-    protected $entityClass = null;
-    protected $importData = [];
-    protected $hash = null;
-    protected $locale = 'de';
-    protected $metaObject = null;
-    protected $entitysToDelete = [];
-    protected $getCurrentEntitys = true;
+    protected ?string $entityClass = null;
+    protected array $importData = [];
+    protected string $hash = '';
+    protected string $locale = 'de';
+    protected ?MetaEntity $metaObject = null;
+    protected array $entitysToDelete = [];
+    protected bool $getCurrentEntitys = true;
 
-    public function __construct(PDOAccess $mySqlAccess, array $importData = [], string $locale = 'de', $options = 0)
+    public function __construct(PDOAccess $mySqlAccess, array $importData = [], string $locale = 'de', int $options = 0)
     {
         try {
             $this->setPDOAccess($mySqlAccess);
@@ -60,16 +60,16 @@ abstract class Base implements Options
         return $this->entitysToDelete;
     }
 
-    public function removeEntityFromCurrentList(int $entityId)
+    public function removeEntityFromCurrentList(int $entityId): void
     {
         unset($this->entitysToDelete[$entityId]);
     }
 
-    public function setCurrentEntitys()
+    public function setCurrentEntitys(): void
     {
         try {
             if (false === $this->getCurrentEntitys) {
-                return true;
+                return;
             }
             $this->entitysToDelete = [];
             $sql = "SELECT 
@@ -93,7 +93,7 @@ abstract class Base implements Options
         }
     }
 
-    public function createMetaObject()
+    public function createMetaObject(): void
     {
         try {
             if (empty($this->metaObject)) {
@@ -125,7 +125,7 @@ abstract class Base implements Options
         return $this;
     }
 
-    public function needsUpdate()
+    public function needsUpdate(): bool
     {
         $metaObject = $this->getMetaObject();
         $needsUpdate = $metaObject->itemNeedsUpdateAlt();
@@ -163,15 +163,19 @@ abstract class Base implements Options
         return $this->hash;
     }
 
-    public function createEntity(array $data = array(), bool $setup = true)
+    public function createEntity(array $data = array(), bool $setup = true): EntityBase
     {
         if (null === $this->entityClass) {
             throw new \InvalidArgumentException(__METHOD__ . " invalid entity class");
         }
-        return new $this->entityClass($this->getPDOAccess(), $data, $setup);
+        $entity = new $this->entityClass($this->getPDOAccess(), $data, $setup);
+        if (!$entity instanceof EntityBase) {
+            throw new \InvalidArgumentException($this->entityClass . ' must extend ' . EntityBase::class);
+        }
+        return $entity;
     }
 
-    final public function clearEntity()
+    final public function clearEntity(): void
     {
         try {
             $entity = null;
@@ -188,13 +192,13 @@ abstract class Base implements Options
         }
     }
 
-    public function preImport()
+    public function preImport(): void
     {
     }
 
-    public function postImport()
+    public function postImport(): void
     {
     }
 
-    abstract public function runImport();
+    abstract public function runImport(): bool;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Authority.php
@@ -20,7 +20,7 @@ class Authority extends Base
     {
         $this->referanceMapping = [
             'meta' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Meta',
+                'class' => Meta::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale'
@@ -37,7 +37,7 @@ class Authority extends Base
                 'multiple' => false
             ],
             'locations' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\AuthorityLocation',
+                'class' => AuthorityLocation::class,
                 'neededFields' => ['id' => 'authority_id', 'meta.locale' => 'locale'],
                 'addFields' => [
 
@@ -63,10 +63,8 @@ class Authority extends Base
     public function preSetup(): void
     {
         try {
-            $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
-            $fields[] = static::getTableName();
             $this->setStatus(static::STATUS_OLD);
-            if ($this->itemNeedsUpdate(...array_values($fields))) {
+            if ($this->entityNeedsUpdate()) {
                 $this->setStatus(static::STATUS_NEW);
                 $this->setupFields();
                 $this->deleteEntity();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
@@ -62,6 +62,19 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
+    protected function entityNeedsUpdate(): bool
+    {
+        $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
+        $hash = $fields['meta.hash'] ?? '';
+
+        return $this->itemNeedsUpdate(
+            (int) ($fields['id'] ?? 0),
+            (string) ($fields['meta.locale'] ?? ''),
+            is_scalar($hash) ? (string) $hash : '',
+            static::getTableName()
+        );
+    }
+
     public function setStatus(int $status = Base::STATUS_NEW): void
     {
         $this->status = $status;
@@ -192,7 +205,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    final public function __set($name, $value)
+    final public function __set(string $name, mixed $value): void
     {
         if (array_key_exists($name, $this->fieldMapping)) {
             $name = $this->fieldMapping[$name];
@@ -202,7 +215,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                 $value = json_encode($value);
             }
             $this->fields[$name] = $value;
-        } elseif (array_key_exists($name, $this->referanceMapping)) {
+        } elseif (array_key_exists($name, $this->referanceMapping) && $value instanceof Base) {
             $this->addReference($name, $value);
         }
     }
@@ -217,7 +230,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    final public function __get($name)
+    final public function __get(string $name): mixed
     {
         if (array_key_exists($name, $this->fields)) {
             return $this->fields[$name];
@@ -228,12 +241,12 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         throw new \InvalidArgumentException(__METHOD__ . " {$name} has not been set!");
     }
 
-    final public function __isset($name): bool
+    final public function __isset(string $name): bool
     {
         return array_key_exists($name, $this->fields) || array_key_exists($name, $this->references);
     }
 
-    final public function __unset($name)
+    final public function __unset(string $name): void
     {
         if (array_key_exists($name, $this->fields)) {
             unset($this->fields[$name]);
@@ -364,7 +377,6 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                 $questionMarks = array_fill(0, count($this->fields), '?');
                 $sql .= 'VALUES (' . implode(', ', $questionMarks) . ') ';
 
-                #print_r($sql . \PHP_EOL) ;
                 $stm = $this->getPDOAccess()->prepare($sql);
 
                 $stm->execute(array_values($this->fields));
@@ -375,11 +387,9 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                 throw new \Exception('Could not save entity');
             }
             throw new \Exception('Could not save entity, fields are empty');
-            return false;
         } catch (\Exception $e) {
             throw $e;
         }
-        return false;
     }
 
     final public function saveReferences(): bool
@@ -414,7 +424,6 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
 
     public function deleteReferences(): bool
     {
-        #return true;
         try {
             foreach ($this->referanceMapping as $name => $mappingData) {
                 if (isset($mappingData['deleteFunction']) && is_callable($mappingData['deleteFunction'])) {
@@ -438,6 +447,9 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                     $addFields,
                     false
                 );
+                if (!$referencesInstance instanceof Base) {
+                    throw new \InvalidArgumentException($referenceEntityClass . ' must extend ' . Base::class);
+                }
                 $referencesInstance->setupFields();
 
                 $referencesInstance->deleteWith(
@@ -501,6 +513,9 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                     [],
                     false
                 );
+                if (!$referencesInstance instanceof Base) {
+                    throw new \InvalidArgumentException($referenceEntityClass . ' must extend ' . Base::class);
+                }
                 if (!empty($clearFields)) {
                     $referencesInstance->deleteWith($clearFields);
                 } else {
@@ -515,12 +530,12 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
 
     public static function getTableName(): string
     {
-        if (defined('static::TABLENAME')) {
-            return strtolower(static::TABLENAME);
-        }
         $classNameWithNs = explode("\\", static::class);
         $className = end($classNameWithNs);
+        $table = defined('static::TABLENAME')
+            ? constant('static::TABLENAME')
+            : preg_replace('/(?<!^)[A-Z]/', '_$0', $className);
 
-        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $className));
+        return strtolower((string) $table);
     }
 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Collection.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Collection.php
@@ -7,7 +7,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
  */
 class Collection implements \Countable, \ArrayAccess
 {
-    protected $entities = [];
+    protected array $entities = [];
 
     #[\Override]
     final public function offsetExists($offset): bool
@@ -53,7 +53,7 @@ class Collection implements \Countable, \ArrayAccess
         return count($this->entities);
     }
 
-    public function saveEntities()
+    public function saveEntities(): void
     {
         try {
             foreach ($this->entities as $entity) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
@@ -30,7 +30,7 @@ class Location extends Base
     {
         $this->referanceMapping = [
             'name' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -53,7 +53,7 @@ class Location extends Base
                 'selfAsArray' => true
             ],
             'address' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -76,7 +76,7 @@ class Location extends Base
                 'selfAsArray' => true
             ],
             'meta.keywords' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -99,7 +99,7 @@ class Location extends Base
                 'selfAsArray' => true
             ],
             'meta' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Meta',
+                'class' => Meta::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale'
@@ -116,7 +116,7 @@ class Location extends Base
                 'clearFields' => ['type' => static::getTableName(), 'locale' => $this->get('meta.locale')],
             ],
             'contact' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Contact',
+                'class' => Contact::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -153,10 +153,8 @@ class Location extends Base
     public function preSetup(): void
     {
         try {
-            $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
-            $fields[] = static::getTableName();
             $this->setStatus(static::STATUS_OLD);
-            if ($this->itemNeedsUpdate(...array_values($fields))) {
+            if ($this->entityNeedsUpdate()) {
                 $this->setStatus(static::STATUS_NEW);
                 $this->setupFields();
                 $this->deleteEntity();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Meta.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Meta.php
@@ -21,7 +21,7 @@ class Meta extends Base
         $this->referanceMapping = [
             /*
             'keywords' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'object_id' => 'object_id',
                     'locale' => 'locale',
@@ -44,7 +44,7 @@ class Meta extends Base
                 'selfAsArray' => true
             ],
             'titles' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'object_id' => 'object_id',
                     'locale' => 'locale',
@@ -72,9 +72,11 @@ class Meta extends Base
     #[\Override]
     public function postSetupFields(): void
     {
-        if (array_key_exists('lastupdate', $this->fields) && !empty($this->fields['lastupdate'])) {
-            $this->fields['lastupdate'] = date_format(date_create($this->fields['lastupdate']), 'Y-m-d H:i:s');
-        } elseif (!array_key_exists('lastupdate', $this->fields) || empty($this->fields['lastupdate'])) {
+        $lastupdate = $this->fields['lastupdate'] ?? null;
+        $created = is_string($lastupdate) && $lastupdate !== '' ? date_create($lastupdate) : false;
+        if ($created instanceof \DateTimeInterface) {
+            $this->fields['lastupdate'] = $created->format('Y-m-d H:i:s');
+        } else {
             $this->fields['lastupdate'] = '1970-01-01 01:00:00';
         }
     }
@@ -131,11 +133,9 @@ class Meta extends Base
                     $needsUpdate = true;
                 }
             }
-            #print_r([$needsUpdate ? 'T' : 'F', $fields]);
             return $needsUpdate;
         } catch (\Exception $e) {
             throw $e;
         }
-        return false;
     }
 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
@@ -35,7 +35,7 @@ class Service extends Base
     {
         $this->referanceMapping = [
             'name' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -59,7 +59,7 @@ class Service extends Base
             ],
             /*
             'description' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -83,7 +83,7 @@ class Service extends Base
             ],
             */
             'meta.keywords' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -106,7 +106,7 @@ class Service extends Base
                 'selfAsArray' => true
             ],
             'meta' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Meta',
+                'class' => Meta::class,
                 'neededFields' => ['id' => 'object_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => static::getTableName()
@@ -123,7 +123,7 @@ class Service extends Base
                 ],
             ],
             'authorities' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\AuthorityService',
+                'class' => AuthorityService::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
 
@@ -137,7 +137,7 @@ class Service extends Base
                 ]
             ],
             'locations' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\LocationService',
+                'class' => LocationService::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [],
                 'deleteFields' => [
@@ -149,7 +149,7 @@ class Service extends Base
                 ]
             ],
             'requirements' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\ServiceInformation',
+                'class' => ServiceInformation::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'requirements',
@@ -168,7 +168,7 @@ class Service extends Base
                 ],
             ],
             'forms' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\ServiceInformation',
+                'class' => ServiceInformation::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'forms',
@@ -187,7 +187,7 @@ class Service extends Base
                 ],
             ],
             'prerequisites' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\ServiceInformation',
+                'class' => ServiceInformation::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'prerequisites',
@@ -206,7 +206,7 @@ class Service extends Base
                 ],
             ],
             'links' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\ServiceInformation',
+                'class' => ServiceInformation::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'links',
@@ -225,7 +225,7 @@ class Service extends Base
                 ],
             ],
             'publications' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\ServiceInformation',
+                'class' => ServiceInformation::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'publications',
@@ -244,7 +244,7 @@ class Service extends Base
                 ],
             ],
             'legal' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\ServiceInformation',
+                'class' => ServiceInformation::class,
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'legal',
@@ -269,17 +269,8 @@ class Service extends Base
     public function preSetup(): void
     {
         try {
-            $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
-            $fields[] = static::getTableName();
-
-            if (is_array($fields[2]) && class_exists('\App', false) && isset(\App::$log)) {
-                \App::$log->warning('Unexpected array in service meta hash during import', [
-                    'fields' => $fields,
-                ]);
-            }
-
             $this->setStatus(static::STATUS_OLD);
-            if ($this->itemNeedsUpdate(...array_values($fields))) {
+            if ($this->entityNeedsUpdate()) {
                 $this->setStatus(static::STATUS_NEW);
                 $this->setupFields();
                 $this->deleteEntity();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/ServiceInformation.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/ServiceInformation.php
@@ -21,7 +21,7 @@ class ServiceInformation extends Base
             return $this->deleteWith(
                 array_combine(
                     ['service_id', 'locale', 'type'],
-                    array_values($this->get('service_id', 'locale', 'type'))
+                    array_values($this->get(['service_id', 'locale', 'type']))
                 )
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Topic.php
@@ -23,7 +23,7 @@ class Topic extends Base
     {
         $this->referanceMapping = [
             'meta' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Meta',
+                'class' => Meta::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale'
@@ -43,7 +43,7 @@ class Topic extends Base
                 ],
             ],
             'name' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -66,7 +66,7 @@ class Topic extends Base
                 'selfAsArray' => true
             ],
             'meta.keywords' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -89,7 +89,7 @@ class Topic extends Base
                 'selfAsArray' => true
             ],
             'meta.titles' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Search',
+                'class' => Search::class,
                 'neededFields' => [
                     'id' => 'object_id',
                     'meta.locale' => 'locale',
@@ -112,7 +112,7 @@ class Topic extends Base
                 'selfAsArray' => true
             ],
             'links' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\TopicLinks',
+                'class' => TopicLinks::class,
                 'neededFields' => ['id' => 'topic_id', 'meta.locale' => 'locale'],
                 'addFields' => ['locale' => $this->get('meta.locale')],
                 'delete' => false,
@@ -128,7 +128,7 @@ class Topic extends Base
                 ]
             ],
             'relation.services' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\TopicService',
+                'class' => TopicService::class,
                 'neededFields' => ['id' => 'topic_id'],
                 'addFields' => [],
                 'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic) {
@@ -140,7 +140,7 @@ class Topic extends Base
                 }
             ],
             'relation.childs' => [
-                'class' => 'BO\\Zmsdldb\\Importer\\MySQL\\Entity\\TopicCluster',
+                'class' => TopicCluster::class,
                 'neededFields' => ['id' => 'parent_id'],
                 'addFields' => [],
                 'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic) {
@@ -158,7 +158,7 @@ class Topic extends Base
         \BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic,
         string $tableName,
         string $whereField
-    ) {
+    ): bool {
         $topicId = $topic->get('id');
         try {
             $sql = "DELETE FROM " . $tableName . " WHERE " . $whereField . " = ?";
@@ -178,10 +178,8 @@ class Topic extends Base
     public function preSetup(): void
     {
         try {
-            $fields = $this->get(['id', 'meta.locale', 'meta.hash']);
-            $fields[] = static::getTableName();
             $this->setStatus(static::STATUS_OLD);
-            if ($this->itemNeedsUpdate(...array_values($fields))) {
+            if ($this->entityNeedsUpdate()) {
                 $this->setStatus(static::STATUS_NEW);
                 $this->setupFields();
                 $this->deleteEntity();

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Locations extends Base
 {
-    protected $entityClass = '\\BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Location';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Location::class;
 
     #[\Override]
     public function runImport(): bool

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Services extends Base
 {
-    protected $entityClass = '\\BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Service';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Service::class;
 
     #[\Override]
     public function runImport(): bool

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Settings.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Settings.php
@@ -4,8 +4,8 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Settings extends Base
 {
-    protected $getCurrentEntitys = false;
-    protected $entityClass = '\\BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Setting';
+    protected bool $getCurrentEntitys = false;
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Setting::class;
 
     #[\Override]
     public function runImport(): bool

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Topics extends Base
 {
-    protected $entityClass = '\\BO\\Zmsdldb\\Importer\\MySQL\\Entity\\Topic';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Topic::class;
 
     #[\Override]
     public function runImport(): bool

--- a/zmsdldb/src/Zmsdldb/Importer/SQLite/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Importer/SQLite/Authorities.php
@@ -6,5 +6,5 @@ use BO\Zmsdldb\Importer\MySQL\Authorities as AuthoritiesBase;
 
 class Authorities extends AuthoritiesBase
 {
-    protected $entityClass = 'BO\\Zmsdldb\\Importer\\SQLite\\Entity\\Authority';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\SQLite\Entity\Authority::class;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/SQLite/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Importer/SQLite/Locations.php
@@ -6,5 +6,5 @@ use BO\Zmsdldb\Importer\MySQL\Locations as LocationsBase;
 
 class Locations extends LocationsBase
 {
-    protected $entityClass = 'BO\\Zmsdldb\\Importer\\SQLite\\Entity\\Location';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\SQLite\Entity\Location::class;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/SQLite/Services.php
+++ b/zmsdldb/src/Zmsdldb/Importer/SQLite/Services.php
@@ -6,5 +6,5 @@ use BO\Zmsdldb\Importer\MySQL\Services as ServicesBase;
 
 class Services extends ServicesBase
 {
-    protected $entityClass = 'BO\\Zmsdldb\\Importer\\SQLite\\Entity\\Service';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\SQLite\Entity\Service::class;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/SQLite/Settings.php
+++ b/zmsdldb/src/Zmsdldb/Importer/SQLite/Settings.php
@@ -6,5 +6,5 @@ use BO\Zmsdldb\Importer\MySQL\Settings as SettingsBase;
 
 class Settings extends SettingsBase
 {
-    protected $entityClass = 'BO\\Zmsdldb\\Importer\\SQLite\\Entity\\Setting';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\SQLite\Entity\Setting::class;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/SQLite/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Importer/SQLite/Topics.php
@@ -6,5 +6,5 @@ use BO\Zmsdldb\Importer\MySQL\Topics as TopicsBase;
 
 class Topics extends TopicsBase
 {
-    protected $entityClass = 'BO\\Zmsdldb\\Importer\\SQLite\\Entity\\Topic';
+    protected ?string $entityClass = \BO\Zmsdldb\Importer\SQLite\Entity\Topic::class;
 }


### PR DESCRIPTION
## Summary
- Clean remaining Psalm alerts under `zmsdldb/src/Zmsdldb/Importer/MySQL` ([code scanning](https://github.com/it-at-m/eappointment/security/code-scanning?query=is%3Aopen+branch%3Anext+path%3Azmsdldb%2Fsrc%2FZmsdldb%2FImporter%2FMySQL)).
- Type importer/entity helpers, fix `get()` arity and `itemNeedsUpdate` scalar mismatches, remove unreachable code, and switch mapping/`entityClass` strings to `::class` so dynamically loaded entities count as used.
- SQLite importer subclasses get the same `entityClass` type so PHP property types stay compatible.

## Test plan
- [ ] After merge to `next`, confirm the MySQL importer code-scanning filter is empty on the next Psalm dead-code run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when creating and linking imported entities.
  * Added safer handling for invalid or missing update timestamps.
  * Improved detection of entities that require updates during imports.

* **Refactor**
  * Strengthened type validation across MySQL and SQLite import workflows.
  * Improved import lifecycle behavior while preserving transaction handling.
  * Simplified entity mappings and reference management for more reliable imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->