### PR TITLE
fix(ZMS): clear remaining Psalm findings in the MySQL importer

### DIFF
--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -11,6 +11,13 @@ use BO\Zmsdldb\PDOAccess;
 use BO\Zmsdldb\FileAccess
 ;
 
+/**
+ * @method \BO\Zmsdldb\Importer\MySQL\Base getServicesImporter(array $entitys, string $locale, int $options)
+ * @method \BO\Zmsdldb\Importer\MySQL\Base getLocationsImporter(array $entitys, string $locale, int $options)
+ * @method \BO\Zmsdldb\Importer\MySQL\Base getAuthoritiesImporter(array $entitys, string $locale, int $options)
+ * @method \BO\Zmsdldb\Importer\MySQL\Base getTopicsImporter(array $entitys, string $locale, int $options)
+ * @method \BO\Zmsdldb\Importer\MySQL\Base getSettingsImporter(array $entitys, string $locale, int $options)
+ */
 abstract class Base implements Options
 {
     use PDOTrait;
@@ -43,13 +50,24 @@ abstract class Base implements Options
         $this->localeList = $localeList;
     }
 
+    /**
+     * @param string $method
+     * @param array $args
+     * @return \BO\Zmsdldb\Importer\MySQL\Base
+     */
     public function __call($method, $args = [])
     {
         try {
             if (preg_match('/get(?P<importer>[A-Za-z]+)Importer/', $method, $matches)) {
                 $ImporterClass = static::class . '\\' . $matches['importer'];
                 array_unshift($args, $this->getPDOAccess());
+                /** @psalm-suppress UnsafeInstantiation */
                 $instance = new $ImporterClass(...$args);
+                if (!$instance instanceof \BO\Zmsdldb\Importer\MySQL\Base) {
+                    throw new \InvalidArgumentException(
+                        $ImporterClass . ' must extend \\BO\\Zmsdldb\\Importer\\MySQL\\Base'
+                    );
+                }
                 return $instance;
             }
             throw new \BadMethodCallException('Method ' . $method . ' not found!');

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Authorities.php
@@ -4,16 +4,21 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Authorities extends Base
 {
+    /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Entity\Base>|null */
     protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Authority::class;
 
+    /** @psalm-api */
     #[\Override]
     public function runImport(): bool
     {
         try {
             if ($this->needsUpdate()) {
                 foreach ($this->getIterator() as $authority) {
+                    if (!is_array($authority)) {
+                        continue;
+                    }
                     $authority = $this->createEntity($authority);
-                    $this->removeEntityFromCurrentList($authority->get('id'));
+                    $this->removeEntityFromCurrentList((int) $authority->get('id'));
                     $authority->save();
                 }
             }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Base.php
@@ -5,7 +5,6 @@ namespace BO\Zmsdldb\Importer\MySQL;
 use BO\Zmsdldb\PDOAccess;
 use BO\Zmsdldb\Importer\OptionsTrait;
 use BO\Zmsdldb\Importer\PDOTrait;
-use BO\Zmsdldb\Importer\ItemNeedsUpdateTrait;
 use BO\Zmsdldb\Importer\Options;
 use BO\Zmsdldb\Importer\MySQL\Entity\Meta as MetaEntity;
 use BO\Zmsdldb\Importer\MySQL\Entity\Base as EntityBase;
@@ -15,11 +14,13 @@ abstract class Base implements Options
     use PDOTrait;
     use OptionsTrait;
 
+    /** @var class-string<EntityBase>|null */
     protected ?string $entityClass = null;
     protected array $importData = [];
     protected string $hash = '';
     protected string $locale = 'de';
     protected ?MetaEntity $metaObject = null;
+    /** @var array<int, EntityBase> */
     protected array $entitysToDelete = [];
     protected bool $getCurrentEntitys = true;
 
@@ -27,8 +28,16 @@ abstract class Base implements Options
     {
         try {
             $this->setPDOAccess($mySqlAccess);
-            $this->setImportData($importData['data']);
-            $this->setImportHash($importData['hash']);
+            $data = $importData['data'] ?? [];
+            $hash = $importData['hash'] ?? '';
+            if (!is_array($data)) {
+                throw new \InvalidArgumentException('Import data must be an array');
+            }
+            if (!is_string($hash)) {
+                throw new \InvalidArgumentException('Import hash must be a string');
+            }
+            $this->setImportData($data);
+            $this->setImportHash($hash);
             $this->setLocale($locale);
 
             $this->setOptions($options);
@@ -43,9 +52,12 @@ abstract class Base implements Options
         return $this->pdoAccess;
     }
 
-    public function getImportData(): array
+    /**
+     * @return array<int, EntityBase>
+     */
+    public function getCurrentEntitys(): array
     {
-        return $this->importData;
+        return $this->entitysToDelete;
     }
 
     public function getIterator(): iterable
@@ -53,11 +65,6 @@ abstract class Base implements Options
         foreach ($this->importData as $item) {
             yield $item;
         }
-    }
-
-    public function getCurrentEntitys(): array
-    {
-        return $this->entitysToDelete;
     }
 
     public function removeEntityFromCurrentList(int $entityId): void
@@ -86,8 +93,12 @@ abstract class Base implements Options
             $stm->execute([$this->getLocale(),$this->getLocale()]);
             $entitys = $stm->fetchAll();
             foreach ($entitys as $entity) {
-                $entityObject = $this->createEntity(json_decode($entity->data_json, true));
-                $this->entitysToDelete[$entity->id] = $entityObject;
+                $decoded = json_decode($entity->data_json, true);
+                if (!is_array($decoded)) {
+                    continue;
+                }
+                $entityObject = $this->createEntity($decoded);
+                $this->entitysToDelete[(int) $entity->id] = $entityObject;
             }
         } catch (\Exception $e) {
             throw $e;
@@ -118,6 +129,9 @@ abstract class Base implements Options
     public function getMetaObject(): MetaEntity
     {
         $this->createMetaObject();
+        if (null === $this->metaObject) {
+            throw new \RuntimeException('Failed to create meta object');
+        }
         return $this->metaObject;
     }
 
@@ -173,12 +187,15 @@ abstract class Base implements Options
         if (null === $this->entityClass) {
             throw new \InvalidArgumentException(__METHOD__ . " invalid entity class");
         }
-        return $this->entityClass;
+        /** @var class-string<EntityBase> $entityClass */
+        $entityClass = $this->entityClass;
+        return $entityClass;
     }
 
     public function createEntity(array $data = array(), bool $setup = true): EntityBase
     {
         $entityClass = $this->getEntityClass();
+        /** @psalm-suppress UnsafeInstantiation */
         $entity = new $entityClass($this->getPDOAccess(), $data, $setup);
         if (!$entity instanceof EntityBase) {
             throw new \InvalidArgumentException($entityClass . ' must extend ' . EntityBase::class);
@@ -189,13 +206,17 @@ abstract class Base implements Options
     final public function clearEntity(): void
     {
         try {
-            $entity = null;
+            if (
+                !$this->checkOptionFlag(static::OPTION_CLEAR_ENTITIY_TABLE) &&
+                !$this->checkOptionFlag(static::OPTION_CLEAR_ENTITIY_REFERENCES_TABLES)
+            ) {
+                return;
+            }
+            $entity = $this->createEntity(['meta' => ['locale' => $this->getLocale()]], false);
             if ($this->checkOptionFlag(static::OPTION_CLEAR_ENTITIY_TABLE)) {
-                $entity = ($entity ?? $this->createEntity(['meta' => ['locale' => $this->getLocale()]], false));
                 $entity->clearEntity();
             }
             if ($this->checkOptionFlag(static::OPTION_CLEAR_ENTITIY_REFERENCES_TABLES)) {
-                $entity =  ($entity ?? $this->createEntity(['meta' => ['locale' => $this->getLocale()]], false));
                 $entity->clearEntityReferences();
             }
         } catch (\Exception $e) {
@@ -203,13 +224,16 @@ abstract class Base implements Options
         }
     }
 
+    /** @psalm-api */
     public function preImport(): void
     {
     }
 
+    /** @psalm-api */
     public function postImport(): void
     {
     }
 
+    /** @psalm-api */
     abstract public function runImport(): bool;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Authority.php
@@ -76,10 +76,10 @@ class Authority extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['id', 'locale'], array_values($this->get(['id', 'meta.locale'])))
             );
         } catch (\Exception $e) {
@@ -88,10 +88,10 @@ class Authority extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 ['locale' => $this->get('meta.locale')]
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityLocation.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityLocation.php
@@ -11,10 +11,10 @@ class AuthorityLocation extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['authority_id', 'location_id', 'locale'],
                     array_values($this->get(['authority_id', 'id', 'locale']))

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityService.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/AuthorityService.php
@@ -11,10 +11,10 @@ class AuthorityService extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['service_id', 'authority_id', 'locale'],
                     array_values($this->get(['service_id', 'id', 'locale']))

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Base.php
@@ -22,12 +22,15 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
     use ItemNeedsUpdateTrait;
     use PDOTrait;
 
+    /** @var array<string, string> */
     protected array $fieldMapping = [];
 
+    /** @var array<string, mixed> */
     protected array $fields = [];
 
     protected array $referanceMapping = [];
 
+    /** @var array<string, EntityCollection> */
     protected array $references = [];
 
     protected array $dataRaw = [];
@@ -118,21 +121,23 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
     {
     }
 
-    final public function setupFields(): bool
+    final public function setupFields(): void
     {
         try {
             if (false === $this->setupFields) {
-                return true;
+                return;
             }
             $this->preSetupFields();
 
             $values = $this->get(array_keys(array_filter($this->fieldMapping)));
             foreach ($values as $key => $value) {
+                if (!is_string($key)) {
+                    continue;
+                }
                 $this->__set($key, $value);
             }
             $this->postSetupFields();
             $this->setupFields = false;
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }
@@ -148,16 +153,19 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         return $referenceFields;
     }
 
-    final public function setupReferences(): bool
+    final public function setupReferences(): void
     {
         try {
             if (false === $this->setupReferences) {
-                return true;
+                return;
             }
             $values = $this->getReferenceFields();
 
             foreach ($values as $name => $references) {
                 $referenceEntityClass = $this->referanceMapping[$name]['class'];
+                if (!is_string($referenceEntityClass)) {
+                    throw new \InvalidArgumentException('Invalid reference entity class');
+                }
                 $addFields = [];
 
                 foreach (($this->referanceMapping[$name]['neededFields'] ?? []) as $sourceKey => $destinationKey) {
@@ -183,6 +191,10 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                             $name => $reference
                         ];
                     }
+                    if (!is_array($reference)) {
+                        $reference = [];
+                    }
+                    /** @psalm-suppress UnsafeInstantiation */
                     $referencesInstance = new $referenceEntityClass(
                         $this->getPDOAccess(),
                         array_merge(
@@ -199,7 +211,6 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                 }
             }
             $this->setupReferences = false;
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }
@@ -211,7 +222,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
             $name = $this->fieldMapping[$name];
             if (is_bool($value)) {
                 $value = (int)$value;
-            } elseif (stripos($name, '_json')) {
+            } elseif (false !== stripos($name, '_json')) {
                 $value = json_encode($value);
             }
             $this->fields[$name] = $value;
@@ -259,18 +270,24 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
     #[\Override]
     final public function offsetExists($offset): bool
     {
-        return $this->__isset($offset);
+        return is_string($offset) && $this->__isset($offset);
     }
 
     #[\Override]
     final public function offsetGet($offset): mixed
     {
+        if (!is_string($offset)) {
+            throw new \InvalidArgumentException(__METHOD__ . ' offset must be a string');
+        }
         return $this->__get($offset);
     }
 
     #[\Override]
     final public function offsetSet($offset, $value): Base
     {
+        if (!is_string($offset)) {
+            throw new \InvalidArgumentException(__METHOD__ . ' offset must be a string');
+        }
         $this->__set($offset, $value);
         return $this;
     }
@@ -278,6 +295,9 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
     #[\Override]
     final public function offsetUnset($offset): Base
     {
+        if (!is_string($offset)) {
+            throw new \InvalidArgumentException(__METHOD__ . ' offset must be a string');
+        }
         $this->__unset($offset);
         return $this;
     }
@@ -339,36 +359,35 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
             return [];
         }
         $keys = explode('.', $key);
-        if (false === $keys) {
-            throw new \Exception('Invalid key, key must be a string!');
-        }
         $keys = array_filter($keys, 'strlen');
-        $keys = array_map(function ($key) {
-            return ((is_numeric($key) && !is_double(1 * $key)) ? (int)$key : $key);
+        $keys = array_map(static function (string $segment): int|string {
+            if (is_numeric($segment) && !str_contains($segment, '.')) {
+                return (int) $segment;
+            }
+            return $segment;
         }, $keys);
 
         return $keys;
     }
 
-    public function save(): bool
+    public function save(): void
     {
         try {
             if (static::STATUS_NEW !== $this->getStatus()) {
-                return false;
+                return;
             }
             $this->saveEntitiy();
             $this->saveReferences();
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    final public function saveEntitiy(): bool
+    final public function saveEntitiy(): void
     {
         try {
             if (static::STATUS_NEW !== $this->getStatus()) {
-                return false;
+                return;
             }
             if (!empty($this->fields)) {
                 $sql = 'REPLACE INTO ' . static::getTableName() . ' ';
@@ -382,7 +401,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                 $stm->execute(array_values($this->fields));
 
                 if ($stm && 0 < $stm->rowCount()) {
-                    return true;
+                    return;
                 }
                 throw new \Exception('Could not save entity');
             }
@@ -392,37 +411,34 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
         }
     }
 
-    final public function saveReferences(): bool
+    final public function saveReferences(): void
     {
         try {
             if (static::STATUS_NEW !== $this->getStatus()) {
-                return false;
+                return;
             }
-            if (!empty($this->references)) {
-                array_map(function ($referencesCollection) {
-                    $referencesCollection->saveEntities();
-                }, $this->references);
+            foreach ($this->references as $referencesCollection) {
+                $referencesCollection->saveEntities();
             }
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    public function delete(): bool
+    /** @psalm-api */
+    public function delete(): void
     {
         try {
             $this->deleteEntity();
             $this->deleteReferences();
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    abstract public function deleteEntity(): bool;
+    abstract public function deleteEntity(): void;
 
-    public function deleteReferences(): bool
+    public function deleteReferences(): void
     {
         try {
             foreach ($this->referanceMapping as $name => $mappingData) {
@@ -438,10 +454,14 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                 }
                 $addFields = [];
                 $referenceEntityClass = $mappingData['class'];
+                if (!is_string($referenceEntityClass)) {
+                    throw new \InvalidArgumentException('Invalid reference entity class');
+                }
                 foreach ($mappingData['deleteFields'] as $sourceKey => $val) {
                     $addFields[$sourceKey] = $val;
                 }
 
+                /** @psalm-suppress UnsafeInstantiation */
                 $referencesInstance = new $referenceEntityClass(
                     $this->getPDOAccess(),
                     $addFields,
@@ -456,18 +476,17 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                     array_intersect_key($referencesInstance->getFields(), $addFields)
                 );
             }
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    final public function deleteWith(array $fields): bool
+    final public function deleteWith(array $fields): void
     {
         try {
             $sql = "DELETE FROM " . static::getTableName();
             if (!empty($fields)) {
-                $where = array_map(function ($field) {
+                $where = array_map(function (int|string $field): string {
                     return $field . ' = ?';
                 }, array_keys($fields));
                 $sql .= " WHERE " . implode(' AND ', $where);
@@ -475,29 +494,28 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
 
             $stm = $this->getPDOAccess()->prepare($sql);
             $stm->execute(array_values($fields));
-            if ($stm && 0 < $stm->rowCount()) {
-                return true;
-            }
-            return false;
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
-            return $this->deleteWith($addWhere);
+            $this->deleteWith($addWhere);
         } catch (\Exception $e) {
             throw $e;
         }
     }
 
-    public function clearEntityReferences(): bool
+    public function clearEntityReferences(): void
     {
         try {
             foreach ($this->getReferenceMapping(true) as $name => $mappingData) {
                 $referenceEntityClass = $mappingData['class'];
+                if (!is_string($referenceEntityClass)) {
+                    throw new \InvalidArgumentException('Invalid reference entity class');
+                }
                 $clearFields = [];
                 $position = 0;
                 foreach (($mappingData['clearFields'] ?? []) as $key => $value) {
@@ -508,6 +526,7 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                     }
                 }
 
+                /** @psalm-suppress UnsafeInstantiation */
                 $referencesInstance = new $referenceEntityClass(
                     $this->getPDOAccess(),
                     [],
@@ -522,7 +541,6 @@ abstract class Base implements \Countable, \ArrayAccess, \JsonSerializable
                     $referencesInstance->clearEntity();
                 }
             }
-            return true;
         } catch (\Exception $e) {
             throw $e;
         }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Collection.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Collection.php
@@ -7,6 +7,7 @@ namespace BO\Zmsdldb\Importer\MySQL\Entity;
  */
 class Collection implements \Countable, \ArrayAccess
 {
+    /** @var array<int|string, Base> */
     protected array $entities = [];
 
     #[\Override]
@@ -53,6 +54,7 @@ class Collection implements \Countable, \ArrayAccess
         return count($this->entities);
     }
 
+    /** @psalm-api */
     public function saveEntities(): void
     {
         try {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Contact.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Contact.php
@@ -15,10 +15,10 @@ class Contact extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['object_id', 'locale'], array_values($this->get(['object_id', 'locale'])))
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Location.php
@@ -166,10 +166,10 @@ class Location extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['id', 'locale'], array_values($this->get(['id', 'meta.locale'])))
             );
         } catch (\Exception $e) {
@@ -178,10 +178,10 @@ class Location extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 ['locale' => $this->get('meta.locale')]
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/LocationService.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/LocationService.php
@@ -18,10 +18,10 @@ class LocationService extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['location_id', 'service_id', 'locale'],
                     array_values($this->get(['location', 'service_id', 'locale']))

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Meta.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Meta.php
@@ -82,10 +82,10 @@ class Meta extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['object_id', 'locale', 'type'],
                     array_values($this->get(['object_id', 'locale', 'type']))
@@ -97,10 +97,10 @@ class Meta extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['type', 'locale'], array_values($this->get(['type', 'locale'])))
             );
         } catch (\Exception $e) {
@@ -108,16 +108,8 @@ class Meta extends Base
         }
     }
 
-    /**
-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function itemNeedsUpdateAlt(
-        int $objectId = 0,
-        string $locale = '',
-        string $objectHash = '',
-        string $type = ''
-    ): bool {
+    public function itemNeedsUpdateAlt(): bool
+    {
         try {
             $statment = $this->getPDOAccess()->prepare(
                 "SELECT count(1) AS count FROM meta WHERE object_id = ? AND locale = ? AND hash = ? AND type = ?"

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Search.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Search.php
@@ -33,10 +33,10 @@ class Search extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['object_id', 'locale', 'entity_type'],
                     array_values($this->get(['object_id', 'locale', 'entity_type']))
@@ -48,11 +48,11 @@ class Search extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
             #print_r(static::class);
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['entity_type', 'locale'], array_values($this->get(['entity_type', 'locale'])))
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
@@ -153,7 +153,7 @@ class Service extends Base
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'requirements',
-                    'sort' => function ($position, $key, $value) {
+                    'sort' => static function (int $position): int {
                         return $position;
                     }
                 ],
@@ -172,7 +172,7 @@ class Service extends Base
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'forms',
-                    'sort' => function ($position, $key, $value) {
+                    'sort' => static function (int $position): int {
                         return $position;
                     }
                 ],
@@ -191,7 +191,7 @@ class Service extends Base
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'prerequisites',
-                    'sort' => function ($position, $key, $value) {
+                    'sort' => static function (int $position): int {
                         return $position;
                     }
                 ],
@@ -210,7 +210,7 @@ class Service extends Base
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'links',
-                    'sort' => function ($position, $key, $value) {
+                    'sort' => static function (int $position): int {
                         return $position;
                     }
                 ],
@@ -229,7 +229,7 @@ class Service extends Base
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'publications',
-                    'sort' => function ($position, $key, $value) {
+                    'sort' => static function (int $position): int {
                         return $position;
                     }
                 ],
@@ -248,7 +248,7 @@ class Service extends Base
                 'neededFields' => ['id' => 'service_id', 'meta.locale' => 'locale'],
                 'addFields' => [
                     'type' => 'legal',
-                    'sort' => function ($position, $key, $value) {
+                    'sort' => static function (int $position): int {
                         return $position;
                     }
                 ],
@@ -282,10 +282,10 @@ class Service extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['id', 'locale'], array_values($this->get(['id', 'meta.locale'])))
             );
         } catch (\Exception $e) {
@@ -294,11 +294,11 @@ class Service extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
             #print_r((array)$this->get(['meta.locale']));exit;
-            return $this->deleteWith(
+            $this->deleteWith(
                 ['locale' => $this->get('meta.locale')]
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/ServiceInformation.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/ServiceInformation.php
@@ -15,10 +15,10 @@ class ServiceInformation extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['service_id', 'locale', 'type'],
                     array_values($this->get(['service_id', 'locale', 'type']))

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Setting.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Setting.php
@@ -10,10 +10,10 @@ class Setting extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['name'], array_values((array)$this->get('name')))
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Topic.php
@@ -116,7 +116,7 @@ class Topic extends Base
                 'neededFields' => ['id' => 'topic_id', 'meta.locale' => 'locale'],
                 'addFields' => ['locale' => $this->get('meta.locale')],
                 'delete' => false,
-                'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic) {
+                'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic): bool {
                     return static::deleteReferencesFn(
                         $topic,
                         \BO\Zmsdldb\Importer\MySQL\Entity\TopicLinks::getTableName(),
@@ -131,7 +131,7 @@ class Topic extends Base
                 'class' => TopicService::class,
                 'neededFields' => ['id' => 'topic_id'],
                 'addFields' => [],
-                'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic) {
+                'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic): bool {
                     return static::deleteReferencesFn(
                         $topic,
                         \BO\Zmsdldb\Importer\MySQL\Entity\TopicService::getTableName(),
@@ -143,7 +143,7 @@ class Topic extends Base
                 'class' => TopicCluster::class,
                 'neededFields' => ['id' => 'parent_id'],
                 'addFields' => [],
-                'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic) {
+                'deleteFunction' => function (\BO\Zmsdldb\Importer\MySQL\Entity\Topic $topic): bool {
                     return static::deleteReferencesFn(
                         $topic,
                         \BO\Zmsdldb\Importer\MySQL\Entity\TopicCluster::getTableName(),
@@ -191,10 +191,10 @@ class Topic extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['id', 'locale'], array_values($this->get(['id', 'meta.locale'])))
             );
         } catch (\Exception $e) {
@@ -203,10 +203,10 @@ class Topic extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 ['locale' => $this->get('meta.locale')]
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicCluster.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicCluster.php
@@ -11,10 +11,10 @@ class TopicCluster extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['topic_id', 'parent_id'], array_values($this->get('id', 'parent_id')))
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicLinks.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicLinks.php
@@ -46,10 +46,10 @@ class TopicLinks extends Base
     }
 
     #[\Override]
-    public function clearEntity(array $addWhere = []): bool
+    public function clearEntity(array $addWhere = []): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 ['locale' => $this->get('meta.locale')]
             );
         } catch (\Exception $e) {
@@ -58,10 +58,10 @@ class TopicLinks extends Base
     }
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(['topic_id', 'locale'], array_values($this->get('topic_id', 'locale')))
             );
         } catch (\Exception $e) {

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicService.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/TopicService.php
@@ -10,10 +10,10 @@ class TopicService extends Base
     ];
 
     #[\Override]
-    public function deleteEntity(): bool
+    public function deleteEntity(): void
     {
         try {
-            return $this->deleteWith(
+            $this->deleteWith(
                 array_combine(
                     ['topic_id', 'service_id'],
                     array_values($this->get('topic_id', 'id'))

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Locations.php
@@ -4,16 +4,21 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Locations extends Base
 {
+    /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Entity\Base>|null */
     protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Location::class;
 
+    /** @psalm-api */
     #[\Override]
     public function runImport(): bool
     {
         try {
             if ($this->needsUpdate()) {
                 foreach ($this->getIterator() as $location) {
+                    if (!is_array($location)) {
+                        continue;
+                    }
                     $location = $this->createEntity($location);
-                    $this->removeEntityFromCurrentList($location->get('id'));
+                    $this->removeEntityFromCurrentList((int) $location->get('id'));
                     $location->save();
                 }
             }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Services.php
@@ -4,16 +4,21 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Services extends Base
 {
+    /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Entity\Base>|null */
     protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Service::class;
 
+    /** @psalm-api */
     #[\Override]
     public function runImport(): bool
     {
         try {
             if ($this->needsUpdate()) {
                 foreach ($this->getIterator() as $service) {
+                    if (!is_array($service)) {
+                        continue;
+                    }
                     $service = $this->createEntity($service);
-                    $this->removeEntityFromCurrentList($service->get('id'));
+                    $this->removeEntityFromCurrentList((int) $service->get('id'));
                     $service->save();
                 }
             }

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Settings.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Settings.php
@@ -5,15 +5,24 @@ namespace BO\Zmsdldb\Importer\MySQL;
 class Settings extends Base
 {
     protected bool $getCurrentEntitys = false;
+    /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Entity\Base>|null */
     protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Setting::class;
 
+    /** @psalm-api */
     #[\Override]
     public function runImport(): bool
     {
         try {
-            $this->importData = array_shift($this->importData);
+            $shifted = array_shift($this->importData);
+            if (!is_array($shifted)) {
+                throw new \RuntimeException('Invalid settings import data');
+            }
+            $this->importData = $shifted;
 
-            $settings = $this->importData['settings'];
+            $settings = $this->importData['settings'] ?? [];
+            if (!is_array($settings)) {
+                throw new \RuntimeException('Invalid settings payload');
+            }
             $settings['boroughs'] = json_encode(($this->importData['boroughs'] ?? ''));
             $settings['office'] = json_encode(($this->importData['office'] ?? ''));
 

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Topics.php
@@ -4,16 +4,21 @@ namespace BO\Zmsdldb\Importer\MySQL;
 
 class Topics extends Base
 {
+    /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Entity\Base>|null */
     protected ?string $entityClass = \BO\Zmsdldb\Importer\MySQL\Entity\Topic::class;
 
+    /** @psalm-api */
     #[\Override]
     public function runImport(): bool
     {
         try {
             if ($this->needsUpdate()) {
                 foreach ($this->getIterator() as $topic) {
+                    if (!is_array($topic)) {
+                        continue;
+                    }
                     $topic = $this->createEntity($topic);
-                    $this->removeEntityFromCurrentList($topic->get('id'));
+                    $this->removeEntityFromCurrentList((int) $topic->get('id'));
                     $topic->save();
                 }
             }


### PR DESCRIPTION
## Summary
- Fixes the remaining **81 open Psalm code-scanning alerts** under `zmsdldb/src/Zmsdldb/Importer/MySQL` (nullability, unused returns, untyped closures, dynamically dispatched import methods).
- Drops unused bool returns (`save`/`delete`/`setupFields`/etc.), guards Settings/`ArrayAccess` offsets, and marks `__call` importers as `MySQL\Base`.

## Test plan
- [x] PHPCS/PHPMD already passed on commit
- [x] After merge, re-run Psalm (module + monorepo dead-code) so GitHub code scanning can close the alerts — they stay open until a new SARIF upload