### PR TITLE
fix(ZMS): declare types on class constants

### DIFF
--- a/zmsadmin/config.example.php
+++ b/zmsadmin/config.example.php
@@ -12,7 +12,7 @@ class App extends \BO\Zmsadmin\Application
 {
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
 
     /**
      * HTTP url for api

--- a/zmsadmin/config.example.php
+++ b/zmsadmin/config.example.php
@@ -12,12 +12,12 @@ class App extends \BO\Zmsadmin\Application
 {
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
 
     /**
      * HTTP url for api
      */
-    const HTTP_BASE_URL = ZMS_API_URL;
+    const string HTTP_BASE_URL = ZMS_API_URL;
 
     /**
      * Name of the module

--- a/zmsadmin/src/Zmsadmin/Application.php
+++ b/zmsadmin/src/Zmsadmin/Application.php
@@ -45,11 +45,11 @@ class Application extends \BO\Slim\Application
 
     const bool DEBUG = false;
 
-    const bool|string TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
 
     const string TEMPLATE_PATH = ZMS_ADMIN_TEMPLATE_FOLDER;
 
-    const string|int SESSION_DURATION = ZMS_ADMIN_SESSION_DURATION;
+    const SESSION_DURATION = ZMS_ADMIN_SESSION_DURATION;
 
     public static $includeUrl = '/terminvereinbarung/admin';
 

--- a/zmsadmin/src/Zmsadmin/Application.php
+++ b/zmsadmin/src/Zmsadmin/Application.php
@@ -45,11 +45,11 @@ class Application extends \BO\Slim\Application
 
     const bool DEBUG = false;
 
-    const TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_ADMIN_TWIG_CACHE;
 
-    const TEMPLATE_PATH = ZMS_ADMIN_TEMPLATE_FOLDER;
+    const string TEMPLATE_PATH = ZMS_ADMIN_TEMPLATE_FOLDER;
 
-    const SESSION_DURATION = ZMS_ADMIN_SESSION_DURATION;
+    const string|int SESSION_DURATION = ZMS_ADMIN_SESSION_DURATION;
 
     public static $includeUrl = '/terminvereinbarung/admin';
 
@@ -68,7 +68,7 @@ class Application extends \BO\Slim\Application
     /**
      * language preferences
      */
-    const MULTILANGUAGE = true;
+    const bool MULTILANGUAGE = true;
 
     public static $locale = 'de';
     public static $supportedLanguages = array(
@@ -88,7 +88,7 @@ class Application extends \BO\Slim\Application
     /**
     * config preferences
     */
-    const CONFIG_SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
+    const string CONFIG_SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
 
     /**
      * signature key for url signature to save query paramter with hash
@@ -104,14 +104,14 @@ class Application extends \BO\Slim\Application
 
     public static $http_curl_config = array();
 
-    const CLIENTKEY = '';
+    const string CLIENTKEY = '';
 
-    const JSON_COMPRESS_LEVEL = 1;
+    const int JSON_COMPRESS_LEVEL = 1;
 
     /**
      * HTTP url for api
      */
-    const HTTP_BASE_URL = 'http://user:pass@host.tdl';
+    const string HTTP_BASE_URL = 'http://user:pass@host.tdl';
 
     public static function initialize(): void
     {

--- a/zmsadmin/src/Zmsadmin/QueueTable.php
+++ b/zmsadmin/src/Zmsadmin/QueueTable.php
@@ -16,7 +16,7 @@ class QueueTable extends BaseController
 {
     protected $processStatusList = ['preconfirmed', 'confirmed', 'queued', 'reserved', 'deleted'];
 
-    private const QUEUE_VIEW_PERMISSIONS = [
+    private const array QUEUE_VIEW_PERMISSIONS = [
         'waitingqueue',
         'parkedqueue',
         'missedqueue',

--- a/zmsadmin/src/Zmsadmin/Search.php
+++ b/zmsadmin/src/Zmsadmin/Search.php
@@ -14,9 +14,9 @@ use BO\Zmsentities\Collection\ProcessList;
 
 class Search extends BaseController
 {
-    private const DEFAULT_RESULTS_PER_PAGE = 100;
+    private const int DEFAULT_RESULTS_PER_PAGE = 100;
 
-    private const MAX_RESULTS_PER_PAGE = 1000;
+    private const int MAX_RESULTS_PER_PAGE = 1000;
 
     /**
      * @SuppressWarnings(Param)

--- a/zmsadmin/src/Zmsadmin/Status.php
+++ b/zmsadmin/src/Zmsadmin/Status.php
@@ -16,7 +16,7 @@ use BO\Zmsentities\Exception\UserAccountMissingRights;
  */
 class Status extends BaseController
 {
-    private const MISSING_LOGIN_TEMPLATES = [
+    private const array MISSING_LOGIN_TEMPLATES = [
         'BO\\Zmsentities\\Exception\\UserAccountMissingLogin',
         'BO\\Zmsbackend\\Workstation\\Exception\\WorkstationNotFound',
     ];

--- a/zmsadmin/src/Zmsadmin/UseraccountEdit.php
+++ b/zmsadmin/src/Zmsadmin/UseraccountEdit.php
@@ -19,7 +19,7 @@ use BO\Zmsentities\Useraccount;
 
 class UseraccountEdit extends BaseController
 {
-    private const SUPERUSER_ONLY_ROLES = [
+    private const array SUPERUSER_ONLY_ROLES = [
         'system_admin',
         'audit_viewer',
     ];

--- a/zmsadmin/src/Zmsadmin/UseraccountListByRole.php
+++ b/zmsadmin/src/Zmsadmin/UseraccountListByRole.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class UseraccountListByRole extends BaseController
 {
-    private const SUPERUSER_ONLY_ROLES = [
+    private const array SUPERUSER_ONLY_ROLES = [
         'system_admin',
         'audit_viewer',
     ];

--- a/zmsbackend/config.example.php
+++ b/zmsbackend/config.example.php
@@ -58,7 +58,7 @@ class App extends \BO\Zmsbackend\Application
     const string DB_DSN_READWRITE = DSN_RW;
     const string DB_USERNAME = MYSQL_USER;
     const string DB_PASSWORD = MYSQL_PASSWORD;
-    const bool|string TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
     const string MODULE_NAME = ZMS_MODULE_NAME;
 }
 

--- a/zmsbackend/config.example.php
+++ b/zmsbackend/config.example.php
@@ -53,12 +53,12 @@ class App extends \BO\Zmsbackend\Application
     const string APP_PATH = __DIR__;
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const bool DEBUG = false;
-    const DB_ENABLE_WSREPSYNCWAIT = true;
-    const DB_DSN_READONLY = DSN_RO;
-    const DB_DSN_READWRITE = DSN_RW;
-    const DB_USERNAME = MYSQL_USER;
-    const DB_PASSWORD = MYSQL_PASSWORD;
-    const TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
+    const bool DB_ENABLE_WSREPSYNCWAIT = true;
+    const string DB_DSN_READONLY = DSN_RO;
+    const string DB_DSN_READWRITE = DSN_RW;
+    const string DB_USERNAME = MYSQL_USER;
+    const string DB_PASSWORD = MYSQL_PASSWORD;
+    const bool|string TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
     const string MODULE_NAME = ZMS_MODULE_NAME;
 }
 

--- a/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiclient.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiclient.php
@@ -10,7 +10,7 @@ class Apiclient extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Quer
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'apiclient';
+    const string TABLE = 'apiclient';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Apikey/Repository/Apikey.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Repository/Apikey.php
@@ -10,9 +10,9 @@ class Apikey extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'apikey';
+    const string TABLE = 'apikey';
 
-    const QUOTATABLE = 'apiquota';
+    const string QUOTATABLE = 'apiquota';
 
     #[\Override]
     protected function addRequiredJoins()

--- a/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiquota.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiquota.php
@@ -10,7 +10,7 @@ class Apiquota extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'apiquota';
+    const string TABLE = 'apiquota';
 
     public static function getQueryReadApiQuotaListByKey()
     {

--- a/zmsbackend/src/Zmsbackend/Application.php
+++ b/zmsbackend/src/Zmsbackend/Application.php
@@ -60,19 +60,19 @@ class Application extends \BO\Slim\Application
     public static int $MAX_RECURSION_DEPTH;
 
     const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
-    const SESSION_DURATION = ZMSBACKEND_SESSION_DURATION;
+    const bool|string TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
+    const string|int SESSION_DURATION = ZMSBACKEND_SESSION_DURATION;
 
-    const DB_ENABLE_WSREPSYNCWAIT = false;
-    const RIGHTSCHECK_ENABLED = true;
+    const bool DB_ENABLE_WSREPSYNCWAIT = false;
+    const bool RIGHTSCHECK_ENABLED = true;
 
-    const DB_DSN_READONLY = 'mysql:dbname=zmsbo;host=127.0.0.1';
-    const DB_DSN_READWRITE = 'mysql:dbname=zmsbo;host=127.0.0.1';
-    const DB_STARTINFO = 'startinfo';
-    const DB_USERNAME = 'server';
-    const DB_PASSWORD = 'internet';
-    const DB_IS_GALERA = true;
-    const SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
+    const string DB_DSN_READONLY = 'mysql:dbname=zmsbo;host=127.0.0.1';
+    const string DB_DSN_READWRITE = 'mysql:dbname=zmsbo;host=127.0.0.1';
+    const string DB_STARTINFO = 'startinfo';
+    const string DB_USERNAME = 'server';
+    const string DB_PASSWORD = 'internet';
+    const bool DB_IS_GALERA = true;
+    const string SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
 
     public static $locale = 'de';
     public static $supportedLanguages = [

--- a/zmsbackend/src/Zmsbackend/Application.php
+++ b/zmsbackend/src/Zmsbackend/Application.php
@@ -60,8 +60,8 @@ class Application extends \BO\Slim\Application
     public static int $MAX_RECURSION_DEPTH;
 
     const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
-    const string|int SESSION_DURATION = ZMSBACKEND_SESSION_DURATION;
+    const TWIG_CACHE = ZMS_BACKEND_TWIG_CACHE;
+    const SESSION_DURATION = ZMSBACKEND_SESSION_DURATION;
 
     const bool DB_ENABLE_WSREPSYNCWAIT = false;
     const bool RIGHTSCHECK_ENABLED = true;

--- a/zmsbackend/src/Zmsbackend/Availability/Repository/Availability.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Repository/Availability.php
@@ -10,11 +10,11 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'oeffnungszeit';
+    const string TABLE = 'oeffnungszeit';
 
-    const TEMPORARY_DELETE = 'DELETE FROM oeffnungszeit WHERE kommentar = "--temporary--"';
+    const string TEMPORARY_DELETE = 'DELETE FROM oeffnungszeit WHERE kommentar = "--temporary--"';
 
-    const QUERY_GET_LOCK = '
+    const string QUERY_GET_LOCK = '
         SELECT OeffnungszeitID FROM oeffnungszeit WHERE OeffnungszeitID = :availabilityId FOR UPDATE
     ';
 

--- a/zmsbackend/src/Zmsbackend/Availability/Repository/Closure.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Repository/Closure.php
@@ -10,7 +10,7 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'closures';
+    const string TABLE = 'closures';
 
     /**
      * No resolving required here

--- a/zmsbackend/src/Zmsbackend/Calendar/Repository/Calendar.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Repository/Calendar.php
@@ -8,7 +8,7 @@ namespace BO\Zmsbackend\Calendar\Repository;
  */
 class Calendar extends \BO\Zmsbackend\Query\Base
 {
-    const QUERY_CALENDAR_BOOKABLEEND = "
+    const string QUERY_CALENDAR_BOOKABLEEND = "
         SELECT 
             MAX(CONCAT(slot.year, '-', LPAD(slot.month, 2, '0'), '-', LPAD(slot.day, 2, '0'))) as bookableEnd
         FROM

--- a/zmsbackend/src/Zmsbackend/Calendar/Repository/OverviewCalendar.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Repository/OverviewCalendar.php
@@ -4,16 +4,16 @@ namespace BO\Zmsbackend\Calendar\Repository;
 
 class OverviewCalendar extends \BO\Zmsbackend\Query\Base
 {
-    const TABLE = 'overview_calendar';
+    const string TABLE = 'overview_calendar';
 
-    const INSERT_ONE = "
+    const string INSERT_ONE = "
         INSERT INTO overview_calendar
             (scope_id, process_id, status, starts_at, ends_at)
         VALUES
             (:scope_id, :process_id, :status, :starts_at, :ends_at)
     ";
 
-    const CANCEL_BY_PROCESS = "
+    const string CANCEL_BY_PROCESS = "
         UPDATE overview_calendar
            SET status     = 'cancelled',
                updated_at = CURRENT_TIMESTAMP
@@ -21,7 +21,7 @@ class OverviewCalendar extends \BO\Zmsbackend\Query\Base
            AND status    <> 'cancelled'
 ";
 
-    const UPDATE_BY_PROCESS = "
+    const string UPDATE_BY_PROCESS = "
         UPDATE overview_calendar
            SET scope_id   = :scope_id,
                starts_at  = :starts_at,
@@ -31,7 +31,7 @@ class OverviewCalendar extends \BO\Zmsbackend\Query\Base
            AND status     = 'confirmed'
     ";
 
-    const SELECT_MAX_UPDATED = "
+    const string SELECT_MAX_UPDATED = "
         SELECT MAX(updated_at) AS max_updated
           FROM overview_calendar
          WHERE scope_id IN (%s)
@@ -39,13 +39,13 @@ class OverviewCalendar extends \BO\Zmsbackend\Query\Base
            AND starts_at < :until
     ";
 
-    const SELECT_MAX_UPDATED_GLOBAL = "
+    const string SELECT_MAX_UPDATED_GLOBAL = "
         SELECT MAX(updated_at) AS max_updated
           FROM overview_calendar
          WHERE scope_id IN (%s)
     ";
 
-    const SELECT_RANGE = "
+    const string SELECT_RANGE = "
         SELECT b.id, b.scope_id, b.process_id, b.status,
                b.starts_at, b.ends_at, b.updated_at,
                p.displayNumber AS display_number,
@@ -61,7 +61,7 @@ class OverviewCalendar extends \BO\Zmsbackend\Query\Base
          ORDER BY b.scope_id, b.starts_at, b.ends_at, b.id
     ";
 
-    const SELECT_RANGE_UPDATED = "
+    const string SELECT_RANGE_UPDATED = "
         SELECT b.id, b.scope_id, b.process_id, b.status,
                b.starts_at, b.ends_at, b.updated_at,
                p.displayNumber AS display_number,
@@ -78,14 +78,14 @@ class OverviewCalendar extends \BO\Zmsbackend\Query\Base
          ORDER BY b.scope_id, b.starts_at, b.ends_at, b.id
     ";
 
-    const SELECT_CHANGED_PIDS_SINCE = "
+    const string SELECT_CHANGED_PIDS_SINCE = "
         SELECT DISTINCT process_id
           FROM overview_calendar
          WHERE scope_id IN (%s)
            AND updated_at > :updatedAfter
     ";
 
-    const DELETE_ALL_BEFORE_END = "
+    const string DELETE_ALL_BEFORE_END = "
         DELETE FROM overview_calendar
          WHERE ends_at < :threshold
     ";

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Repository/Calldisplay.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Repository/Calldisplay.php
@@ -7,7 +7,7 @@ class Calldisplay extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'imagedata';
+    const string TABLE = 'imagedata';
 
     public function getQueryImage()
     {

--- a/zmsbackend/src/Zmsbackend/Cluster/Repository/Cluster.php
+++ b/zmsbackend/src/Zmsbackend/Cluster/Repository/Cluster.php
@@ -7,7 +7,7 @@ class Cluster extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'standortcluster';
+    const string TABLE = 'standortcluster';
 
     public function getQueryWriteAssignedScopes()
     {

--- a/zmsbackend/src/Zmsbackend/Config/Repository/Config.php
+++ b/zmsbackend/src/Zmsbackend/Config/Repository/Config.php
@@ -7,20 +7,20 @@ class Config extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'config';
+    const string TABLE = 'config';
 
-    const QUERY_SELECT = '
+    const string QUERY_SELECT = '
         SELECT * FROM config
     ';
 
-    const QUERY_SELECT_PROPERTY =
+    const string QUERY_SELECT_PROPERTY =
             'SELECT
                 value
             FROM config
             WHERE name = ?
             ';
 
-    const QUERY_REPLACE_PROPERTY =
+    const string QUERY_REPLACE_PROPERTY =
         'REPLACE INTO config
             SET name  = :property, 
                 value = :value

--- a/zmsbackend/src/Zmsbackend/Day/Repository/Day.php
+++ b/zmsbackend/src/Zmsbackend/Day/Repository/Day.php
@@ -8,7 +8,7 @@ namespace BO\Zmsbackend\Day\Repository;
  */
 class Day extends \BO\Zmsbackend\Query\Base
 {
-    const QUERY_CREATE_TEMPORARY_SCOPELIST = '
+    const string QUERY_CREATE_TEMPORARY_SCOPELIST = '
         CREATE TEMPORARY TABLE calendarscope (
             scopeID INT,
             year SMALLINT,
@@ -18,7 +18,7 @@ class Day extends \BO\Zmsbackend\Query\Base
         );
     ';
 
-    const QUERY_INSERT_TEMPORARY_SCOPELIST = '
+    const string QUERY_INSERT_TEMPORARY_SCOPELIST = '
         INSERT INTO calendarscope SET
             scopeID = :scopeID,
             year = :year,
@@ -26,14 +26,14 @@ class Day extends \BO\Zmsbackend\Query\Base
             slotsRequired = :slotsRequired;
     ';
 
-    const QUERY_DROP_TEMPORARY_SCOPELIST = 'DROP TEMPORARY TABLE IF EXISTS calendarscope;';
+    const string QUERY_DROP_TEMPORARY_SCOPELIST = 'DROP TEMPORARY TABLE IF EXISTS calendarscope;';
 
     /**
      * Shared daylist used by zmsadmin / classic /calendar/ (same semantics as next).
      *
      * see also \BO\Zmsbackend\Process\Repository\ProcessStatusFree::QUERY_SELECT_PROCESSLIST_DAYS
      */
-    const QUERY_DAYLIST_JOIN = '
+    const string QUERY_DAYLIST_JOIN = '
         SELECT
             year,
             LPAD(month, 2, "0") AS month,
@@ -111,7 +111,7 @@ class Day extends \BO\Zmsbackend\Query\Base
      *
      * see also \BO\Zmsbackend\Process\Repository\ProcessStatusFree::QUERY_SELECT_PROCESSLIST_DAYS_AVAILABILITY
      */
-    const QUERY_DAYLIST_JOIN_AVAILABILITY = '
+    const string QUERY_DAYLIST_JOIN_AVAILABILITY = '
         SELECT
             year,
             LPAD(month, 2, "0") AS month,

--- a/zmsbackend/src/Zmsbackend/Dayoff/Repository/DayOff.php
+++ b/zmsbackend/src/Zmsbackend/Dayoff/Repository/DayOff.php
@@ -7,7 +7,7 @@ class DayOff extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'feiertage';
+    const string TABLE = 'feiertage';
 
     /**
      * No resolving required here

--- a/zmsbackend/src/Zmsbackend/Department/Repository/Department.php
+++ b/zmsbackend/src/Zmsbackend/Department/Repository/Department.php
@@ -4,9 +4,9 @@ namespace BO\Zmsbackend\Department\Repository;
 
 class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\MappingInterface
 {
-    const TABLE = 'behoerde';
+    const string TABLE = 'behoerde';
 
-    const QUERY_MAIL_UPDATE = '
+    const string QUERY_MAIL_UPDATE = '
         SET @tempEmailID = (SELECT emailID from email WHERE BehoerdenID=:departmentId);
         REPLACE INTO
             email
@@ -19,7 +19,7 @@ class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
             send_reminder_minutes_before=:sendEmailReminderMinutesBefore
     ';
 
-    const QUERY_MAIL_DELETE = '
+    const string QUERY_MAIL_DELETE = '
         DELETE FROM email WHERE BehoerdenID=?
     ';
 

--- a/zmsbackend/src/Zmsbackend/EventLog/Repository/EventLog.php
+++ b/zmsbackend/src/Zmsbackend/EventLog/Repository/EventLog.php
@@ -10,8 +10,8 @@ use BO\Zmsentities\EventLog as EventLogEntity;
 
 class EventLog extends \BO\Zmsbackend\Query\Base
 {
-    public const TABLE = 'eventlog';
-    public const ALIAS = 'eventLog';
+    public const string TABLE = 'eventlog';
+    public const string ALIAS = 'eventLog';
 
     protected $resolveLevel = 0;
 

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeCapacityscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeCapacityscope.php
@@ -7,12 +7,12 @@ class ExchangeCapacityscope extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'slot_process';
+    const string TABLE = 'slot_process';
 
     /**
      * Time-series metrics for one scope: booked/planned capacity per day, all dates.
      */
-    const QUERY_CAPACITY_METRICS_BY_DAY_ALL_DATES = '
+    const string QUERY_CAPACITY_METRICS_BY_DAY_ALL_DATES = '
     SELECT
         `scopeID` as subjectid,
         CONCAT(year, "-", LPAD(month, 2, 0), "-", LPAD(day, 2, 0)) as date,
@@ -46,7 +46,7 @@ class ExchangeCapacityscope extends \BO\Zmsbackend\Query\Base
     /**
      * Time-series metrics for one scope: booked/planned capacity per day, within a date range.
      */
-    const QUERY_CAPACITY_METRICS_BY_DAY_IN_DATE_RANGE = '
+    const string QUERY_CAPACITY_METRICS_BY_DAY_IN_DATE_RANGE = '
     SELECT
         `scopeID` as subjectid,
         CONCAT(year, "-", LPAD(month, 2, 0), "-", LPAD(day, 2, 0)) as date,
@@ -82,7 +82,7 @@ class ExchangeCapacityscope extends \BO\Zmsbackend\Query\Base
     /**
      * Time-series metrics for one scope: booked/planned capacity per clock hour, within a date range.
      */
-    const QUERY_CAPACITY_METRICS_BY_HOUR_IN_DATE_RANGE = '
+    const string QUERY_CAPACITY_METRICS_BY_HOUR_IN_DATE_RANGE = '
     SELECT
         `scopeID` as subjectid,
         CONCAT(year, "-", LPAD(month, 2, 0), "-", LPAD(day, 2, 0), " ", LPAD(HOUR(`time`), 2, "0"), ":00") as date,

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientdepartment.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientdepartment.php
@@ -7,9 +7,9 @@ class ExchangeClientdepartment extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const BATABLE = 'buergeranliegen';
+    const string BATABLE = 'buergeranliegen';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientorganisation.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientorganisation.php
@@ -8,9 +8,9 @@ class ExchangeClientorganisation extends \BO\Zmsbackend\Query\Base
      * @var String TABLE mysql table reference
      */
 
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const BATABLE = 'buergeranliegen';
+    const string BATABLE = 'buergeranliegen';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientowner.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientowner.php
@@ -8,9 +8,9 @@ class ExchangeClientowner extends \BO\Zmsbackend\Query\Base
      * @var String TABLE mysql table reference
      */
 
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const BATABLE = 'buergeranliegen';
+    const string BATABLE = 'buergeranliegen';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeClientscope.php
@@ -7,9 +7,9 @@ class ExchangeClientscope extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const BATABLE = 'buergeranliegen';
+    const string BATABLE = 'buergeranliegen';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestdepartment.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestdepartment.php
@@ -9,9 +9,9 @@ class ExchangeRequestdepartment extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const REQUESTTABLE = 'request';
+    const string REQUESTTABLE = 'request';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestorganisation.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestorganisation.php
@@ -9,9 +9,9 @@ class ExchangeRequestorganisation extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const REQUESTTABLE = 'request';
+    const string REQUESTTABLE = 'request';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestowner.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestowner.php
@@ -9,9 +9,9 @@ class ExchangeRequestowner extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const REQUESTTABLE = 'request';
+    const string REQUESTTABLE = 'request';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestscope.php
@@ -9,9 +9,9 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'statistik';
+    const string TABLE = 'statistik';
 
-    const REQUESTTABLE = 'request';
+    const string REQUESTTABLE = 'request';
 
     const QUERY_READ_REPORT = '
     SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeSlotscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeSlotscope.php
@@ -7,9 +7,9 @@ class ExchangeSlotscope extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'slot_process';
+    const string TABLE = 'slot_process';
 
-    const QUERY_READ_REPORT = '
+    const string QUERY_READ_REPORT = '
     SELECT
         `scopeID` as subjectid,
         CONCAT(year, "-", LPAD(month, 2, 0), "-", LPAD(day, 2, 0)) as date,

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeUnassignedscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeUnassignedscope.php
@@ -4,7 +4,7 @@ namespace BO\Zmsbackend\Exchange\Repository;
 
 class ExchangeUnassignedscope extends \BO\Zmsbackend\Query\Base
 {
-    const QUERY_READ_REPORT = "SELECT 
+    const string QUERY_READ_REPORT = "SELECT 
             standort.StandortID, 
             standort.Bezeichnung, 
             IFNULL(COUNT(buerger.BuergerID), '') AS TerminAnzahl, 

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingdepartment.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingdepartment.php
@@ -7,7 +7,7 @@ class ExchangeWaitingdepartment extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'wartenrstatistik';
+    const string TABLE = 'wartenrstatistik';
 
     const QUERY_READ_DAY = '
         SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingorganisation.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingorganisation.php
@@ -7,7 +7,7 @@ class ExchangeWaitingorganisation extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'wartenrstatistik';
+    const string TABLE = 'wartenrstatistik';
 
     const QUERY_READ_DAY = '
         SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingowner.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingowner.php
@@ -7,7 +7,7 @@ class ExchangeWaitingowner extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'wartenrstatistik';
+    const string TABLE = 'wartenrstatistik';
 
     const QUERY_READ_DAY = '
         SELECT

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingscope.php
@@ -7,9 +7,9 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'wartenrstatistik';
+    const string TABLE = 'wartenrstatistik';
 
-    const WAITING_VALUES = "
+    const string WAITING_VALUES = "
         AVG(hour_00_waiting_time_spontaneous) as hour_00_waiting_time_spontaneous,
         AVG(hour_01_waiting_time_spontaneous) as hour_01_waiting_time_spontaneous,
         AVG(hour_02_waiting_time_spontaneous) as hour_02_waiting_time_spontaneous,

--- a/zmsbackend/src/Zmsbackend/Helper/SearchPagination.php
+++ b/zmsbackend/src/Zmsbackend/Helper/SearchPagination.php
@@ -4,11 +4,11 @@ namespace BO\Zmsbackend\Helper;
 
 final class SearchPagination
 {
-    public const DEFAULT_RESULTS_PER_PAGE = 100;
+    public const int DEFAULT_RESULTS_PER_PAGE = 100;
 
-    public const MIN_RESULTS_PER_PAGE = 1;
+    public const int MIN_RESULTS_PER_PAGE = 1;
 
-    public const MAX_RESULTS_PER_PAGE = 1000;
+    public const int MAX_RESULTS_PER_PAGE = 1000;
 
     public static function normalizePage(int $requestedPage): int
     {

--- a/zmsbackend/src/Zmsbackend/Helper/User.php
+++ b/zmsbackend/src/Zmsbackend/Helper/User.php
@@ -20,7 +20,7 @@ class User
 
     public static $request = null;
 
-    private const SUPERUSER_ONLY_ROLES = [
+    private const array SUPERUSER_ONLY_ROLES = [
         'system_admin',
         'audit_viewer',
     ];

--- a/zmsbackend/src/Zmsbackend/Link/Repository/Link.php
+++ b/zmsbackend/src/Zmsbackend/Link/Repository/Link.php
@@ -7,7 +7,7 @@ class Link extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'kundenlinks';
+    const string TABLE = 'kundenlinks';
 
     /**
      * No resolving required here

--- a/zmsbackend/src/Zmsbackend/Log/Repository/Log.php
+++ b/zmsbackend/src/Zmsbackend/Log/Repository/Log.php
@@ -7,7 +7,7 @@ class Log extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'log';
+    const string TABLE = 'log';
 
     /**
      * No resolving required here

--- a/zmsbackend/src/Zmsbackend/Log/Service/Log.php
+++ b/zmsbackend/src/Zmsbackend/Log/Service/Log.php
@@ -13,33 +13,33 @@ use DateTime;
  */
 class Log extends \BO\Zmsbackend\Base
 {
-    const PROCESS = 'buerger';
-    const MIGRATION = 'migration';
-    const ERROR = 'error';
+    const string PROCESS = 'buerger';
+    const string MIGRATION = 'migration';
+    const string ERROR = 'error';
 
-    const ACTION_MAIL_SUCCESS = 'E-Mail-Versand erfolgreich';
-    const ACTION_MAIL_FAIL = 'E-Mail-Versand ist fehlgeschlagen';
-    const ACTION_STATUS_CHANGE = 'Terminstatus wurde geändert';
-    const ACTION_SEND_REMINDER = 'Erinnerungsmail wurde gesendet';
-    const ACTION_REMOVED = 'Termin aus der Warteschlange entfernt';
-    const ACTION_CALLED = 'Termin wurde aufgerufen';
-    const ACTION_ARCHIVED = 'Termin wurde archiviert';
-    const ACTION_EDITED = 'Termin wurde geändert';
-    const ACTION_REDIRECTED = 'Termin wurde weitergeleitet';
-    const ACTION_NEW = 'Neuer Termin wurde erstellt';
-    const ACTION_DELETED = 'Termin wurde gelöscht';
-    const ACTION_CANCELED = 'Termin wurde abgesagt';
+    const string ACTION_MAIL_SUCCESS = 'E-Mail-Versand erfolgreich';
+    const string ACTION_MAIL_FAIL = 'E-Mail-Versand ist fehlgeschlagen';
+    const string ACTION_STATUS_CHANGE = 'Terminstatus wurde geändert';
+    const string ACTION_SEND_REMINDER = 'Erinnerungsmail wurde gesendet';
+    const string ACTION_REMOVED = 'Termin aus der Warteschlange entfernt';
+    const string ACTION_CALLED = 'Termin wurde aufgerufen';
+    const string ACTION_ARCHIVED = 'Termin wurde archiviert';
+    const string ACTION_EDITED = 'Termin wurde geändert';
+    const string ACTION_REDIRECTED = 'Termin wurde weitergeleitet';
+    const string ACTION_NEW = 'Neuer Termin wurde erstellt';
+    const string ACTION_DELETED = 'Termin wurde gelöscht';
+    const string ACTION_CANCELED = 'Termin wurde abgesagt';
 
-    private const FULLTEXT_SEARCH_COLUMNS = 'citizen_name, services, scope_name, citizen_email';
+    private const string FULLTEXT_SEARCH_COLUMNS = 'citizen_name, services, scope_name, citizen_email';
 
-    private const TEXT_SEARCH_COLUMNS = [
+    private const array TEXT_SEARCH_COLUMNS = [
         'citizen_name',
         'services',
         'scope_name',
         'citizen_email',
     ];
 
-    private const INDEXED_COLUMNS = [
+    private const array INDEXED_COLUMNS = [
         'action',
         'display_number',
         'queue_number',
@@ -55,7 +55,7 @@ class Log extends \BO\Zmsbackend\Base
         'process_amendment',
     ];
 
-    private const ACTION_LABEL_TO_CODE = [
+    private const array ACTION_LABEL_TO_CODE = [
         self::ACTION_MAIL_SUCCESS => 'mail_success',
         self::ACTION_MAIL_FAIL => 'mail_fail',
         self::ACTION_STATUS_CHANGE => 'status_changed',

--- a/zmsbackend/src/Zmsbackend/Mail/Repository/MailQueue.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Repository/MailQueue.php
@@ -7,7 +7,7 @@ class MailQueue extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'mailqueue';
+    const string TABLE = 'mailqueue';
 
     const QUERY_DELETE = '
         DELETE mq,  mp

--- a/zmsbackend/src/Zmsbackend/Mail/Repository/Mailtemplate.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Repository/Mailtemplate.php
@@ -7,20 +7,20 @@ class Mailtemplate extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'mailtemplate';
+    const string TABLE = 'mailtemplate';
 
-    const QUERY_SELECT = '
+    const string QUERY_SELECT = '
         SELECT * FROM mailtemplate
     ';
 
-    const QUERY_SELECT_PROPERTY =
+    const string QUERY_SELECT_PROPERTY =
             'SELECT
                 value
             FROM mailtemplate
             WHERE name = ?
             ';
 
-    const QUERY_REPLACE_PROPERTY =
+    const string QUERY_REPLACE_PROPERTY =
         'REPLACE INTO mailtemplate
             SET name  = :property, 
                 value = :value

--- a/zmsbackend/src/Zmsbackend/Mail/Repository/Mimepart.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Repository/Mimepart.php
@@ -7,7 +7,7 @@ class Mimepart extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'mailpart';
+    const string TABLE = 'mailpart';
 
     /**
      * No resolving required here

--- a/zmsbackend/src/Zmsbackend/Organisation/Repository/Organisation.php
+++ b/zmsbackend/src/Zmsbackend/Organisation/Repository/Organisation.php
@@ -7,7 +7,7 @@ class Organisation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'organisation';
+    const string TABLE = 'organisation';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Owner/Repository/Owner.php
+++ b/zmsbackend/src/Zmsbackend/Owner/Repository/Owner.php
@@ -7,7 +7,7 @@ class Owner extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Ma
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'kunde';
+    const string TABLE = 'kunde';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Permission/Repository/Permission.php
+++ b/zmsbackend/src/Zmsbackend/Permission/Repository/Permission.php
@@ -7,7 +7,7 @@ class Permission extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
     /**
      * @var string TABLE mysql table reference
      */
-    const TABLE = 'permission';
+    const string TABLE = 'permission';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Preferences/Repository/Preferences.php
+++ b/zmsbackend/src/Zmsbackend/Preferences/Repository/Preferences.php
@@ -7,9 +7,9 @@ class Preferences extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'preferences';
+    const string TABLE = 'preferences';
 
-    const QUERY_SELECT_PROPERTY =
+    const string QUERY_SELECT_PROPERTY =
         'SELECT
                 value
             FROM preferences
@@ -20,7 +20,7 @@ class Preferences extends \BO\Zmsbackend\Query\Base
                 AND name = :name
             ';
 
-    const QUERY_SELECT_TIMESTAMP =
+    const string QUERY_SELECT_TIMESTAMP =
         'SELECT
                 updateTimestamp
             FROM preferences
@@ -31,7 +31,7 @@ class Preferences extends \BO\Zmsbackend\Query\Base
                 AND name = :name
             ';
 
-    const QUERY_REPLACE_PROPERTY =
+    const string QUERY_REPLACE_PROPERTY =
         'REPLACE INTO preferences
             SET 
                 entity = :entityName,
@@ -41,7 +41,7 @@ class Preferences extends \BO\Zmsbackend\Query\Base
                 value = :value
             ';
 
-    const QUERY_DELETE_PROPERTY =
+    const string QUERY_DELETE_PROPERTY =
         'DELETE FROM preferences
             WHERE
                 entity = :entityName

--- a/zmsbackend/src/Zmsbackend/Preferences/Service/Preferences.php
+++ b/zmsbackend/src/Zmsbackend/Preferences/Service/Preferences.php
@@ -4,7 +4,7 @@ namespace BO\Zmsbackend\Preferences\Service;
 
 class Preferences extends \BO\Zmsbackend\Base
 {
-    const REPLACE_SKIPPED = 'skipped';
+    const string REPLACE_SKIPPED = 'skipped';
 
     public function readProperty($entityName, $entityId, $groupName, $name, $forUpdate = false)
     {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessListSummaryMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessListSummaryMail.php
@@ -30,7 +30,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class ProcessListSummaryMail extends \BO\Zmsbackend\Api\BaseController
 {
-    public const PROCESSLIST_SUMMARY_REQUEST_REPETITION_SEC = 600;
+    public const int PROCESSLIST_SUMMARY_REQUEST_REPETITION_SEC = 600;
 
     /**
      * @SuppressWarnings(Param)

--- a/zmsbackend/src/Zmsbackend/Process/Repository/Process.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/Process.php
@@ -16,9 +16,9 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     /**
      *     * @var String TABLE mysql table reference
      */
-    const TABLE = 'buerger';
+    const string TABLE = 'buerger';
 
-    const QUERY_DEREFERENCED = "UPDATE `buerger` process LEFT JOIN `standort` s USING(StandortID)
+    const string QUERY_DEREFERENCED = "UPDATE `buerger` process LEFT JOIN `standort` s USING(StandortID)
         SET
             process.Anmerkung = ?,
             process.custom_text_field = ?,
@@ -42,7 +42,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
             OR process.istFolgeterminvon = ?
         ";
 
-    const QUERY_CANCELED = "
+    const string QUERY_CANCELED = "
         UPDATE `buerger` process LEFT JOIN `standort` s USING(StandortID)
             SET
                 process.Anmerkung = CONCAT(
@@ -62,31 +62,31 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
                 OR process.istFolgeterminvon = :processId
         ";
 
-    const QUERY_DELETE = "DELETE FROM `buerger`
+    const string QUERY_DELETE = "DELETE FROM `buerger`
         WHERE
             BuergerID = ?
             OR istFolgeterminvon = ?
         ";
 
-    const QUERY_REASSIGN_PROCESS_CREDENTIALS = "UPDATE `buerger` process
+    const string QUERY_REASSIGN_PROCESS_CREDENTIALS = "UPDATE `buerger` process
        SET 
             process.BuergerID = :newProcessId, 
             process.absagecode = :newAuthKey
         WHERE BuergerID = :processId
     ";
 
-    const QUERY_REASSIGN_PROCESS_REQUESTS = "UPDATE `buergeranliegen` requests
+    const string QUERY_REASSIGN_PROCESS_REQUESTS = "UPDATE `buergeranliegen` requests
         SET 
             requests.BuergerID = :newProcessId
         WHERE BuergerID = :processId
     ";
 
-    const QUERY_REASSIGN_FOLLWING_PROCESS = "UPDATE `buerger` process
+    const string QUERY_REASSIGN_FOLLWING_PROCESS = "UPDATE `buerger` process
         SET process.istFolgeterminvon = :newProcessId
         WHERE istFolgeterminvon = :processId
     ";
 
-    const QUERY_UPDATE_FOLLOWING_PROCESS = "UPDATE buerger 
+    const string QUERY_UPDATE_FOLLOWING_PROCESS = "UPDATE buerger 
         SET vorlaeufigeBuchung = :reserved 
         WHERE istFolgeterminvon = :processID
         ";

--- a/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusArchived.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusArchived.php
@@ -13,9 +13,9 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
      *
      * @var String TABLE mysql table reference
      */
-    public const TABLE = 'buergerarchiv';
-    public const STATISTIC_TABLE = 'statistik';
-    public const ALIAS = 'process';
+    public const string TABLE = 'buergerarchiv';
+    public const string STATISTIC_TABLE = 'statistik';
+    public const string ALIAS = 'process';
 
     const QUERY_INSERT_IN_STATISTIC = '
         INSERT INTO ' . self::STATISTIC_TABLE . ' SET

--- a/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusArchivedToday.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusArchivedToday.php
@@ -13,6 +13,6 @@ class ProcessStatusArchivedToday extends ProcessStatusArchived
      *
      * @var String TABLE mysql table reference
      */
-    public const TABLE = 'buergerarchivtoday';
-    const DELETE_ALL = 'DELETE FROM buergerarchivtoday';
+    public const string TABLE = 'buergerarchivtoday';
+    const string DELETE_ALL = 'DELETE FROM buergerarchivtoday';
 }

--- a/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusFree.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusFree.php
@@ -12,7 +12,7 @@ class ProcessStatusFree extends \BO\Zmsbackend\Query\Base
      *
      * see also \BO\Zmsbackend\Day\Repository\Day::QUERY_DAYLIST_JOIN
      */
-    const QUERY_SELECT_PROCESSLIST_DAYS = '
+    const string QUERY_SELECT_PROCESSLIST_DAYS = '
         SELECT
             -- tmp_avail.*,
             "free" AS status,
@@ -60,7 +60,7 @@ class ProcessStatusFree extends \BO\Zmsbackend\Query\Base
      *
      * see also \BO\Zmsbackend\Day\Repository\Day::QUERY_DAYLIST_JOIN_AVAILABILITY
      */
-    const QUERY_SELECT_PROCESSLIST_DAYS_AVAILABILITY = '
+    const string QUERY_SELECT_PROCESSLIST_DAYS_AVAILABILITY = '
         SELECT
             -- tmp_avail.*,
             "free" AS status,
@@ -110,7 +110,7 @@ class ProcessStatusFree extends \BO\Zmsbackend\Query\Base
             INNER JOIN slot_sequence sq ON sq.slotsequence <= tmp_avail.free
     ';
 
-    const GROUPBY_SELECT_PROCESSLIST_DAY = 'GROUP BY scope__id, appointments__0__date';
+    const string GROUPBY_SELECT_PROCESSLIST_DAY = 'GROUP BY scope__id, appointments__0__date';
 
     public static function buildDaysCondition($days)
     {

--- a/zmsbackend/src/Zmsbackend/Provider/Repository/Provider.php
+++ b/zmsbackend/src/Zmsbackend/Provider/Repository/Provider.php
@@ -4,7 +4,7 @@ namespace BO\Zmsbackend\Provider\Repository;
 
 class Provider extends \BO\Zmsbackend\Query\Base
 {
-    const TABLE = 'provider';
+    const string TABLE = 'provider';
 
     /** @psalm-api */
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Query/Base.php
+++ b/zmsbackend/src/Zmsbackend/Query/Base.php
@@ -26,11 +26,11 @@ abstract class Base
     /**
      * Identifier for the type of query
      */
-    const SELECT = 'SELECT';
-    const INSERT = 'INSERT';
-    const UPDATE = 'UPDATE';
-    const REPLACE = 'REPLACE';
-    const DELETE = 'DELETE';
+    const string SELECT = 'SELECT';
+    const string INSERT = 'INSERT';
+    const string UPDATE = 'UPDATE';
+    const string REPLACE = 'REPLACE';
+    const string DELETE = 'DELETE';
 
     /**
      * Name of table in DB

--- a/zmsbackend/src/Zmsbackend/Query/Scope.php
+++ b/zmsbackend/src/Zmsbackend/Query/Scope.php
@@ -7,9 +7,9 @@ class Scope extends Base implements MappingInterface
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'standort';
+    const string TABLE = 'standort';
 
-    const QUERY_BY_DEPARTMENTID = 'SELECT
+    const string QUERY_BY_DEPARTMENTID = 'SELECT
             scope.`StandortID` AS id
         FROM `standort` scope
         WHERE

--- a/zmsbackend/src/Zmsbackend/Queue/Repository/Queue.php
+++ b/zmsbackend/src/Zmsbackend/Queue/Repository/Queue.php
@@ -9,7 +9,7 @@ namespace BO\Zmsbackend\Queue\Repository;
  */
 class Queue extends \BO\Zmsbackend\Process\Repository\Process implements \BO\Zmsbackend\Query\MappingInterface
 {
-    const ALIAS = 'process';
+    const string ALIAS = 'process';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Request/Repository/Request.php
+++ b/zmsbackend/src/Zmsbackend/Request/Repository/Request.php
@@ -4,11 +4,11 @@ namespace BO\Zmsbackend\Request\Repository;
 
 class Request extends \BO\Zmsbackend\Query\Base
 {
-    const TABLE = 'request';
+    const string TABLE = 'request';
 
-    const BATABLE = 'buergeranliegen';
+    const string BATABLE = 'buergeranliegen';
 
-    const QUERY_BY_PROCESSID = 'SELECT
+    const string QUERY_BY_PROCESSID = 'SELECT
             ba.`AnliegenID` AS id
         FROM `buergeranliegen` ba
         WHERE

--- a/zmsbackend/src/Zmsbackend/Request/Repository/XRequest.php
+++ b/zmsbackend/src/Zmsbackend/Request/Repository/XRequest.php
@@ -8,7 +8,7 @@ class XRequest extends \BO\Zmsbackend\Query\Base
      *
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'buergeranliegen';
+    const string TABLE = 'buergeranliegen';
 
     public function addConditionProcessId($processId)
     {

--- a/zmsbackend/src/Zmsbackend/RequestRelation/Repository/RequestRelation.php
+++ b/zmsbackend/src/Zmsbackend/RequestRelation/Repository/RequestRelation.php
@@ -4,9 +4,9 @@ namespace BO\Zmsbackend\RequestRelation\Repository;
 
 class RequestRelation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\MappingInterface
 {
-    const TABLE = 'request_provider';
+    const string TABLE = 'request_provider';
 
-    const ALIAS = 'request_provider';
+    const string ALIAS = 'request_provider';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/RequestVariant/Repository/RequestVariant.php
+++ b/zmsbackend/src/Zmsbackend/RequestVariant/Repository/RequestVariant.php
@@ -4,8 +4,8 @@ namespace BO\Zmsbackend\RequestVariant\Repository;
 
 class RequestVariant extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\MappingInterface
 {
-    const TABLE = 'request_variant';
-    const ALIAS = 'request_variant';
+    const string TABLE = 'request_variant';
+    const string ALIAS = 'request_variant';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Role/Repository/Role.php
+++ b/zmsbackend/src/Zmsbackend/Role/Repository/Role.php
@@ -7,7 +7,7 @@ class Role extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
     /**
      * @var string TABLE mysql table reference
      */
-    const TABLE = 'role';
+    const string TABLE = 'role';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Role/Repository/RolePermission.php
+++ b/zmsbackend/src/Zmsbackend/Role/Repository/RolePermission.php
@@ -7,7 +7,7 @@ class RolePermission extends \BO\Zmsbackend\Query\Base
     /**
      * @var string TABLE mysql table reference
      */
-    const TABLE = 'role_permission';
+    const string TABLE = 'role_permission';
 
     public function addConditionRoleId(int $roleId): self
     {

--- a/zmsbackend/src/Zmsbackend/Role/Repository/UserRole.php
+++ b/zmsbackend/src/Zmsbackend/Role/Repository/UserRole.php
@@ -7,7 +7,7 @@ class UserRole extends \BO\Zmsbackend\Query\Base
     /**
      * @var string TABLE mysql table reference
      */
-    const TABLE = 'user_role';
+    const string TABLE = 'user_role';
 
     /** @psalm-api */
     public function addConditionUserId(int $userId): self

--- a/zmsbackend/src/Zmsbackend/Session/Repository/Session.php
+++ b/zmsbackend/src/Zmsbackend/Session/Repository/Session.php
@@ -7,14 +7,14 @@ class Session extends \BO\Zmsbackend\Query\Base
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'sessiondata';
+    const string TABLE = 'sessiondata';
 
     /**
      * No resolving required here
      */
     protected $resolveLevel = 0;
 
-    const QUERY_WRITE = '
+    const string QUERY_WRITE = '
         REPLACE INTO
             sessiondata
         SET
@@ -23,7 +23,7 @@ class Session extends \BO\Zmsbackend\Query\Base
             sessioncontent=?
     ';
 
-    const QUERY_DELETE = '
+    const string QUERY_DELETE = '
         DELETE FROM
             sessiondata
         WHERE

--- a/zmsbackend/src/Zmsbackend/Slot/Repository/Slot.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Repository/Slot.php
@@ -8,41 +8,41 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
      *
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'slot';
+    const string TABLE = 'slot';
 
-    const QUERY_OPTIMIZE_SLOT = 'OPTIMIZE TABLE slot;';
-    const QUERY_OPTIMIZE_SLOT_HIERA = 'OPTIMIZE TABLE slot_hiera;';
-    const QUERY_OPTIMIZE_SLOT_PROCESS = 'OPTIMIZE TABLE slot_proces;';
-    const QUERY_OPTIMIZE_PROCESS = 'OPTIMIZE TABLE buerger;';
+    const string QUERY_OPTIMIZE_SLOT = 'OPTIMIZE TABLE slot;';
+    const string QUERY_OPTIMIZE_SLOT_HIERA = 'OPTIMIZE TABLE slot_hiera;';
+    const string QUERY_OPTIMIZE_SLOT_PROCESS = 'OPTIMIZE TABLE slot_proces;';
+    const string QUERY_OPTIMIZE_PROCESS = 'OPTIMIZE TABLE buerger;';
 
-    const QUERY_LAST_CHANGED = 'SELECT MAX(updateTimestamp) AS dateString FROM slot;';
+    const string QUERY_LAST_CHANGED = 'SELECT MAX(updateTimestamp) AS dateString FROM slot;';
 
-    const QUERY_LAST_CHANGED_AVAILABILITY = '
+    const string QUERY_LAST_CHANGED_AVAILABILITY = '
         SELECT MAX(updateTimestamp) AS dateString FROM slot WHERE availabilityID = :availabilityID AND status="free";';
 
-    const QUERY_LAST_IN_AVAILABILITY = '
+    const string QUERY_LAST_IN_AVAILABILITY = '
         SELECT CONCAT(year, "-", LPAD(month, 2, "0"), "-", LPAD(day, 2, "0")) AS dateString
         FROM slot
         WHERE availabilityID = :availabilityID AND status="free"
         ORDER BY year DESC, month DESC, day DESC
         LIMIT 1;';
 
-    const QUERY_OLDEST_VERSION_IN_AVAILABILITY = '
+    const string QUERY_OLDEST_VERSION_IN_AVAILABILITY = '
         SELECT `version`
         FROM slot
         WHERE availabilityID = :availabilityID AND status="free"
         ORDER BY `version` ASC
         LIMIT 1;';
 
-    const QUERY_LAST_CHANGED_SCOPE = '
+    const string QUERY_LAST_CHANGED_SCOPE = '
         SELECT MAX(updateTimestamp) AS dateString FROM slot WHERE scopeID = :scopeID;';
 
-    const QUERY_INSERT_SLOT_PROCESS = '
+    const string QUERY_INSERT_SLOT_PROCESS = '
         INSERT INTO slot_process
         VALUES(?,?,?) 
     ';
 
-    const QUERY_SELECT_BY_SCOPE_AND_DAY = '
+    const string QUERY_SELECT_BY_SCOPE_AND_DAY = '
         SELECT
             s.*
         FROM slot s
@@ -53,7 +53,7 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
             AND s.day = :day
     ';
 
-    const QUERY_SELECT_MISSING_PROCESS = '
+    const string QUERY_SELECT_MISSING_PROCESS = '
         SELECT 
           s.slotID,
           b.BuergerID,
@@ -70,12 +70,12 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
         WHERE
           sp.processID IS NULL
     ';
-    const QUERY_SELECT_MISSING_PROCESS_BY_SCOPE = '
+    const string QUERY_SELECT_MISSING_PROCESS_BY_SCOPE = '
           AND s.scopeID = :scopeID
     ';
 
 
-    const QUERY_INSERT_SLOT_PROCESS_ID = '
+    const string QUERY_INSERT_SLOT_PROCESS_ID = '
         REPLACE INTO slot_process
         SELECT 
           s.slotID,
@@ -92,17 +92,17 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
         WHERE
           b.BuergerID = :processId
     ';
-    const QUERY_DELETE_SLOT_PROCESS_CANCELLED = '
+    const string QUERY_DELETE_SLOT_PROCESS_CANCELLED = '
         DELETE sp 
             FROM slot_process sp LEFT JOIN slot s USING (slotID)
             WHERE (s.status = "cancelled" OR s.status IS NULL)
     ';
-    const QUERY_DELETE_SLOT_PROCESS_CANCELLED_BY_SCOPE = '
+    const string QUERY_DELETE_SLOT_PROCESS_CANCELLED_BY_SCOPE = '
                 AND s.scopeID = :scopeID
     ';
 
 
-    const QUERY_UPDATE_SLOT_MISSING_AVAILABILITY_BY_SCOPE = '
+    const string QUERY_UPDATE_SLOT_MISSING_AVAILABILITY_BY_SCOPE = '
     UPDATE
          slot s
            LEFT JOIN oeffnungszeit a ON s.availabilityID = a.OeffnungszeitID
@@ -115,7 +115,7 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
              AND s.scopeID = :scopeID
     ';
 
-    const QUERY_UPDATE_SLOT_MISSING_AVAILABILITY = '
+    const string QUERY_UPDATE_SLOT_MISSING_AVAILABILITY = '
     UPDATE
          slot s
            LEFT JOIN oeffnungszeit a ON s.availabilityID = a.OeffnungszeitID
@@ -125,7 +125,7 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
                OR a.Endedatum < :dateString
     ';
 
-    const QUERY_SELECT_DELETABLE_SLOT_PROCESS = '
+    const string QUERY_SELECT_DELETABLE_SLOT_PROCESS = '
         SELECT sp.processID AS processId
             FROM slot_process sp
               LEFT JOIN buerger b ON sp.processID = b.BuergerID
@@ -143,17 +143,17 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
                 )
               ) 
     ';
-    const QUERY_SELECT_DELETABLE_SLOT_PROCESS_BY_SCOPE = '
+    const string QUERY_SELECT_DELETABLE_SLOT_PROCESS_BY_SCOPE = '
               AND b.StandortID = :scopeID
     ';
 
-    const QUERY_DELETE_SLOT_PROCESS_ID = '
+    const string QUERY_DELETE_SLOT_PROCESS_ID = '
         DELETE sp 
             FROM slot_process sp 
             WHERE sp.processID = :processId
     ';
 
-    const QUERY_UPDATE_SLOT_STATUS = "
+    const string QUERY_UPDATE_SLOT_STATUS = "
         UPDATE slot
           LEFT JOIN (
           SELECT s.slotID,
@@ -167,7 +167,7 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
         WHERE slot.status != calc.newstatus
 ";
 
-    const QUERY_SELECT_SLOT = '
+    const string QUERY_SELECT_SLOT = '
     SELECT slotID FROM slot WHERE
       scopeID = :scopeID
       AND year = :year
@@ -195,29 +195,29 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
     FOR UPDATE
 ';
 
-    const QUERY_INSERT_ANCESTOR = '
+    const string QUERY_INSERT_ANCESTOR = '
     INSERT INTO slot_hiera SET slotID = :slotID, ancestorID = :ancestorID, ancestorLevel = :ancestorLevel
 ';
 
-    const QUERY_DELETE_ANCESTOR = '
+    const string QUERY_DELETE_ANCESTOR = '
     DELETE FROM slot_hiera WHERE slotID = :slotID
 ';
 
-    const QUERY_CANCEL_AVAILABILITY = '
+    const string QUERY_CANCEL_AVAILABILITY = '
         UPDATE slot SET status = "cancelled" WHERE availabilityID = :availabilityID
 ';
 
-    const QUERY_CANCEL_AVAILABILITY_BEFORE_BOOKABLE = '
+    const string QUERY_CANCEL_AVAILABILITY_BEFORE_BOOKABLE = '
             UPDATE slot SET status = "cancelled" WHERE availabilityID = :availabilityID 
             AND CONCAT(year, "-", LPAD(month, 2, "0"), "-", LPAD(day, 2, "0")) < :providedDate
 ';
 
-    const QUERY_CANCEL_AVAILABILITY_AFTER_BOOKABLE = '
+    const string QUERY_CANCEL_AVAILABILITY_AFTER_BOOKABLE = '
             UPDATE slot SET status = "cancelled" WHERE availabilityID = :availabilityID 
             AND CONCAT(year, "-", LPAD(month, 2, "0"), "-", LPAD(day, 2, "0")) > :providedDate
     ';
 
-    const QUERY_CANCEL_SLOT_OLD_BY_SCOPE = '
+    const string QUERY_CANCEL_SLOT_OLD_BY_SCOPE = '
     UPDATE slot SET status =  "cancelled" 
         WHERE scopeID = :scopeID AND (
             (year < :year)
@@ -226,21 +226,21 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
         )
 ';
 
-    const QUERY_CANCEL_SLOT_OLD = '
+    const string QUERY_CANCEL_SLOT_OLD = '
     UPDATE slot SET status =  "cancelled" 
         WHERE (year < :year)
             OR (year = :year AND  month < :month) 
             OR (year = :year AND  month = :month AND  day <= :day AND time < :time)
 ';
 
-    const QUERY_DELETE_SLOT_OLD = '
+    const string QUERY_DELETE_SLOT_OLD = '
     DELETE FROM slot 
         WHERE (year < :year) 
             OR (year = :year AND  month < :month) 
             OR (year = :year AND  month = :month AND  day < :day)
 ';
 
-    const QUERY_DELETE_SLOT_HIERA = '
+    const string QUERY_DELETE_SLOT_HIERA = '
         DELETE sh 
             FROM slot_hiera sh LEFT JOIN slot s USING(slotID)
             WHERE s.slotID IS NULL

--- a/zmsbackend/src/Zmsbackend/Slot/Repository/SlotList.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Repository/SlotList.php
@@ -12,7 +12,7 @@ use BO\Zmsentities\Slot;
  */
 class SlotList extends \BO\Zmsbackend\Query\Base
 {
-    const QUERY = 'SELECT
+    const string QUERY = 'SELECT
 
             -- collect some important settings, especially from the scope, use the appointment key
             CONCAT(b.Datum, " ", b.Uhrzeit) AS appointment__date,

--- a/zmsbackend/src/Zmsbackend/Slot/Service/Slot.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Service/Slot.php
@@ -18,9 +18,9 @@ class Slot extends \BO\Zmsbackend\Base
     /**
      * maximum number of slots per appointment
      */
-    const MAX_SLOTS = 25;
+    const int MAX_SLOTS = 25;
 
-    const MAX_DAYS_OF_SLOT_CALCULATION = 180;
+    const int MAX_DAYS_OF_SLOT_CALCULATION = 180;
 
     /**
      * @return \BO\Zmsentities\Collection\SlotList

--- a/zmsbackend/src/Zmsbackend/Source/Repository/Source.php
+++ b/zmsbackend/src/Zmsbackend/Source/Repository/Source.php
@@ -7,7 +7,7 @@ class Source extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'source';
+    const string TABLE = 'source';
 
     #[\Override]
     public function getEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Ticketprinter/Repository/Ticketprinter.php
+++ b/zmsbackend/src/Zmsbackend/Ticketprinter/Repository/Ticketprinter.php
@@ -7,9 +7,9 @@ class Ticketprinter extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'kiosk';
+    const string TABLE = 'kiosk';
 
-    const PRIMARY = 'hash';
+    const string PRIMARY = 'hash';
 
     /**
      * No resolving required here

--- a/zmsbackend/src/Zmsbackend/Useraccount/Repository/Useraccount.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Repository/Useraccount.php
@@ -6,7 +6,7 @@ use BO\Slim\Application as App;
 
 class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\MappingInterface
 {
-    private const VALID_PERMISSION_NAMES = [
+    private const array VALID_PERMISSION_NAMES = [
         'appointment',
         'availability',
         'calldisplay',
@@ -42,8 +42,8 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'nutzer';
-    const TABLE_ASSIGNMENT = 'nutzerzuordnung';
+    const string TABLE = 'nutzer';
+    const string TABLE_ASSIGNMENT = 'nutzerzuordnung';
 
     const QUERY_READ_ID_BY_USERNAME = '
         SELECT user.`NutzerID` AS id
@@ -68,11 +68,11 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         ORDER BY behoerdenid
     ';
 
-    const QUERY_DELETE_USER_ROLES = '
+    const string QUERY_DELETE_USER_ROLES = '
         DELETE FROM user_role WHERE user_id = ?
     ';
 
-    const QUERY_INSERT_USER_ROLES_BY_NAME = '
+    const string QUERY_INSERT_USER_ROLES_BY_NAME = '
         INSERT INTO user_role (user_id, role_id)
         SELECT ?, r.id FROM role r WHERE r.name IN (:roleNames)
     ';

--- a/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
@@ -14,9 +14,9 @@ use BO\Zmsentities\Collection\UseraccountList as Collection;
  */
 class Useraccount extends \BO\Zmsbackend\Base
 {
-    private const CACHE_VERSION_KEY = 'useraccountCacheVersion';
-    private const CACHE_INDEX_PREFIX = 'useraccountCacheIndex-';
-    private const CACHE_INDEX_GLOBAL = 'all';
+    private const string CACHE_VERSION_KEY = 'useraccountCacheVersion';
+    private const string CACHE_INDEX_PREFIX = 'useraccountCacheIndex-';
+    private const string CACHE_INDEX_GLOBAL = 'all';
 
     /**
      * Read or initialize the cache version for all useraccount-related cache entries.

--- a/zmsbackend/src/Zmsbackend/Workstation/Repository/Workstation.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Repository/Workstation.php
@@ -11,7 +11,7 @@ class Workstation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
     /**
      * @var String TABLE mysql table reference
      */
-    const TABLE = 'nutzer';
+    const string TABLE = 'nutzer';
 
     const QUERY_LOGIN = '
         UPDATE

--- a/zmsbackend/tests/Zmsbackend/Availability/Api/AvailabilityListByScopeTest.php
+++ b/zmsbackend/tests/Zmsbackend/Availability/Api/AvailabilityListByScopeTest.php
@@ -6,7 +6,7 @@ class AvailabilityListByScopeTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "AvailabilityListByScope";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
     
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Calendar/Api/OverallCalendarReadTest.php
+++ b/zmsbackend/tests/Zmsbackend/Calendar/Api/OverallCalendarReadTest.php
@@ -11,7 +11,7 @@ class OverallCalendarReadTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "OverallCalendarRead";
 
-    private const VALID_PARAMS = [
+    private const array VALID_PARAMS = [
         'scopeIds'  => '65202',
         'dateFrom'  => '2025-05-14',
         'dateUntil' => '2025-05-14',

--- a/zmsbackend/tests/Zmsbackend/Cluster/Api/ClusterCalldisplayImageDataDeleteTest.php
+++ b/zmsbackend/tests/Zmsbackend/Cluster/Api/ClusterCalldisplayImageDataDeleteTest.php
@@ -11,7 +11,7 @@ class ClusterCalldisplayImageDataDeleteTest extends \BO\Zmsbackend\Tests\Api\Bas
 {
     protected $classname = "ClusterCalldisplayImageDataDelete";
 
-    const CLUSTER_ID = 109;
+    const int CLUSTER_ID = 109;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Cluster/Api/ClusterCalldisplayImageDataGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Cluster/Api/ClusterCalldisplayImageDataGetTest.php
@@ -11,7 +11,7 @@ class ClusterCalldisplayImageDataGetTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ClusterCalldisplayImageDataGet";
 
-    const CLUSTER_ID = 109;
+    const int CLUSTER_ID = 109;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Cluster/Api/ClusterCalldisplayImageDataUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Cluster/Api/ClusterCalldisplayImageDataUpdateTest.php
@@ -11,7 +11,7 @@ class ClusterCalldisplayImageDataUpdateTest extends \BO\Zmsbackend\Tests\Api\Bas
 {
     protected $classname = "ClusterCalldisplayImageDataUpdate";
 
-    const CLUSTER_ID = 109;
+    const int CLUSTER_ID = 109;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Dayoff/Api/DayoffUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Dayoff/Api/DayoffUpdateTest.php
@@ -12,9 +12,9 @@ class DayoffUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "DayoffUpdate";
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
-    const YEAR = 2016;
+    const int YEAR = 2016;
 
     public function testNoLogin()
     {

--- a/zmsbackend/tests/Zmsbackend/Log/Service/LogTest.php
+++ b/zmsbackend/tests/Zmsbackend/Log/Service/LogTest.php
@@ -7,9 +7,9 @@ use \BO\Zmsentities\Log as Entity;
 
 class LogTest extends \BO\Zmsbackend\Tests\Service\Base
 {
-    private const CITIZEN_MAX_MUSTERMANN = 'Max Mustermann';
+    private const string CITIZEN_MAX_MUSTERMANN = 'Max Mustermann';
 
-    private const CITIZEN_ERIKA_MUSTERMANN = 'Erika Mustermann';
+    private const string CITIZEN_ERIKA_MUSTERMANN = 'Erika Mustermann';
 
     private static function logSearchLabel(string $label): string
     {

--- a/zmsbackend/tests/Zmsbackend/Organisation/Api/OrganisationUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Organisation/Api/OrganisationUpdateTest.php
@@ -11,7 +11,7 @@ class OrganisationUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "OrganisationUpdate";
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/OverviewCalendar/Service/OverviewCalendarTest.php
+++ b/zmsbackend/tests/Zmsbackend/OverviewCalendar/Service/OverviewCalendarTest.php
@@ -7,8 +7,8 @@ use DateTimeImmutable;
 
 class OverviewCalendarTest extends \BO\Zmsbackend\Tests\Service\Base
 {
-    private const SCOPE1 = 65001;
-    private const SCOPE2 = 65002;
+    private const int SCOPE1 = 65001;
+    private const int SCOPE2 = 65002;
 
     private function fetchByPid(int $pid): ?array
     {

--- a/zmsbackend/tests/Zmsbackend/Owner/Api/OwnerUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Owner/Api/OwnerUpdateTest.php
@@ -11,7 +11,7 @@ class OwnerUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "OwnerUpdate";
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/AppointmentUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/AppointmentUpdateTest.php
@@ -6,9 +6,9 @@ class AppointmentUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "AppointmentUpdate";
 
-    const PROCESS_ID = 94860; // with appointment date 1464595200 2016-05-30 10:00
+    const int PROCESS_ID = 94860; // with appointment date 1464595200 2016-05-30 10:00
 
-    const AUTHKEY = 'cdce';
+    const string AUTHKEY = 'cdce';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessAddLogTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessAddLogTest.php
@@ -8,7 +8,7 @@ class ProcessAddLogTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessAddLog";
 
-    const PROCESS_ID = 10030;
+    const int PROCESS_ID = 10030;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessConfirmationMailTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessConfirmationMailTest.php
@@ -6,9 +6,9 @@ class ProcessConfirmationMailTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessConfirmationMail";
 
-    const PROCESS_ID = 10029;
+    const int PROCESS_ID = 10029;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessDeleteMailTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessDeleteMailTest.php
@@ -6,9 +6,9 @@ class ProcessDeleteMailTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessDeleteMail";
 
-    const PROCESS_ID = 10029;
+    const int PROCESS_ID = 10029;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessGetByExternalUserIdTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessGetByExternalUserIdTest.php
@@ -6,11 +6,11 @@ class ProcessGetByExternalUserIdTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessGetByExternalUserId";
 
-    const PROCESS_ID = 10030;
+    const int PROCESS_ID = 10030;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
-    const EXTERNAL_USER_ID = 'gh1582-citizen-user';
+    const string EXTERNAL_USER_ID = 'gh1582-citizen-user';
 
     protected function assignExternalUserIdToTestProcess(): void
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessListByExternalUserIdTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessListByExternalUserIdTest.php
@@ -6,13 +6,13 @@ class ProcessListByExternalUserIdTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessListByExternalUserId";
 
-    const PROCESS_ID = 10030;
+    const int PROCESS_ID = 10030;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
-    const EXTERNAL_USER_ID = 'gh1582-citizen-user';
+    const string EXTERNAL_USER_ID = 'gh1582-citizen-user';
 
-    const REQUEST_ID = '120335';
+    const string REQUEST_ID = '120335';
 
     protected function prepareTestProcess(): void
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessLogTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessLogTest.php
@@ -8,9 +8,9 @@ class ProcessLogTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessLog";
 
-    const SEARCH_PARAM = 10029;
+    const int SEARCH_PARAM = 10029;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessSearchTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessSearchTest.php
@@ -6,7 +6,7 @@ class ProcessSearchTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessSearch";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessUpdateTest.php
@@ -6,9 +6,9 @@ class ProcessUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ProcessUpdate";
 
-    const PROCESS_ID = 10029;
+    const int PROCESS_ID = 10029;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Request/Service/RequestAllForProcessIdsTest.php
+++ b/zmsbackend/tests/Zmsbackend/Request/Service/RequestAllForProcessIdsTest.php
@@ -7,7 +7,7 @@ use BO\Zmsentities\Collection\RequestList;
 
 class RequestAllForProcessIdsTest extends \BO\Zmsbackend\Tests\Service\Base
 {
-    const PROCESS_ID = 10029;
+    const int PROCESS_ID = 10029;
 
     public function testEmptyProcessIdsReturnsEmptyArray()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeCalldisplayImageDataDeleteTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeCalldisplayImageDataDeleteTest.php
@@ -11,7 +11,7 @@ class ScopeCalldisplayImageDataDeleteTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeCalldisplayImageDataDelete";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeCalldisplayImageDataGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeCalldisplayImageDataGetTest.php
@@ -11,7 +11,7 @@ class ScopeCalldisplayImageDataGetTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeCalldisplayImageDataGet";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeCalldisplayImageDataUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeCalldisplayImageDataUpdateTest.php
@@ -11,7 +11,7 @@ class ScopeCalldisplayImageDataUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeCalldisplayImageDataUpdate";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeEmergencyRespondTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeEmergencyRespondTest.php
@@ -11,7 +11,7 @@ class ScopeEmergencyRespondTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeEmergencyRespond";
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
     public function testNoLogin()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeEmergencyStopTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeEmergencyStopTest.php
@@ -11,7 +11,7 @@ class ScopeEmergencyStopTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeEmergencyStop";
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
     public function testNoLogin()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeEmergencyTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeEmergencyTest.php
@@ -11,7 +11,7 @@ class ScopeEmergencyTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeEmergency";
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
     public function testNoLogin()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeGetTest.php
@@ -11,7 +11,7 @@ class ScopeGetTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeGet";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
 
     public function testReducedDataAccess()
     {

--- a/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeWithWorkstationCountTest.php
+++ b/zmsbackend/tests/Zmsbackend/Scope/Api/ScopeWithWorkstationCountTest.php
@@ -11,7 +11,7 @@ class ScopeWithWorkstationCountTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "ScopeWithWorkstationCount";
 
-    const SCOPE_ID = 141;
+    const int SCOPE_ID = 141;
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Service/Base.php
+++ b/zmsbackend/tests/Zmsbackend/Service/Base.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class Base extends TestCase
 {
-    public const DB_OPERATION_SECONDS_DEFAULT = 1;
+    public const int DB_OPERATION_SECONDS_DEFAULT = 1;
     public static $username = 'superuser';
     public static $password = 'vorschau';
     public static $now = null;

--- a/zmsbackend/tests/Zmsbackend/Session/Api/SessionDeleteTest.php
+++ b/zmsbackend/tests/Zmsbackend/Session/Api/SessionDeleteTest.php
@@ -6,9 +6,9 @@ class SessionDeleteTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "SessionDelete";
 
-    const SESSION_ID = 'unittest';
+    const string SESSION_ID = 'unittest';
 
-    const SESSION_NAME = 'unittest';
+    const string SESSION_NAME = 'unittest';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Session/Api/SessionGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Session/Api/SessionGetTest.php
@@ -6,9 +6,9 @@ class SessionGetTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "SessionGet";
 
-    const SESSION_ID = 'unittest';
+    const string SESSION_ID = 'unittest';
 
-    const SESSION_NAME = 'unittest';
+    const string SESSION_NAME = 'unittest';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Slot/Service/SlotTest.php
+++ b/zmsbackend/tests/Zmsbackend/Slot/Service/SlotTest.php
@@ -7,7 +7,7 @@ use \BO\Zmsentities\Collection\SlotList as Collection;
 
 class SlotTest extends \BO\Zmsbackend\Tests\Service\Base
 {
-    const TEST_AVAILABILITY_ID = 68985;
+    const int TEST_AVAILABILITY_ID = 68985;
 
     public function testWriteOptimizedSlotTables()
     {

--- a/zmsbackend/tests/Zmsbackend/Source/Api/SourceGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Source/Api/SourceGetTest.php
@@ -8,7 +8,7 @@ class SourceGetTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "SourceGet";
 
-    const SOURCE = 'unittest';
+    const string SOURCE = 'unittest';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Source/Api/SourceListTest.php
+++ b/zmsbackend/tests/Zmsbackend/Source/Api/SourceListTest.php
@@ -8,7 +8,7 @@ class SourceListTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "SourceList";
 
-    const SOURCE = 'dldb';
+    const string SOURCE = 'dldb';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessParkedTest.php
+++ b/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessParkedTest.php
@@ -8,9 +8,9 @@ class WorkstationProcessParkedTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "WorkstationProcessParked";
 
-    const PROCESS_ID = 10030;
+    const int PROCESS_ID = 10030;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessRemoveTest.php
+++ b/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessRemoveTest.php
@@ -9,13 +9,13 @@ class WorkstationProcessRemoveTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "WorkstationProcessRemove";
 
-    const PROCESS_ID = 10030;
+    const int PROCESS_ID = 10030;
 
-    const AUTHKEY = '1c56';
+    const string AUTHKEY = '1c56';
 
-    const CALLED_PROCESS_ID = 11468;
+    const int CALLED_PROCESS_ID = 11468;
 
-    const CALLED_AUTHKEY = '7b41';
+    const string CALLED_AUTHKEY = '7b41';
 
     public function testRequeueAndSkipToNextKeepsProcessOnWaitingListWithinCallCountMax()
     {

--- a/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessTest.php
+++ b/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessTest.php
@@ -10,11 +10,11 @@ class WorkstationProcessTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "WorkstationProcess";
 
-    const PROCESS_ID = 11468;
+    const int PROCESS_ID = 11468;
 
-    const AUTHKEY = '7b41';
+    const string AUTHKEY = '7b41';
 
-    const SCOPE_ID = 143;
+    const int SCOPE_ID = 143;
 
     public function tearDown(): void
     {

--- a/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessWaitingnumberTest.php
+++ b/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationProcessWaitingnumberTest.php
@@ -8,9 +8,9 @@ class WorkstationProcessWaitingnumberTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "WorkstationProcessWaitingnumber";
 
-    const PROCESS_ID = 10255;
+    const int PROCESS_ID = 10255;
 
-    const AUTHKEY = '29ed';
+    const string AUTHKEY = '29ed';
 
     public function testRendering()
     {

--- a/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationUpdateTest.php
+++ b/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationUpdateTest.php
@@ -11,9 +11,9 @@ class WorkstationUpdateTest extends \BO\Zmsbackend\Tests\Api\Base
 {
     protected $classname = "WorkstationUpdate";
 
-    const PLACE = '12';
+    const string PLACE = '12';
 
-    const SCOPEID = 141;
+    const int SCOPEID = 141;
 
     public static $loginName = 'testadmin';
 

--- a/zmscalldisplay/config.example.php
+++ b/zmscalldisplay/config.example.php
@@ -13,8 +13,8 @@ class App extends \BO\Zmscalldisplay\Application
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const string APP_PATH = __DIR__;
     const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
-    const HTTP_BASE_URL = ZMS_API_URL;
+    const bool|string TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
+    const string HTTP_BASE_URL = ZMS_API_URL;
 
     /**
      * Name of the module

--- a/zmscalldisplay/config.example.php
+++ b/zmscalldisplay/config.example.php
@@ -13,7 +13,7 @@ class App extends \BO\Zmscalldisplay\Application
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const string APP_PATH = __DIR__;
     const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
     const string HTTP_BASE_URL = ZMS_API_URL;
 
     /**

--- a/zmscalldisplay/src/Zmscalldisplay/Application.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Application.php
@@ -34,7 +34,7 @@ class Application extends \BO\Slim\Application
     public static ?CacheInterface $cache = null;
 
     const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
 
     /**
      * language preferences
@@ -71,13 +71,13 @@ class Application extends \BO\Slim\Application
 
     public static $http_curl_config = array();
 
-    const JSON_COMPRESS_LEVEL = 1;
+    const int JSON_COMPRESS_LEVEL = 1;
 
     /**
      * HTTP url for api
      */
-    const HTTP_BASE_URL = 'http://user:pass@host.tdl';
-    const SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
+    const string HTTP_BASE_URL = 'http://user:pass@host.tdl';
+    const string SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
 
      /**
      * signature key for url signature to save query paramter with hash

--- a/zmscalldisplay/src/Zmscalldisplay/Application.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Application.php
@@ -34,7 +34,7 @@ class Application extends \BO\Slim\Application
     public static ?CacheInterface $cache = null;
 
     const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_CALLDISPLAY_TWIG_CACHE;
 
     /**
      * language preferences

--- a/zmscalldisplay/src/Zmscalldisplay/Helper/Calldisplay.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Helper/Calldisplay.php
@@ -17,8 +17,8 @@ class Calldisplay
     protected $entity;
     protected $isEntityResolved = false;
 
-    const DEFAULT_STATUS = ['called'];
-    const WAITING_STATUS = ['confirmed', 'queued', 'called', 'pending'];
+    const array DEFAULT_STATUS = ['called'];
+    const array WAITING_STATUS = ['confirmed', 'queued', 'called', 'pending'];
 
 
     public function __construct($request)

--- a/zmscitizenapi/config.example.php
+++ b/zmscitizenapi/config.example.php
@@ -11,12 +11,12 @@ class App extends \BO\Zmscitizenapi\Application
     /**
      * HTTP url for api
      */
-    const ZMS_API_URL = ZMS_API_URL;
+    const string ZMS_API_URL = ZMS_API_URL;
 
     /**
      * Flag for enabling maintenance mode
      */
-    const MAINTENANCE_MODE_ENABLED = MAINTENANCE_MODE_ENABLED;
+    const bool MAINTENANCE_MODE_ENABLED = MAINTENANCE_MODE_ENABLED;
 
     /**
      * Name of the application
@@ -41,6 +41,6 @@ class App extends \BO\Zmscitizenapi\Application
     /**
      * Name of the OIDC claim that uniquely identifies a citizen user.
      */
-    const ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME = ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME;
+    const string ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME = ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME;
 
 }

--- a/zmscitizenapi/src/Zmscitizenapi/Middleware/IpFilterMiddleware.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Middleware/IpFilterMiddleware.php
@@ -14,9 +14,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class IpFilterMiddleware implements MiddlewareInterface
 {
-    private const ERROR_BLACKLISTED = 'ipBlacklisted';
-    private const IPV4_BITS = 32;
-    private const IPV6_BITS = 128;
+    private const string ERROR_BLACKLISTED = 'ipBlacklisted';
+    private const int IPV4_BITS = 32;
+    private const int IPV6_BITS = 128;
     private string $blacklist;
     private LoggerService $logger;
     public function __construct(LoggerService $logger)

--- a/zmscitizenapi/src/Zmscitizenapi/Middleware/MaintenanceMiddleware.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Middleware/MaintenanceMiddleware.php
@@ -12,8 +12,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class MaintenanceMiddleware implements MiddlewareInterface
 {
-    private const HTTP_UNAVAILABLE = 503;
-    private const ERROR_UNAVAILABLE = 'serviceUnavailable';
+    private const int HTTP_UNAVAILABLE = 503;
+    private const string ERROR_UNAVAILABLE = 'serviceUnavailable';
     #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/zmscitizenapi/src/Zmscitizenapi/Middleware/RateLimitingMiddleware.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Middleware/RateLimitingMiddleware.php
@@ -15,7 +15,7 @@ use Psr\SimpleCache\CacheInterface;
 
 class RateLimitingMiddleware implements MiddlewareInterface
 {
-    private const ERROR_RATE_LIMIT = 'rateLimitExceeded';
+    private const string ERROR_RATE_LIMIT = 'rateLimitExceeded';
     private int $maxRequests;
     private int $cacheExpiry;
     private int $maxRetries;

--- a/zmscitizenapi/src/Zmscitizenapi/Middleware/RequestSizeLimitMiddleware.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Middleware/RequestSizeLimitMiddleware.php
@@ -13,7 +13,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class RequestSizeLimitMiddleware implements MiddlewareInterface
 {
-    private const ERROR_TOO_LARGE = 'requestEntityTooLarge';
+    private const string ERROR_TOO_LARGE = 'requestEntityTooLarge';
     private int $maxSize;
     private LoggerService $logger;
     public function __construct(LoggerService $logger)

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Captcha/TokenValidationService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Captcha/TokenValidationService.php
@@ -11,10 +11,10 @@ use Firebase\JWT\ExpiredException;
 
 class TokenValidationService
 {
-    public const TOKEN_VALID = 'valid';
-    public const TOKEN_MISSING = 'missing';
-    public const TOKEN_INVALID = 'invalid';
-    public const TOKEN_EXPIRED = 'expired';
+    public const string TOKEN_VALID = 'valid';
+    public const string TOKEN_MISSING = 'missing';
+    public const string TOKEN_INVALID = 'invalid';
+    public const string TOKEN_EXPIRED = 'expired';
     private string $captchaTokenSecret;
 
     public function __construct()

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ValidationService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ValidationService.php
@@ -27,17 +27,17 @@ class ValidationService
     {
         self::$officeServicesCache = [];
     }
-    private const DATE_FORMAT = 'Y-m-d';
-    private const MIN_PROCESS_ID = 1;
-    private const PHONE_PATTERN = '/^\+?[0-9]\d{6,14}$/';
-    private const SERVICE_COUNT_PATTERN = '/^\d+$/';
-    private const EMAIL_PATTERN = '/^(?!.*\.\.)(?!\.)(?!.*\.$)[^\s@+]+(?<!\.)@(?!\.)[^\s@+]+\.[^\s@]{2,}$/';
-    private const MAX_FUTURE_DAYS = 365;
+    private const string DATE_FORMAT = 'Y-m-d';
+    private const int MIN_PROCESS_ID = 1;
+    private const string PHONE_PATTERN = '/^\+?[0-9]\d{6,14}$/';
+    private const string SERVICE_COUNT_PATTERN = '/^\d+$/';
+    private const string EMAIL_PATTERN = '/^(?!.*\.\.)(?!\.)(?!.*\.$)[^\s@+]+(?<!\.)@(?!\.)[^\s@+]+\.[^\s@]{2,}$/';
+    private const int MAX_FUTURE_DAYS = 365;
     // Maximum days in the future for appointments
     /** Must match {@see \BO\Zmsdb\Slot::MAX_SLOTS} */
-    private const MAX_SERVICE_COUNT = 25;
-    private const AUTH_KEY_LEGACY_HEX_LENGTH = 4;
-    private const AUTH_KEY_NEW_HEX_LENGTH = 64;
+    private const int MAX_SERVICE_COUNT = 25;
+    private const int AUTH_KEY_LEGACY_HEX_LENGTH = 4;
+    private const int AUTH_KEY_NEW_HEX_LENGTH = 64;
 
     private static function getError(string $key): array
     {

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -31,11 +31,11 @@ use BO\Zmsentities\Collection\ProcessList;
  */
 class ZmsApiFacadeService
 {
-    private const CACHE_KEY_OFFICES = 'processed_offices';
-    private const CACHE_KEY_SCOPES = 'processed_scopes';
-    private const CACHE_KEY_SERVICES = 'processed_services';
-    private const CACHE_KEY_OFFICES_AND_SERVICES = 'processed_offices_and_services';
-    private const CACHE_KEY_SERVICES_BY_OFFICE_PREFIX = 'processed_services_by_office_';
+    private const string CACHE_KEY_OFFICES = 'processed_offices';
+    private const string CACHE_KEY_SCOPES = 'processed_scopes';
+    private const string CACHE_KEY_SERVICES = 'processed_services';
+    private const string CACHE_KEY_OFFICES_AND_SERVICES = 'processed_offices_and_services';
+    private const string CACHE_KEY_SERVICES_BY_OFFICE_PREFIX = 'processed_services_by_office_';
 
     private static function setMappedCache(string $cacheKey, mixed $data): void
     {

--- a/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Utils/ErrorMessages.php
@@ -6,22 +6,22 @@ namespace BO\Zmscitizenapi\Utils;
 
 class ErrorMessages
 {
-    private const HTTP_OK = 200;
-    private const HTTP_BAD_REQUEST = 400;
-    private const HTTP_FORBIDDEN = 403;
-    private const HTTP_NOT_FOUND = 404;
-    private const HTTP_INVALID_REQUEST_METHOD = 405;
-    private const HTTP_NOT_ACCEPTABLE = 406;
-    private const HTTP_CONFLICT = 409;
-    private const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
-    private const HTTP_TOO_MANY_REQUESTS = 429;
-    private const HTTP_INTERNAL_SERVER_ERROR = 500;
-    private const HTTP_NOT_IMPLEMENTED = 501;
-    private const HTTP_UNAVAILABLE = 503;
-    private const HTTP_UNKNOWN = 520;
+    private const int HTTP_OK = 200;
+    private const int HTTP_BAD_REQUEST = 400;
+    private const int HTTP_FORBIDDEN = 403;
+    private const int HTTP_NOT_FOUND = 404;
+    private const int HTTP_INVALID_REQUEST_METHOD = 405;
+    private const int HTTP_NOT_ACCEPTABLE = 406;
+    private const int HTTP_CONFLICT = 409;
+    private const int HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+    private const int HTTP_TOO_MANY_REQUESTS = 429;
+    private const int HTTP_INTERNAL_SERVER_ERROR = 500;
+    private const int HTTP_NOT_IMPLEMENTED = 501;
+    private const int HTTP_UNAVAILABLE = 503;
+    private const int HTTP_UNKNOWN = 520;
 
     // English messages only
-    private const MESSAGES = [
+    private const array MESSAGES = [
         'zmsClientCommunicationError' => [
             'errorCode' => 'zmsClientCommunicationError',
             'errorMessage' => 'The service is temporarily unavailable. Please try again later.',

--- a/zmsclient/src/Zmsclient/ModuleAccess.php
+++ b/zmsclient/src/Zmsclient/ModuleAccess.php
@@ -7,9 +7,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class ModuleAccess
 {
-    public const MODULE_ADMIN = 'zmsadmin';
+    public const string MODULE_ADMIN = 'zmsadmin';
 
-    public const MODULE_STATISTIC = 'zmsstatistic';
+    public const string MODULE_STATISTIC = 'zmsstatistic';
 
     public static function rejectWrongModuleAccess(
         string $application,

--- a/zmsclient/src/Zmsclient/Ticketprinter.php
+++ b/zmsclient/src/Zmsclient/Ticketprinter.php
@@ -7,8 +7,8 @@ namespace BO\Zmsclient;
  */
 class Ticketprinter
 {
-    const HASH_COOKIE_NAME = 'Ticketprinter';
-    const HOME_URL_COOKIE_NAME = 'Ticketprinter_Homeurl';
+    const string HASH_COOKIE_NAME = 'Ticketprinter';
+    const string HOME_URL_COOKIE_NAME = 'Ticketprinter_Homeurl';
 
     /**
      * @SuppressWarnings(Superglobals)

--- a/zmsclient/tests/Zmsclient/SessionTest.php
+++ b/zmsclient/tests/Zmsclient/SessionTest.php
@@ -4,9 +4,9 @@ namespace BO\Zmsclient\Tests;
 
 class SessionTest extends Base
 {
-    const SESSION_NAME = 'ZmsclientUnittest';
+    const string SESSION_NAME = 'ZmsclientUnittest';
 
-    const SESSION_ID = '0058pfv918e8ipmbadj05sm1e7';
+    const string SESSION_ID = '0058pfv918e8ipmbadj05sm1e7';
 
     public function testBasic()
     {

--- a/zmsclient/tests/Zmsclient/TicketprinterTest.php
+++ b/zmsclient/tests/Zmsclient/TicketprinterTest.php
@@ -4,13 +4,13 @@ namespace BO\Zmsclient\Tests;
 
 class TicketprinterTest extends Base
 {
-    const HASH_COOKIE_NAME = 'Ticketprinter';
+    const string HASH_COOKIE_NAME = 'Ticketprinter';
 
-    const HOME_URL_COOKIE_NAME = 'Ticketprinter_Homeurl';
+    const string HOME_URL_COOKIE_NAME = 'Ticketprinter_Homeurl';
 
-    const HASH_TEST = '0058pfv918e8ipmbadj05sm1e7';
+    const string HASH_TEST = '0058pfv918e8ipmbadj05sm1e7';
 
-    const HOMEURL_TEST = 'https://service.berlin.de/terminvereinbarung/ticketprinter';
+    const string HOMEURL_TEST = 'https://service.berlin.de/terminvereinbarung/ticketprinter';
 
     /**
      * @runInSeparateProcess

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -53,45 +53,45 @@ class App extends \BO\Zmsbackend\Application
     const string APP_PATH = __DIR__;
     const string IDENTIFIER = 'Zmsbackend-ENV';
     const bool DEBUG = false;
-    const DB_ENABLE_WSREPSYNCWAIT = true;
+    const bool DB_ENABLE_WSREPSYNCWAIT = true;
     /**
      * @var String DB_DSN_READONLY
      */
-    const DB_DSN_READONLY = DSN_RO;
+    const string DB_DSN_READONLY = DSN_RO;
 
     /**
      * @var String DB_DSN_READWRITE
      */
-    const DB_DSN_READWRITE = DSN_RW;
+    const string DB_DSN_READWRITE = DSN_RW;
 
     /**
      * @var String DB_USERNAME
      */
-    const DB_USERNAME = MYSQL_USER;
+    const string DB_USERNAME = MYSQL_USER;
 
     /**
      * @var String DB_PASSWORD
      */
-    const DB_PASSWORD = MYSQL_PASSWORD;
+    const string DB_PASSWORD = MYSQL_PASSWORD;
 
     /**
      * Use caching
      *
      */
-    const TWIG_CACHE = ZMS_DLDB_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_DLDB_TWIG_CACHE;
     const string MODULE_NAME = 'zmsdldb';
 
     /** Fallback when settings key d115.openingTime is unset */
-    const D115_DEFAULT_OPENINGTIME = '';
+    const string D115_DEFAULT_OPENINGTIME = '';
 
     /** Fallback when settings key d115.messageHtml is unset */
-    const D115_DEFAULT_TEXT = '';
+    const string D115_DEFAULT_TEXT = '';
 
     /** Mapbox/OSM access token for frontend maps */
-    const OSM_ACCESS_TOKEN = '';
+    const string OSM_ACCESS_TOKEN = '';
 
     /** Leaflet gestureHandling option value */
-    const OSM_GESTURE_HANDLING = 'true';
+    const string OSM_GESTURE_HANDLING = 'true';
 }
 
 // Uncomment the following line for testing data with vendor/bin/importTestData

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -78,7 +78,7 @@ class App extends \BO\Zmsbackend\Application
      * Use caching
      *
      */
-    const bool|string TWIG_CACHE = ZMS_DLDB_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_DLDB_TWIG_CACHE;
     const string MODULE_NAME = 'zmsdldb';
 
     /** Fallback when settings key d115.openingTime is unset */

--- a/zmsdldb/src/Zmsdldb/Importer/Options.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Options.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer;
 
 interface Options
 {
-    const OPTION_NONE = 0;
-    const OPTION_CLEAR_ENTITIY_TABLE = 2;
-    const OPTION_CLEAR_ENTITIY_REFERENCES_TABLES = 4;
+    const int OPTION_NONE = 0;
+    const int OPTION_CLEAR_ENTITIY_TABLE = 2;
+    const int OPTION_CLEAR_ENTITIY_REFERENCES_TABLES = 4;
 }

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -14,9 +14,9 @@ use BO\Zmsdldb\FileAccess;
  */
 class ElasticSearch
 {
-    const ES_INDEX_PREFIX = 'dldb-';
+    const string ES_INDEX_PREFIX = 'dldb-';
 
-    const ES_INDEX_DATE = 'Ymd-His';
+    const string ES_INDEX_DATE = 'Ymd-His';
 
     protected $localeList = array(
         'de',

--- a/zmsdldb/src/Zmsdldb/SQLiteAccess.php
+++ b/zmsdldb/src/Zmsdldb/SQLiteAccess.php
@@ -12,8 +12,8 @@ namespace BO\Zmsdldb;
  */
 class SQLiteAccess extends PDOAccess
 {
-    const DEFAULT_DATABASE_NAME = 'dldb_frontend_dev';
-    const DEFAULT_DATABASE_PATH = __DIR__;
+    const string DEFAULT_DATABASE_NAME = 'dldb_frontend_dev';
+    const string DEFAULT_DATABASE_PATH = __DIR__;
 
     #[\Override]
     protected function connect(array $options): void

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
  */
 class Munich
 {
-    const EXCLUSIVE_LOCATIONS = [
+    const array EXCLUSIVE_LOCATIONS = [
         //SZE
         54285,
         // Standesamt München - registry office locations (exclusive, don't show alternatives)
@@ -22,7 +22,7 @@ class Munich
         103666, 103633, 101905,
     ];
 
-    const LOCATION_PRIO_BY_DISPLAY_NAME = [
+    const array LOCATION_PRIO_BY_DISPLAY_NAME = [
         'Bürgerbüro Ruppertstraße' => 100,
         'Bürgerbüro Orleansplatz' => 90,
         'Bürgerbüro Pasing' => 80,
@@ -41,7 +41,7 @@ class Munich
         'Feuerwache 10 - Riem / Neue Messe' => 1
     ];
 
-    const DONT_SHOW_LOCATION_BY_SERVICES = [
+    const array DONT_SHOW_LOCATION_BY_SERVICES = [
         [
             "locations" => [10489], // Bürgerbüro Ruppertstraße
             "services" => [1063453, 1063441, 1080582] // Reisepass, Personalausweis, Vorläufiger Reisepass
@@ -54,12 +54,12 @@ class Munich
 
     // Offices where disabledByServices/DONT_SHOW_LOCATION_BY_SERVICES are interpreted with special
     // "exclusive vs mixed" semantics in the frontend (allowDisabledServicesMix=true).
-    const LOCATIONS_ALLOW_DISABLED_MIX = [
+    const array LOCATIONS_ALLOW_DISABLED_MIX = [
         [10489, 10491, 10500, 10502] // Bürgerbüro Ruppertstraße (KVR-II/22) // Bürgerbüro Ruppertstraße (KVR-II/221)
     ];
 
     // Offices that share one Ort but keep pooled calendar capacity (ZMSKVR-1046 Ausbildung).
-    const LOCATIONS_SHARED_BOOKING = [
+    const array LOCATIONS_SHARED_BOOKING = [
         [10489, 10503, 10500, 10491] // 10491 now has some of the same services as 10489 10502 10503 which means if it exposes external appointments it must mix them otherwise shows up double.
     ];
 
@@ -76,7 +76,7 @@ class Munich
         1080716
     ];
 
-    const SERVICE_COMBINATIONS = [
+    const array SERVICE_COMBINATIONS = [
         //BB
         [10295182],
         [10242339, 1063475, 1063441, 1063453, 10308996, 10224136, 10225205, 10225181, 1063426, 1063428, 10306925, 10225119, 1080843, 1076889, 1078273, 1080582, 10225197, 10224132],

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -12,19 +12,19 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Queue';
 
-    public const FAKE_WAITINGNUMBER = -1;
+    public const int FAKE_WAITINGNUMBER = -1;
 
-    public const STATUS_IGNORE = ['called', 'processing', 'missed', 'parked'];
+    public const array STATUS_IGNORE = ['called', 'processing', 'missed', 'parked'];
 
-    public const STATUS_APPEND = ['missed', 'parked'];
+    public const array STATUS_APPEND = ['missed', 'parked'];
 
-    public const STATUS_CALLED = ['called', 'processing'];
+    public const array STATUS_CALLED = ['called', 'processing'];
 
-    public const STATUS_FAKE = ['fake'];
+    public const array STATUS_FAKE = ['fake'];
 
-    public const DEFAULT_PRIORITY_WITHOUT_APPOINTMENT = 3;
+    public const int DEFAULT_PRIORITY_WITHOUT_APPOINTMENT = 3;
 
-    public const DEFAULT_PRIORITY_WITH_APPOINTMENT = 2;
+    public const int DEFAULT_PRIORITY_WITH_APPOINTMENT = 2;
 
     protected $processTimeAverage;
 

--- a/zmsentities/src/Zmsentities/Day.php
+++ b/zmsentities/src/Zmsentities/Day.php
@@ -6,15 +6,15 @@ class Day extends Schema\Entity
 {
     public const string PRIMARY = 'day';
 
-    public const FULL = 'full';
+    public const string FULL = 'full';
 
-    public const BOOKABLE = 'bookable';
+    public const string BOOKABLE = 'bookable';
 
-    public const NOTBOOKABLE = 'notBookable';
+    public const string NOTBOOKABLE = 'notBookable';
 
-    public const RESTRICTED = 'restricted';
+    public const string RESTRICTED = 'restricted';
 
-    public const DETAIL = 'detail';
+    public const string DETAIL = 'detail';
 
     public static $schema = "day.json";
 

--- a/zmsentities/src/Zmsentities/EventLog.php
+++ b/zmsentities/src/Zmsentities/EventLog.php
@@ -28,24 +28,24 @@ class EventLog extends Schema\Entity
 
     public static $schema = "eventlog.json";
 
-    public const LIVETIME_LONGER  = 315360000; // 10 years
-    public const LIVETIME_LONG    = 94608000; // 3 years
-    public const LIVETIME_YEAR    = 31536000; // one year (365 days)
-    public const LIVETIME_DEFAULT = 15552000; // half a year (180 days)
-    public const LIVETIME_MONTH   = 2592000; // one month (30 days)
-    public const LIVETIME_WEEK    = 604800; // one week
-    public const LIVETIME_DAY     = 86400; // one day
-    public const LIVETIME_HOUR    = 3600; // one hour
+    public const int LIVETIME_LONGER  = 315360000; // 10 years
+    public const int LIVETIME_LONG    = 94608000; // 3 years
+    public const int LIVETIME_YEAR    = 31536000; // one year (365 days)
+    public const int LIVETIME_DEFAULT = 15552000; // half a year (180 days)
+    public const int LIVETIME_MONTH   = 2592000; // one month (30 days)
+    public const int LIVETIME_WEEK    = 604800; // one week
+    public const int LIVETIME_DAY     = 86400; // one day
+    public const int LIVETIME_HOUR    = 3600; // one hour
 
     /***************  Event Names ****************/
-    public const CLIENT_PROCESSLIST_REQUEST = 'CLIENT_PROCESSLIST_REQUEST';
-    public const CLIENT_PROCESSLIST_SEND = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string CLIENT_PROCESSLIST_REQUEST = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string CLIENT_PROCESSLIST_SEND = 'CLIENT_PROCESSLIST_REQUEST';
     // examples for future use below
-    public const QUEUE_PROCESS_SCHEDULE = 'CLIENT_PROCESSLIST_REQUEST';
-    public const QUEUE_PROCESS_DELETE = 'CLIENT_PROCESSLIST_REQUEST';
-    public const WORKSTATION_PROCESS_CALL = 'CLIENT_PROCESSLIST_REQUEST';
-    public const WORKSTATION_PROCESS_START = 'CLIENT_PROCESSLIST_REQUEST';
-    public const WORKSTATION_PROCESS_FINISH = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string QUEUE_PROCESS_SCHEDULE = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string QUEUE_PROCESS_DELETE = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string WORKSTATION_PROCESS_CALL = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string WORKSTATION_PROCESS_START = 'CLIENT_PROCESSLIST_REQUEST';
+    public const string WORKSTATION_PROCESS_FINISH = 'CLIENT_PROCESSLIST_REQUEST';
 
     #[\Override]
     public function getDefaults(): array

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -14,9 +14,9 @@ class Exchange extends Schema\Entity
     /**
      * Statistik CASE labels (must match warehouse SQL in ExchangeRequest* queries).
      */
-    public const REQUEST_STAT_NAME_UNCATEGORIZED = 'uncategorized';
+    public const string REQUEST_STAT_NAME_UNCATEGORIZED = 'uncategorized';
 
-    public const REQUEST_STAT_NAME_NONEXISTENT = 'nonexistent';
+    public const string REQUEST_STAT_NAME_NONEXISTENT = 'nonexistent';
 
     public static $schema = "exchange.json";
 

--- a/zmsentities/src/Zmsentities/Helper/ProcessPlainText.php
+++ b/zmsentities/src/Zmsentities/Helper/ProcessPlainText.php
@@ -7,9 +7,9 @@ namespace BO\Zmsentities\Helper;
  */
 class ProcessPlainText
 {
-    public const MAX_CUSTOM_TEXTFIELD_CHARS = 250;
+    public const int MAX_CUSTOM_TEXTFIELD_CHARS = 250;
 
-    public const MAX_AMENDMENT_CHARS = 500;
+    public const int MAX_AMENDMENT_CHARS = 500;
 
     /**
      * Strip HTML, decode entities, normalize line breaks to "\n" for storage/display.

--- a/zmsentities/src/Zmsentities/Log.php
+++ b/zmsentities/src/Zmsentities/Log.php
@@ -6,20 +6,20 @@ class Log extends Schema\Entity
 {
     public const string PRIMARY = 'reference';
 
-    public const ACTION_MAIL_SUCCESS = 'E-Mail-Versand erfolgreich';
-    public const ACTION_MAIL_FAIL = 'E-Mail-Versand ist fehlgeschlagen';
-    public const ACTION_STATUS_CHANGE = 'Terminstatus wurde geändert';
-    public const ACTION_SEND_REMINDER = 'Erinnerungsmail wurde gesendet';
-    public const ACTION_REMOVED = 'Termin aus der Warteschlange entfernt';
-    public const ACTION_CALLED = 'Termin wurde aufgerufen';
-    public const ACTION_ARCHIVED = 'Termin wurde archiviert';
-    public const ACTION_EDITED = 'Termin wurde geändert';
-    public const ACTION_REDIRECTED = 'Termin wurde weitergeleitet';
-    public const ACTION_NEW = 'Neuer Termin wurde erstellt';
-    public const ACTION_DELETED = 'Termin wurde gelöscht';
-    public const ACTION_CANCELED = 'Termin wurde abgesagt';
+    public const string ACTION_MAIL_SUCCESS = 'E-Mail-Versand erfolgreich';
+    public const string ACTION_MAIL_FAIL = 'E-Mail-Versand ist fehlgeschlagen';
+    public const string ACTION_STATUS_CHANGE = 'Terminstatus wurde geändert';
+    public const string ACTION_SEND_REMINDER = 'Erinnerungsmail wurde gesendet';
+    public const string ACTION_REMOVED = 'Termin aus der Warteschlange entfernt';
+    public const string ACTION_CALLED = 'Termin wurde aufgerufen';
+    public const string ACTION_ARCHIVED = 'Termin wurde archiviert';
+    public const string ACTION_EDITED = 'Termin wurde geändert';
+    public const string ACTION_REDIRECTED = 'Termin wurde weitergeleitet';
+    public const string ACTION_NEW = 'Neuer Termin wurde erstellt';
+    public const string ACTION_DELETED = 'Termin wurde gelöscht';
+    public const string ACTION_CANCELED = 'Termin wurde abgesagt';
 
-    private const ACTION_CODE_TO_LABEL = [
+    private const array ACTION_CODE_TO_LABEL = [
         'mail_success' => self::ACTION_MAIL_SUCCESS,
         'mail_fail' => self::ACTION_MAIL_FAIL,
         'status_changed' => self::ACTION_STATUS_CHANGE,
@@ -34,7 +34,7 @@ class Log extends Schema\Entity
         'canceled' => self::ACTION_CANCELED,
     ];
 
-    private const DISPLAY_TEXT_FIELDS = [
+    private const array DISPLAY_TEXT_FIELDS = [
         'user_id' => 'Sachbearbeiter*in',
         'display_number' => 'Terminnummer',
         'citizen_name' => 'Bürger*in',
@@ -47,7 +47,7 @@ class Log extends Schema\Entity
         'db_status' => 'DB Status',
     ];
 
-    private const DISPLAY_OPTIONAL_NUMBER_FIELDS = [
+    private const array DISPLAY_OPTIONAL_NUMBER_FIELDS = [
         'queue_number' => 'Wartenummer',
         'slot_count' => 'Slots',
     ];

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -14,22 +14,22 @@ use BO\Zmsentities\Helper\Property;
 class Process extends Schema\Entity
 {
     public const string PRIMARY = 'id';
-    public const STATUS_FREE = 'free';
-    public const STATUS_RESERVED = 'reserved';
-    public const STATUS_CONFIRMED = 'confirmed';
-    public const STATUS_PRECONFIRMED = 'preconfirmed';
-    public const STATUS_QUEUED = 'queued';
-    public const STATUS_CALLED = 'called';
-    public const STATUS_PROCESSING = 'processing';
-    public const STATUS_PENDING = 'pending';
-    public const STATUS_FINISHED = 'finished';
-    public const STATUS_MISSED = 'missed';
-    public const STATUS_PARKED = 'parked';
-    public const STATUS_ARCHIVED = 'archived';
-    public const STATUS_DELETED = 'deleted';
-    public const STATUS_ANONYMIZED = 'anonymized';
-    public const STATUS_BLOCKED = 'blocked';
-    public const STATUS_CONFLICT = 'conflict';
+    public const string STATUS_FREE = 'free';
+    public const string STATUS_RESERVED = 'reserved';
+    public const string STATUS_CONFIRMED = 'confirmed';
+    public const string STATUS_PRECONFIRMED = 'preconfirmed';
+    public const string STATUS_QUEUED = 'queued';
+    public const string STATUS_CALLED = 'called';
+    public const string STATUS_PROCESSING = 'processing';
+    public const string STATUS_PENDING = 'pending';
+    public const string STATUS_FINISHED = 'finished';
+    public const string STATUS_MISSED = 'missed';
+    public const string STATUS_PARKED = 'parked';
+    public const string STATUS_ARCHIVED = 'archived';
+    public const string STATUS_DELETED = 'deleted';
+    public const string STATUS_ANONYMIZED = 'anonymized';
+    public const string STATUS_BLOCKED = 'blocked';
+    public const string STATUS_CONFLICT = 'conflict';
     public static $schema = "process.json";
     #[\Override]
     public function getDefaults()

--- a/zmsentities/src/Zmsentities/Slot.php
+++ b/zmsentities/src/Zmsentities/Slot.php
@@ -11,31 +11,31 @@ class Slot extends Schema\Entity
      *  appointments
      *
      */
-    public const FREE = 'free';
+    public const string FREE = 'free';
 
     /**
      *  the values represent free appointments for a given day. Confirmed and
      *  reserved appointments on processes are substracted.
      */
-    public const TIMESLICE = 'timeslice';
+    public const string TIMESLICE = 'timeslice';
 
     /**
      * like timeslice, but for more than one scope
      */
-    public const SUM = 'sum';
+    public const string SUM = 'sum';
 
     /**
      * like timeslice, but numbers were reduced due to required slots on a
      * given request
      *
      */
-    public const REDUCED = 'reduced';
+    public const string REDUCED = 'reduced';
 
     /**
      * the values represent a unix timestamp to when there are free processes
      *
      */
-    public const TIMESTAMP = 'timestamp';
+    public const string TIMESTAMP = 'timestamp';
 
     #[\Override]
     public function getDefaults()

--- a/zmsentities/tests/Zmsentities/AvailabilityTest.php
+++ b/zmsentities/tests/Zmsentities/AvailabilityTest.php
@@ -11,7 +11,7 @@ use \BO\Zmsentities\Collection\AvailabilityList;
  */
 class AvailabilityTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-01-01 12:50:00'; //friday
+    const string DEFAULT_TIME = '2016-01-01 12:50:00'; //friday
 
     public $entityclass = '\BO\Zmsentities\Availability';
 

--- a/zmsentities/tests/Zmsentities/CalendarTest.php
+++ b/zmsentities/tests/Zmsentities/CalendarTest.php
@@ -4,17 +4,17 @@ namespace BO\Zmsentities\Tests;
 
 class CalendarTest extends EntityCommonTests
 {
-    const FIRST_DAY = '2015-11-19';
+    const string FIRST_DAY = '2015-11-19';
 
-    const LAST_DAY = '2015-12-31';
+    const string LAST_DAY = '2015-12-31';
 
-    const PROVIDER = 122217;
+    const int PROVIDER = 122217;
 
-    const SCOPE = 141;
+    const int SCOPE = 141;
 
-    const CLUSTER = 109;
+    const int CLUSTER = 109;
 
-    const REQUESTS = 120703;
+    const int REQUESTS = 120703;
 
     public $entityclass = '\BO\Zmsentities\Calendar';
 

--- a/zmsentities/tests/Zmsentities/DayTest.php
+++ b/zmsentities/tests/Zmsentities/DayTest.php
@@ -4,7 +4,7 @@ namespace BO\Zmsentities\Tests;
 
 class DayTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2015-11-18 11:55:00';
+    const string DEFAULT_TIME = '2015-11-18 11:55:00';
 
     public $entityclass = '\BO\Zmsentities\Day';
 

--- a/zmsentities/tests/Zmsentities/ExchangeTest.php
+++ b/zmsentities/tests/Zmsentities/ExchangeTest.php
@@ -4,9 +4,9 @@ namespace BO\Zmsentities\Tests;
 
 class ExchangeTest extends EntityCommonTests
 {
-    const FIRST_DAY = '2015-11-19';
+    const string FIRST_DAY = '2015-11-19';
 
-    const LAST_DAY = '2015-12-31';
+    const string LAST_DAY = '2015-12-31';
 
     public $entityclass = '\BO\Zmsentities\Exchange';
 

--- a/zmsentities/tests/Zmsentities/LinkTest.php
+++ b/zmsentities/tests/Zmsentities/LinkTest.php
@@ -4,7 +4,7 @@ namespace BO\Zmsentities\Tests;
 
 class LinkTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2015-11-18 11:55:00';
+    const string DEFAULT_TIME = '2015-11-18 11:55:00';
 
     public $entityclass = '\BO\Zmsentities\Link';
 

--- a/zmsentities/tests/Zmsentities/MailTest.php
+++ b/zmsentities/tests/Zmsentities/MailTest.php
@@ -8,7 +8,7 @@ class MailTest extends EntityCommonTests
 
     public $collectionclass = '\BO\Zmsentities\Collection\MailList';
 
-    const DEFAULT_TIME = '2016-04-01 11:55:00';
+    const string DEFAULT_TIME = '2016-04-01 11:55:00';
 
     public function testBasic()
     {

--- a/zmsentities/tests/Zmsentities/MonthTest.php
+++ b/zmsentities/tests/Zmsentities/MonthTest.php
@@ -4,9 +4,9 @@ namespace BO\Zmsentities\Tests;
 
 class MonthTest extends EntityCommonTests
 {
-    const FIRST_DAY = '2015-11-19';
+    const string FIRST_DAY = '2015-11-19';
 
-    const LAST_DAY = '2015-11-31';
+    const string LAST_DAY = '2015-11-31';
 
     public $entityclass = '\BO\Zmsentities\Month';
 

--- a/zmsentities/tests/Zmsentities/ProcessTest.php
+++ b/zmsentities/tests/Zmsentities/ProcessTest.php
@@ -17,7 +17,7 @@ use \BO\Zmsentities\Collection\ProcessList;
  */
 class ProcessTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-01-01 12:50:00';
+    const string DEFAULT_TIME = '2016-01-01 12:50:00';
 
     public $entityclass = '\BO\Zmsentities\Process';
 

--- a/zmsentities/tests/Zmsentities/QueueListTest.php
+++ b/zmsentities/tests/Zmsentities/QueueListTest.php
@@ -4,9 +4,9 @@ namespace BO\Zmsentities\Tests;
 
 class QueueListTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-11-19 08:50:00';
+    const string DEFAULT_TIME = '2016-11-19 08:50:00';
 
-    const FAKE_WAITINGNUMBER = 1002;
+    const int FAKE_WAITINGNUMBER = 1002;
 
     public $entityclass = '\BO\Zmsentities\Queue';
 

--- a/zmsentities/tests/Zmsentities/ScopeListTest.php
+++ b/zmsentities/tests/Zmsentities/ScopeListTest.php
@@ -4,7 +4,7 @@ namespace BO\Zmsentities\Tests;
 
 class ScopeListTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-04-01 11:50:00';
+    const string DEFAULT_TIME = '2016-04-01 11:50:00';
 
     public $entityclass = '\BO\Zmsentities\Scope';
 

--- a/zmsentities/tests/Zmsentities/ScopeTest.php
+++ b/zmsentities/tests/Zmsentities/ScopeTest.php
@@ -4,8 +4,8 @@ namespace BO\Zmsentities\Tests;
 
 class ScopeTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-04-01 11:50:00';
-    const LAST_GIVEN_NUMBER_TIME = '2015-11-19 10:25:59';
+    const string DEFAULT_TIME = '2016-04-01 11:50:00';
+    const string LAST_GIVEN_NUMBER_TIME = '2015-11-19 10:25:59';
 
     public $entityclass = '\BO\Zmsentities\Scope';
 

--- a/zmsentities/tests/Zmsentities/SlotTest.php
+++ b/zmsentities/tests/Zmsentities/SlotTest.php
@@ -4,7 +4,7 @@ namespace BO\Zmsentities\Tests;
 
 class SlotTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-05-27 12:50:00';
+    const string DEFAULT_TIME = '2016-05-27 12:50:00';
 
     public $entityclass = '\BO\Zmsentities\Slot';
 

--- a/zmsentities/tests/Zmsentities/UseraccountTest.php
+++ b/zmsentities/tests/Zmsentities/UseraccountTest.php
@@ -9,7 +9,7 @@ namespace BO\Zmsentities\Tests;
  */
 class UseraccountTest extends EntityCommonTests
 {
-    const DEFAULT_TIME = '2016-04-01 11:55:00';
+    const string DEFAULT_TIME = '2016-04-01 11:55:00';
 
     public $entityclass = '\BO\Zmsentities\Useraccount';
 

--- a/zmsentities/tests/Zmsentities/WorkstationTest.php
+++ b/zmsentities/tests/Zmsentities/WorkstationTest.php
@@ -10,7 +10,7 @@ class WorkstationTest extends EntityCommonTests
 {
     public $entityclass = '\BO\Zmsentities\Workstation';
 
-    const DEFAULT_TIME = '2015-11-19 11:55:00';
+    const string DEFAULT_TIME = '2015-11-19 11:55:00';
 
     public function testBasic()
     {

--- a/zmsmessaging/config.example.php
+++ b/zmsmessaging/config.example.php
@@ -32,7 +32,7 @@ class App extends \BO\Zmsmessaging\Application
     /**
      * HTTP access for api
      */
-    const HTTP_BASE_URL = ZMS_API_URL;
+    const string HTTP_BASE_URL = ZMS_API_URL;
 
     const string IDENTIFIER = ZMS_IDENTIFIER;
     /**

--- a/zmsmessaging/src/Zmsmessaging/Application.php
+++ b/zmsmessaging/src/Zmsmessaging/Application.php
@@ -50,12 +50,12 @@ class Application extends \BO\Slim\Application
     /**
      * config preferences
      */
-    const CONFIG_SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
+    const string CONFIG_SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
 
     /**
      * HTTP url for api
      */
-    const HTTP_BASE_URL = 'http://user:pass@host.tdl';
+    const string HTTP_BASE_URL = 'http://user:pass@host.tdl';
 
     /*
      * -----------------------------------------------------------------------

--- a/zmsslim/src/Slim/Application.php
+++ b/zmsslim/src/Slim/Application.php
@@ -32,7 +32,7 @@ class Application
      */
     public const bool DEBUG = false;
     const string DEBUGLEVEL = ZMS_DEBUGLEVEL;
-    const string|int SESSION_DURATION = ZMS_SESSION_DURATION;
+    const SESSION_DURATION = ZMS_SESSION_DURATION;
     const string SECURE_TOKEN = '';
     const string CONFIG_SECURE_TOKEN = '';
     const bool RIGHTSCHECK_ENABLED = true;
@@ -73,7 +73,7 @@ class Application
 /**
      * Define path for Twig template cache
      */
-    const bool|string TWIG_CACHE = false;
+    const TWIG_CACHE = false;
 /**
      * Set this option, if ESI should be used
      */

--- a/zmsslim/src/Slim/Application.php
+++ b/zmsslim/src/Slim/Application.php
@@ -31,23 +31,23 @@ class Application
      * if debug is enabled, an exception is shown with a backtrace
      */
     public const bool DEBUG = false;
-    const DEBUGLEVEL = ZMS_DEBUGLEVEL;
-    const SESSION_DURATION = ZMS_SESSION_DURATION;
-    const SECURE_TOKEN = '';
-    const CONFIG_SECURE_TOKEN = '';
-    const RIGHTSCHECK_ENABLED = true;
-    const JSON_COMPRESS_LEVEL = 1;
-    const HTTP_BASE_URL = '';
-    const CLIENTKEY = '';
-    const MAINTENANCE_MODE_ENABLED = false;
-    const ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME = '';
-    const LOG_ERRORS = true;
-    const LOG_DETAILS = true;
+    const string DEBUGLEVEL = ZMS_DEBUGLEVEL;
+    const string|int SESSION_DURATION = ZMS_SESSION_DURATION;
+    const string SECURE_TOKEN = '';
+    const string CONFIG_SECURE_TOKEN = '';
+    const bool RIGHTSCHECK_ENABLED = true;
+    const int JSON_COMPRESS_LEVEL = 1;
+    const string HTTP_BASE_URL = '';
+    const string CLIENTKEY = '';
+    const bool MAINTENANCE_MODE_ENABLED = false;
+    const string ZMS_CITIZENLOGIN_EXTERNALUSERID_CLAIM_NAME = '';
+    const bool LOG_ERRORS = true;
+    const bool LOG_DETAILS = true;
 /**
      * Settings for region
      */
-    const CHARSET = 'UTF-8';
-    const TIMEZONE = 'Europe/Berlin';
+    const string CHARSET = 'UTF-8';
+    const string TIMEZONE = 'Europe/Berlin';
     public static $includeUrl = null;
 /*
      * -----------------------------------------------------------------------
@@ -69,19 +69,19 @@ class Application
 /**
      * Define the path for the templates relative to APP_PATH
      */
-    const TEMPLATE_PATH = '/templates/';
+    const string TEMPLATE_PATH = '/templates/';
 /**
      * Define path for Twig template cache
      */
-    const TWIG_CACHE = false;
+    const bool|string TWIG_CACHE = false;
 /**
      * Set this option, if ESI should be used
      */
-    const ESI_ENABLED = true;
+    const bool ESI_ENABLED = true;
 /**
      * translator class
      */
-    const TRANSLATOR_CLASS = '\\Symfony\\Component\\Translation\\Translator';
+    const string TRANSLATOR_CLASS = '\\Symfony\\Component\\Translation\\Translator';
 /**
      * Default parameters for templates
      *
@@ -106,7 +106,7 @@ class Application
      * @var \BO\Slim\Language $language
      *
      */
-    const MULTILANGUAGE = true;
+    const bool MULTILANGUAGE = true;
     public static $languagesource = 'json';
     public static $language = null;
     public static $supportedLanguages = array(

--- a/zmsslim/src/Slim/Headers.php
+++ b/zmsslim/src/Slim/Headers.php
@@ -10,9 +10,9 @@ namespace BO\Slim;
 
 class Headers extends \Slim\Psr7\Headers
 {
-    public const MEDIA_TYPE_APPLICATION_XML = 'application/xml';
-    public const MEDIA_TYPE_APPLICATION_JSON = 'application/json';
-    public const MEDIA_TYPE_TEXT_XML = 'text/xml';
-    public const MEDIA_TYPE_TEXT_HTML = 'text/html';
-    public const MEDIA_TYPE_TEXT_PLAIN = 'text/plain';
+    public const string MEDIA_TYPE_APPLICATION_XML = 'application/xml';
+    public const string MEDIA_TYPE_APPLICATION_JSON = 'application/json';
+    public const string MEDIA_TYPE_TEXT_XML = 'text/xml';
+    public const string MEDIA_TYPE_TEXT_HTML = 'text/html';
+    public const string MEDIA_TYPE_TEXT_PLAIN = 'text/plain';
 }

--- a/zmsslim/src/Slim/LoggerService.php
+++ b/zmsslim/src/Slim/LoggerService.php
@@ -12,7 +12,7 @@ use Psr\SimpleCache\CacheInterface;
 
 class LoggerService
 {
-    private const SENSITIVE_HEADERS = [
+    private const array SENSITIVE_HEADERS = [
         'authorization',
         'cookie',
         'x-api-key',
@@ -21,7 +21,7 @@ class LoggerService
         'captchatoken',
     ];
 
-    private const SENSITIVE_PARAMS = [
+    private const array SENSITIVE_PARAMS = [
         'authkey',
         'auth_key',
         'auth-key',
@@ -30,13 +30,13 @@ class LoggerService
         'captcha-token',
     ];
 
-    private const IMPORTANT_HEADERS = [
+    private const array IMPORTANT_HEADERS = [
         'user-agent',
     ];
 
-    private const CACHE_KEY_PREFIX = 'logger.';
-    private const CACHE_REQUEST_COUNTER_KEY = self::CACHE_KEY_PREFIX . 'request';
-    private const CACHE_ERROR_REQUEST_COUNTER_KEY = self::CACHE_KEY_PREFIX . 'request_error';
+    private const string CACHE_KEY_PREFIX = 'logger.';
+    private const string CACHE_REQUEST_COUNTER_KEY = self::CACHE_KEY_PREFIX . 'request';
+    private const string CACHE_ERROR_REQUEST_COUNTER_KEY = self::CACHE_KEY_PREFIX . 'request_error';
 
     public static ?CacheInterface $cache = null;
 

--- a/zmsslim/src/Slim/Middleware/OAuth/Keycloak/Provider.php
+++ b/zmsslim/src/Slim/Middleware/OAuth/Keycloak/Provider.php
@@ -13,7 +13,7 @@ use BO\Zmsentities\Useraccount;
 
 class Provider extends Keycloak
 {
-    const PROVIDERNAME = 'keycloak';
+    const string PROVIDERNAME = 'keycloak';
 
     protected $oauthService;
 

--- a/zmsslim/src/Slim/Middleware/SecurityHeadersMiddleware.php
+++ b/zmsslim/src/Slim/Middleware/SecurityHeadersMiddleware.php
@@ -12,7 +12,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SecurityHeadersMiddleware implements MiddlewareInterface
 {
-    private const DEFAULT_SECURITY_HEADERS = [
+    private const array DEFAULT_SECURITY_HEADERS = [
         'X-Frame-Options' => 'DENY',
         'X-Content-Type-Options' => 'nosniff',
         'X-XSS-Protection' => '1; mode=block',

--- a/zmsslim/src/Slim/Middleware/Session/SessionHuman.php
+++ b/zmsslim/src/Slim/Middleware/Session/SessionHuman.php
@@ -7,11 +7,11 @@ namespace BO\Slim\Middleware\Session;
  */
 class SessionHuman extends SessionContainer
 {
-    const MAX_RELOAD = 10;
+    const int MAX_RELOAD = 10;
 
-    const MAX_TIME = 1800;
+    const int MAX_TIME = 1800;
 
-    const MIN_TIME = 3;
+    const int MIN_TIME = 3;
 
     public function writeVerifySession($request, $origin = '')
     {

--- a/zmsslim/src/Slim/Middleware/SessionHeadersHandler.php
+++ b/zmsslim/src/Slim/Middleware/SessionHeadersHandler.php
@@ -32,7 +32,7 @@ class SessionHeadersHandler
     /**
      * The timestamp for "already expired."
      */
-    const EXPIRED = 'Thu, 19 Nov 1981 08:52:00 GMT';
+    const string EXPIRED = 'Thu, 19 Nov 1981 08:52:00 GMT';
 
     /**
      *

--- a/zmsslim/src/Slim/Middleware/SessionMiddleware.php
+++ b/zmsslim/src/Slim/Middleware/SessionMiddleware.php
@@ -9,7 +9,7 @@ use BO\Slim\Factory\ResponseFactory;
 
 class SessionMiddleware
 {
-    const SESSION_ATTRIBUTE = 'session';
+    const string SESSION_ATTRIBUTE = 'session';
 
     protected $sessionClass = null;
 

--- a/zmsslim/src/Slim/TwigExceptionHandler.php
+++ b/zmsslim/src/Slim/TwigExceptionHandler.php
@@ -17,7 +17,7 @@ use Slim\Interfaces\ErrorHandlerInterface;
   */
 class TwigExceptionHandler implements ErrorHandlerInterface
 {
-    const DEFAULT_TEMPLATE = "exception/default.twig";
+    const string DEFAULT_TEMPLATE = "exception/default.twig";
 
     /**
      * @SuppressWarnings("PMD.UnusedFormalParameter")

--- a/zmsslim/src/Slim/Version.php
+++ b/zmsslim/src/Slim/Version.php
@@ -4,7 +4,7 @@ namespace BO\Slim;
 
 class Version
 {
-    const UNKNOWN = 'version.unknown';
+    const string UNKNOWN = 'version.unknown';
 
     public static function getString()
     {

--- a/zmsslim/tests/Slim/Config.php
+++ b/zmsslim/tests/Slim/Config.php
@@ -13,7 +13,7 @@ class App extends \BO\Slim\Application
     const string SESSION_NAME = "Unittest";
     const string SESSION_ATTRIBUTE = 'session';
     const bool MULTILANGUAGE = true;
-    const bool|string TWIG_CACHE = '/cache';
+    const TWIG_CACHE = '/cache';
 }
 
 App::$now = new DateTimeImmutable('2016-04-01 08:00', new DateTimeZone('Europe/Berlin'));

--- a/zmsslim/tests/Slim/Config.php
+++ b/zmsslim/tests/Slim/Config.php
@@ -6,14 +6,14 @@ class App extends \BO\Slim\Application
     public const string IDENTIFIER = 'Slim-ENV';
     public const string APP_PATH = APP_PATH;
     public const bool DEBUG = true;
-    const LOG_ERRORS = false;
+    const bool LOG_ERRORS = false;
 
-    const TEMPLATE_PATH = '/Slim/templates/';
+    const string TEMPLATE_PATH = '/Slim/templates/';
 
-    const SESSION_NAME = "Unittest";
-    const SESSION_ATTRIBUTE = 'session';
-    const MULTILANGUAGE = true;
-    const TWIG_CACHE = '/cache';
+    const string SESSION_NAME = "Unittest";
+    const string SESSION_ATTRIBUTE = 'session';
+    const bool MULTILANGUAGE = true;
+    const bool|string TWIG_CACHE = '/cache';
 }
 
 App::$now = new DateTimeImmutable('2016-04-01 08:00', new DateTimeZone('Europe/Berlin'));

--- a/zmsstatistic/config.example.php
+++ b/zmsstatistic/config.example.php
@@ -12,12 +12,12 @@ class App extends \BO\Zmsstatistic\Application
 {
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
 
     /**
      * HTTP url for api
      */
-    const HTTP_BASE_URL = ZMS_API_URL;
+    const string HTTP_BASE_URL = ZMS_API_URL;
 
     /**
      * Name of the module

--- a/zmsstatistic/config.example.php
+++ b/zmsstatistic/config.example.php
@@ -12,7 +12,7 @@ class App extends \BO\Zmsstatistic\Application
 {
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
 
     /**
      * HTTP url for api

--- a/zmsstatistic/src/Zmsstatistic/Application.php
+++ b/zmsstatistic/src/Zmsstatistic/Application.php
@@ -41,9 +41,9 @@ class Application extends \BO\Slim\Application
 
     const bool DEBUG = false;
 
-    const bool|string TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
 
-    const string|int SESSION_DURATION = ZMS_STATISTIC_SESSION_DURATION;
+    const SESSION_DURATION = ZMS_STATISTIC_SESSION_DURATION;
 
     public static $includeUrl = '/terminvereinbarung/statistic';
     /**

--- a/zmsstatistic/src/Zmsstatistic/Application.php
+++ b/zmsstatistic/src/Zmsstatistic/Application.php
@@ -41,9 +41,9 @@ class Application extends \BO\Slim\Application
 
     const bool DEBUG = false;
 
-    const TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_STATISTIC_TWIG_CACHE;
 
-    const SESSION_DURATION = ZMS_STATISTIC_SESSION_DURATION;
+    const string|int SESSION_DURATION = ZMS_STATISTIC_SESSION_DURATION;
 
     public static $includeUrl = '/terminvereinbarung/statistic';
     /**
@@ -78,17 +78,17 @@ class Application extends \BO\Slim\Application
 
     public static $http_curl_config = array();
 
-    const JSON_COMPRESS_LEVEL = 1;
+    const int JSON_COMPRESS_LEVEL = 1;
 
     /**
     * config preferences
     */
-    const CONFIG_SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
+    const string CONFIG_SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
 
     /**
      * HTTP url for api
      */
-    const HTTP_BASE_URL = 'http://user:pass@host.tdl';
+    const string HTTP_BASE_URL = 'http://user:pass@host.tdl';
 
     public static function initialize(): void
     {

--- a/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
@@ -17,9 +17,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class WaitingReport extends Base
 {
-    private const CUSTOMER_TYPE_GESAMT = 'gesamt';
-    private const CUSTOMER_TYPE_TERMIN = 'termin';
-    private const CUSTOMER_TYPE_SPONTAN = 'spontan';
+    private const string CUSTOMER_TYPE_GESAMT = 'gesamt';
+    private const string CUSTOMER_TYPE_TERMIN = 'termin';
+    private const string CUSTOMER_TYPE_SPONTAN = 'spontan';
 
     protected $reportPartsGesamt = [
         'waitingtime_total' => 'Durchschnittliche Wartezeit in Min. (Gesamt)',

--- a/zmsstatistic/src/Zmsstatistic/Service/ReportCapacityService.php
+++ b/zmsstatistic/src/Zmsstatistic/Service/ReportCapacityService.php
@@ -17,10 +17,10 @@ use DateTimeImmutable;
 class ReportCapacityService
 {
     /** Fetch hour-level warehouse data up to this range length (chart buckets are derived in PHP). */
-    private const MAX_HOURLY_FETCH_HOURS = 336;
+    private const int MAX_HOURLY_FETCH_HOURS = 336;
 
     /** Above this count, slot-time hints group by duration instead of listing scope names. */
-    private const SLOT_TIME_HINT_MAX_NAMED_SCOPES = 4;
+    private const int SLOT_TIME_HINT_MAX_NAMED_SCOPES = 4;
 
     public function getExchangeCapacityData(string $scopeId, ?array $dateRange, array $args): mixed
     {

--- a/zmsticketprinter/config.example.php
+++ b/zmsticketprinter/config.example.php
@@ -13,7 +13,7 @@ class App extends \BO\Zmsticketprinter\Application
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const string APP_PATH = __DIR__;
     const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
     const string HTTP_BASE_URL = ZMS_API_URL;
 
     /**

--- a/zmsticketprinter/config.example.php
+++ b/zmsticketprinter/config.example.php
@@ -13,8 +13,8 @@ class App extends \BO\Zmsticketprinter\Application
     const string IDENTIFIER = ZMS_IDENTIFIER;
     const string APP_PATH = __DIR__;
     const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
-    const HTTP_BASE_URL = ZMS_API_URL;
+    const bool|string TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
+    const string HTTP_BASE_URL = ZMS_API_URL;
 
     /**
      * Name of the module

--- a/zmsticketprinter/src/Zmsticketprinter/Application.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Application.php
@@ -35,7 +35,7 @@ class Application extends \BO\Slim\Application
     public static ?CacheInterface $cache = null;
 
     public const bool DEBUG = false;
-    const TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
+    const bool|string TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
 
     /**
      * language preferences
@@ -72,15 +72,15 @@ class Application extends \BO\Slim\Application
 
     public static $http_curl_config = array();
 
-    public const JSON_COMPRESS_LEVEL = 1;
+    public const int JSON_COMPRESS_LEVEL = 1;
 
     /**
      * HTTP url for api
      */
-    public const HTTP_BASE_URL = 'http://user:pass@host.tdl';
-    public const SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
+    public const string HTTP_BASE_URL = 'http://user:pass@host.tdl';
+    public const string SECURE_TOKEN = ZMS_CONFIG_SECURE_TOKEN;
 
-    public const CLIENTKEY = '';
+    public const string CLIENTKEY = '';
 
     public static function initialize(): void
     {

--- a/zmsticketprinter/src/Zmsticketprinter/Application.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Application.php
@@ -35,7 +35,7 @@ class Application extends \BO\Slim\Application
     public static ?CacheInterface $cache = null;
 
     public const bool DEBUG = false;
-    const bool|string TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
+    const TWIG_CACHE = ZMS_TICKETPRINTER_TWIG_CACHE;
 
     /**
      * language preferences


### PR DESCRIPTION
## Summary
- Adds PHP 8.3 native types on class constants with obvious literal values (`string` / `int` / `bool` / `array`) so Psalm `MissingClassConstType` can close in bulk.
- Uses `bool|string` for `TWIG_CACHE` and `string|int` for `SESSION_DURATION` because those values come from env/defines and are not a single type.
- Leaves `null` sentinels (`Query\Base::TABLE` / `ALIAS`) untyped so subclasses can still override with `string`.

## Test plan
- [ ] Combined PHP workflow is green against `next`
- [ ] App boot still accepts `TWIG_CACHE` as `false` or a cache path
- [ ] Confirm a sample of former `MissingClassConstType` alerts close after the next Psalm scan