### PR TITLE
fix(ZMS): add native parameter and return types

### DIFF
--- a/mellon/src/Mellon/Collection.php
+++ b/mellon/src/Mellon/Collection.php
@@ -87,7 +87,7 @@ class Collection
     }
 
 
-    public function addValid(Valid ...$validList)
+    public function addValid(Valid ...$validList): void
     {
         foreach ($validList as $valid) {
             $this->validatorList[$valid->getName()] = $valid;

--- a/mellon/src/Mellon/Condition.php
+++ b/mellon/src/Mellon/Condition.php
@@ -2,9 +2,6 @@
 
 namespace BO\Mellon;
 
-/**
- *
- */
 class Condition
 {
     protected $collection = [];
@@ -17,7 +14,7 @@ class Condition
         }
     }
 
-    public function addValid(Valid $valid)
+    public function addValid(Valid $valid): static
     {
         $this->getCollection()->addValid($valid);
         return $this;

--- a/mellon/src/Mellon/Failure/Exception.php
+++ b/mellon/src/Mellon/Failure/Exception.php
@@ -9,10 +9,6 @@ namespace BO\Mellon\Failure;
 
 use BO\Mellon\Valid;
 
-/**
-  *
-  *
-  */
 class Exception extends \Exception
 {
     /**
@@ -21,7 +17,7 @@ class Exception extends \Exception
      */
     protected $validator = null;
 
-    public function setValidator(Valid $validator)
+    public function setValidator(Valid $validator): static
     {
         $this->validator = $validator;
         $this->message = (string)$validator->getMessages();

--- a/mellon/src/Mellon/Valid.php
+++ b/mellon/src/Mellon/Valid.php
@@ -65,7 +65,7 @@ class Valid extends \BO\Mellon\Parameter
         return $this;
     }
 
-    protected function setFailureMessage($message)
+    protected function setFailureMessage(string $message): static
     {
         if (null === $this->messages) {
             $this->messages = new Failure\MessageList();
@@ -317,7 +317,7 @@ class Valid extends \BO\Mellon\Parameter
         return $status;
     }
 
-    public function getUnvalidated()
+    public function getUnvalidated(): string|null
     {
         return $this->value;
     }

--- a/mellon/src/Mellon/Valid.php
+++ b/mellon/src/Mellon/Valid.php
@@ -317,7 +317,7 @@ class Valid extends \BO\Mellon\Parameter
         return $status;
     }
 
-    public function getUnvalidated(): string|null
+    public function getUnvalidated(): mixed
     {
         return $this->value;
     }

--- a/mellon/src/Mellon/ValidDatetime.php
+++ b/mellon/src/Mellon/ValidDatetime.php
@@ -13,7 +13,7 @@ class ValidDatetime extends Valid
 {
     protected $dateTime;
 
-    public function isDatetime($message = 'Please enter a valid date', $format = false)
+    public function isDatetime($message = 'Please enter a valid date', $format = false): Valid
     {
         $this->validated = true;
         $date = $this->value;
@@ -34,7 +34,7 @@ class ValidDatetime extends Valid
         return $this;
     }
 
-    public function isOldEnough($years = 18, $message = 'Minimum age of 18 years is required')
+    public function isOldEnough($years = 18, $message = 'Minimum age of 18 years is required'): Valid
     {
         if ($this->dateTime instanceof \DateTimeInterface) {
             $now = new DateTime();

--- a/mellon/src/Mellon/ValidFile.php
+++ b/mellon/src/Mellon/ValidFile.php
@@ -32,7 +32,7 @@ class ValidFile extends Valid
         'png' => 'image/png'
     );
 
-    public function isFile($name = 'fileupload', $message = 'No valid file found.')
+    public function isFile($name = 'fileupload', $message = 'No valid file found.'): static
     {
         $this->fileName = $name;
         $this->validated = true;
@@ -42,7 +42,7 @@ class ValidFile extends Valid
         return $this;
     }
 
-    public function hasType($type = 'jpeg', $message = 'Invalid file type.')
+    public function hasType($type = 'jpeg', $message = 'Invalid file type.'): static
     {
         if (isset($_FILES[$this->fileName])) {
             if (
@@ -55,7 +55,7 @@ class ValidFile extends Valid
         return $this;
     }
 
-    public function hasMaxSize($maxSize = 50, $message = 'File size not valid.')
+    public function hasMaxSize($maxSize = 50, $message = 'File size not valid.'): static
     {
         $maxByteSize = $maxSize * 1000 * 1024;
         if (isset($_FILES[$this->fileName])) {

--- a/mellon/src/Mellon/ValidMail.php
+++ b/mellon/src/Mellon/ValidMail.php
@@ -41,7 +41,7 @@ class ValidMail extends \BO\Mellon\ValidString
      * Not every DNS server refreshes an outdated entry on an ANY requests
      * So we have to check common types before checking an ANY type
      */
-    protected function checkDnsAny($domain)
+    protected function checkDnsAny(string $domain): bool
     {
         checkdnsrr($domain, 'A'); // refresh on outdated TTL
         checkdnsrr($domain, 'AAAA');
@@ -49,8 +49,10 @@ class ValidMail extends \BO\Mellon\ValidString
         return checkdnsrr($domain, 'ANY');
     }
 
-    /** @psalm-api */
-    public function hasDNS($message = 'no valid DNS entry found')
+    /**
+     * @psalm-api
+     */
+    public function hasDNS($message = 'no valid DNS entry found'): static
     {
         $this->validated = true;
         if ($this->value && !$this::$disableDnsChecks) {
@@ -63,8 +65,10 @@ class ValidMail extends \BO\Mellon\ValidString
         return $this;
     }
 
-    /** @psalm-api */
-    public function hasMX($message = 'no valid DNS entry of type MX found')
+    /**
+     * @psalm-api
+     */
+    public function hasMX($message = 'no valid DNS entry of type MX found'): static
     {
         $this->validated = true;
         if ($this->value) {

--- a/mellon/src/Mellon/ValidationException.php
+++ b/mellon/src/Mellon/ValidationException.php
@@ -7,10 +7,6 @@
 
 namespace BO\Mellon;
 
-/**
-  *
-  *
-  */
 class ValidationException extends \Exception
 {
     /**
@@ -19,8 +15,10 @@ class ValidationException extends \Exception
      */
     protected $validator = null;
 
-    /** @psalm-api */
-    public function setValidator(Valid $validator)
+    /**
+     * @psalm-api
+     */
+    public function setValidator(Valid $validator): static
     {
         $this->validator = $validator;
         return $this;

--- a/mellon/src/Mellon/Validator.php
+++ b/mellon/src/Mellon/Validator.php
@@ -109,7 +109,7 @@ class Validator
      *
      * @return \BO\Mellon\Unvalidated
      */
-    public function getParameter($name)
+    public function getParameter(string $name)
     {
         if ($this->hasParameter($name)) {
             return new \BO\Mellon\Unvalidated($this->parameters[$name], $name);

--- a/zmsadmin/src/Zmsadmin/AppointmentFormButtons.php
+++ b/zmsadmin/src/Zmsadmin/AppointmentFormButtons.php
@@ -52,7 +52,7 @@ class AppointmentFormButtons extends BaseController
         );
     }
 
-    protected function isNewAppointment($process, $selectedDate, $selectedTime)
+    protected function isNewAppointment($process, $selectedDate, string $selectedTime): bool
     {
         $selectedAppointment = new Appointment();
         $selectedAppointment->setTime($selectedDate . ' ' . $selectedTime);

--- a/zmsadmin/src/Zmsadmin/BaseController.php
+++ b/zmsadmin/src/Zmsadmin/BaseController.php
@@ -34,7 +34,11 @@ abstract class BaseController extends \BO\Slim\Controller
         return parent::__invoke($request, $response, $args);
     }
 
-    public function getSchemaConstraintList($schema)
+    /**
+     * @return array[]
+     *
+     */
+    public function getSchemaConstraintList($schema): array
     {
         $list = [];
         $locale = \App::$language->getLocale();

--- a/zmsadmin/src/Zmsadmin/Department.php
+++ b/zmsadmin/src/Zmsadmin/Department.php
@@ -67,7 +67,7 @@ class Department extends BaseController
         );
     }
 
-    protected function withCleanupLinks(array $input)
+    protected function withCleanupLinks(array $input): array
     {
         if (!isset($input['links'])) {
             return $input;
@@ -85,7 +85,7 @@ class Department extends BaseController
         return $input;
     }
 
-    protected function withCleanupDayoffs(array $input)
+    protected function withCleanupDayoffs(array $input): array
     {
         if (!isset($input['dayoff'])) {
             return $input;
@@ -98,7 +98,7 @@ class Department extends BaseController
         return $input;
     }
 
-    private function withEmailReminderDefaultValues(array $input)
+    private function withEmailReminderDefaultValues(array $input): array
     {
         if ($input['sendEmailReminderMinutesBefore'] === '') {
             $input['sendEmailReminderMinutesBefore'] = null;

--- a/zmsadmin/src/Zmsadmin/Helper/AppointmentFormHelper.php
+++ b/zmsadmin/src/Zmsadmin/Helper/AppointmentFormHelper.php
@@ -20,7 +20,7 @@ use BO\Zmsentities\Process;
  */
 class AppointmentFormHelper
 {
-    public static function readFreeProcessList($request, $workstation, $resolveReferences = 1)
+    public static function readFreeProcessList(\Psr\Http\Message\RequestInterface $request, $workstation, int $resolveReferences = 1)
     {
         $validator = $request->getAttribute('validator');
         $selectedProcessId = $validator->getParameter('selectedprocess')->isNumber()->getValue();
@@ -51,7 +51,7 @@ class AppointmentFormHelper
         return ($freeProcessList) ? $freeProcessList->toProcessListByTime()->sortByTimeKey() : null;
     }
 
-    public static function readRequestList($request, $workstation, $selectedScope = null)
+    public static function readRequestList(\Psr\Http\Message\RequestInterface $request, $workstation, $selectedScope = null)
     {
         $scope = ($selectedScope) ? $selectedScope : static::readSelectedScope($request, $workstation);
         $requestList = null;
@@ -65,7 +65,7 @@ class AppointmentFormHelper
         return ($requestList) ? $requestList->sortByName() : new RequestList();
     }
 
-    public static function readSelectedScope($request, $workstation, $selectedProcess = null, $resolveReferences = 1)
+    public static function readSelectedScope(\Psr\Http\Message\RequestInterface $request, $workstation, $selectedProcess = null, int $resolveReferences = 1)
     {
         $validator = $request->getAttribute('validator');
         $input = $request->getParsedBody();
@@ -93,7 +93,7 @@ class AppointmentFormHelper
         return $selectedScope;
     }
 
-    public static function readSelectedProcess($request)
+    public static function readSelectedProcess(\Psr\Http\Message\RequestInterface $request)
     {
         $validator = $request->getAttribute('validator');
         $selectedProcessId = $validator->getParameter('selectedprocess')->isNumber()->getValue();
@@ -104,7 +104,7 @@ class AppointmentFormHelper
             null;
     }
 
-    public static function updateMail($formData, Process $process)
+    public static function updateMail($formData, Process $process): void
     {
         if (isset($formData['sendMailConfirmation'])) {
             $mailConfirmation = $formData['sendMailConfirmation'];
@@ -165,7 +165,7 @@ class AppointmentFormHelper
         return $slotsRequired;
     }
 
-    protected static function writeMail($mailConfirmation, Process $process)
+    protected static function writeMail($mailConfirmation, Process $process): void
     {
         if (
             $mailConfirmation &&

--- a/zmsadmin/src/Zmsadmin/Helper/AvailabilityCheckDayOff.php
+++ b/zmsadmin/src/Zmsadmin/Helper/AvailabilityCheckDayOff.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class AvailabilityCheckDayOff extends BaseController
 {
+    /**
+     * @return ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         RequestInterface $request,

--- a/zmsadmin/src/Zmsadmin/Helper/AvailabilityConflicts.php
+++ b/zmsadmin/src/Zmsadmin/Helper/AvailabilityConflicts.php
@@ -36,7 +36,11 @@ class AvailabilityConflicts extends BaseController
         );
     }
 
-    protected static function getAvailabilityData($input)
+    /**
+     * @return (array|mixed)[]
+     *
+     */
+    protected static function getAvailabilityData($input): array
     {
         $availabilityList = (new AvailabilityList())->addData($input['availabilityList']);
         $conflictedList = [];

--- a/zmsadmin/src/Zmsadmin/Helper/Calendar.php
+++ b/zmsadmin/src/Zmsadmin/Helper/Calendar.php
@@ -43,7 +43,7 @@ class Calendar
         return $this->dateTime;
     }
 
-    public function readMonthListByScopeList(ScopeList $scopeList, $slotType, $slotsRequired)
+    public function readMonthListByScopeList(ScopeList $scopeList, string $slotType, int $slotsRequired)
     {
         // TODO Berechne die Tage im Kalendar
         $this->calendar->scopes = $scopeList;
@@ -69,9 +69,9 @@ class Calendar
 
     public function readAvailableSlotsFromDayAndScopeList(
         ScopeList $scopeList,
-        $slotType = 'intern',
-        $slotsRequired = 0,
-        $forWeek = false
+        string $slotType = 'intern',
+        int $slotsRequired = 0,
+        bool $forWeek = false
     ) {
         $this->calendar->scopes = $scopeList;
 
@@ -163,13 +163,17 @@ class Calendar
         return $this->toDayListByHour($dayList);
     }
 
-    protected function getDateTimeFromWeekAndYear($week, $year)
+    protected function getDateTimeFromWeekAndYear($week, $year): DateTimeImmutable
     {
         $dateTime = new DateTimeImmutable();
         return $dateTime->setISODate($year, $week);
     }
 
-    public function toProcessListByHour(ProcessList $processList)
+    /**
+     * @return ProcessList[][]
+     *
+     */
+    public function toProcessListByHour(ProcessList $processList): array
     {
         $list = array();
         $oldList = $processList;
@@ -195,7 +199,11 @@ class Calendar
         return $list;
     }
 
-    public function toDayListByHour(DayList $dayList)
+    /**
+     * @return ((ProcessList|mixed)[]|Day)[][]
+     *
+     */
+    public function toDayListByHour(DayList $dayList): array
     {
         $list = array();
         $hours = array();
@@ -225,7 +233,11 @@ class Calendar
         return $list;
     }
 
-    private function splitByDate(ProcessList $processList)
+    /**
+     * @return ProcessList[]
+     *
+     */
+    private function splitByDate(ProcessList $processList): array
     {
         $list = [];
 

--- a/zmsadmin/src/Zmsadmin/Helper/ClusterHelper.php
+++ b/zmsadmin/src/Zmsadmin/Helper/ClusterHelper.php
@@ -53,7 +53,7 @@ class ClusterHelper
         return ($processList) ? $processList->getCollection() : new ProcessList();
     }
 
-    public static function getNextProcess($excludedIds)
+    public static function getNextProcess(array $excludedIds)
     {
         $exclude = is_array($excludedIds) ? ExcludeIds::toQuery($excludedIds) : (string) $excludedIds;
         if (static::isClusterEnabled()) {
@@ -74,7 +74,7 @@ class ClusterHelper
         return $nextProcess;
     }
 
-    public static function isClusterEnabled()
+    public static function isClusterEnabled(): bool
     {
         return (static::$workstation->queue['clusterEnabled'] && static::$cluster);
     }

--- a/zmsadmin/src/Zmsadmin/Helper/FileUploader.php
+++ b/zmsadmin/src/Zmsadmin/Helper/FileUploader.php
@@ -31,7 +31,7 @@ class FileUploader
         $this->imageData = $this->createImage($imageName);
     }
 
-    public function writeUploadToScope($entityId)
+    public function writeUploadToScope($entityId): static
     {
         $this->imageData = \App::$http->readPostResult(
             '/scope/' . $entityId . '/imagedata/calldisplay/',
@@ -40,7 +40,7 @@ class FileUploader
         return $this;
     }
 
-    public function writeUploadToCluster($entityId)
+    public function writeUploadToCluster($entityId): static
     {
         $this->imageData = \App::$http->readPostResult(
             '/cluster/' . $entityId . '/imagedata/calldisplay/',
@@ -55,7 +55,7 @@ class FileUploader
         return (isset($files[$imageName])) ? $files[$imageName] : false;
     }
 
-    protected function createImage($imageName)
+    protected function createImage($imageName): Mimepart|null
     {
         $image = null;
         $this->uploadFile = $this->getUploadedFile($imageName);

--- a/zmsadmin/src/Zmsadmin/Helper/GraphDefaults.php
+++ b/zmsadmin/src/Zmsadmin/Helper/GraphDefaults.php
@@ -4,7 +4,7 @@ namespace BO\Zmsadmin\Helper;
 
 class GraphDefaults
 {
-    protected static function defaultFormat($string)
+    protected static function defaultFormat(string $string): string|null
     {
         return preg_replace('#\s+#m', ' ', trim($string));
     }

--- a/zmsadmin/src/Zmsadmin/Helper/LoginForm.php
+++ b/zmsadmin/src/Zmsadmin/Helper/LoginForm.php
@@ -10,13 +10,14 @@
 namespace BO\Zmsadmin\Helper;
 
 use BO\Mellon\Validator;
+use BO\Mellon\Collection;
 
 class LoginForm
 {
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromLoginParameters(): Validator
+    public static function fromLoginParameters(): Collection
     {
         $collection = array();
         // loginName
@@ -37,7 +38,7 @@ class LoginForm
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromAdditionalParameters(): Validator
+    public static function fromAdditionalParameters(): Collection
     {
         $collection = array();
 
@@ -72,7 +73,7 @@ class LoginForm
         return $collection;
     }
 
-    public static function fromQuickLogin(): Validator
+    public static function fromQuickLogin(): Collection
     {
         $loginData = static::fromLoginParameters();
         $additionalData = static::fromAdditionalParameters();

--- a/zmsadmin/src/Zmsadmin/Helper/LoginForm.php
+++ b/zmsadmin/src/Zmsadmin/Helper/LoginForm.php
@@ -16,7 +16,7 @@ class LoginForm
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromLoginParameters()
+    public static function fromLoginParameters(): Validator
     {
         $collection = array();
         // loginName
@@ -37,7 +37,7 @@ class LoginForm
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromAdditionalParameters()
+    public static function fromAdditionalParameters(): Validator
     {
         $collection = array();
 
@@ -72,7 +72,7 @@ class LoginForm
         return $collection;
     }
 
-    public static function fromQuickLogin()
+    public static function fromQuickLogin(): Validator
     {
         $loginData = static::fromLoginParameters();
         $additionalData = static::fromAdditionalParameters();
@@ -82,7 +82,7 @@ class LoginForm
         return $collection;
     }
 
-    public static function writeWorkstationUpdate($data, $workstation)
+    public static function writeWorkstationUpdate($data, \BO\Zmsentities\Workstation $workstation): bool
     {
         if (isset($workstation->useraccount)) {
             $formData = $data->getValues();

--- a/zmsadmin/src/Zmsadmin/Helper/MailTemplateArrayProvider.php
+++ b/zmsadmin/src/Zmsadmin/Helper/MailTemplateArrayProvider.php
@@ -22,7 +22,7 @@ class MailTemplateArrayProvider
         return $this->templates;
     }
 
-    public function setTemplates($templates)
+    public function setTemplates(array $templates): void
     {
         $this->templates = $templates;
     }

--- a/zmsadmin/src/Zmsadmin/Helper/MailTemplateDummyPreview.php
+++ b/zmsadmin/src/Zmsadmin/Helper/MailTemplateDummyPreview.php
@@ -9,6 +9,9 @@
 
 class MailTemplateDummyPreview extends BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,

--- a/zmsadmin/src/Zmsadmin/Helper/MailTemplatePreviewMail.php
+++ b/zmsadmin/src/Zmsadmin/Helper/MailTemplatePreviewMail.php
@@ -11,6 +11,9 @@
 
 class MailTemplatePreviewMail extends BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,

--- a/zmsadmin/src/Zmsadmin/Helper/ProcessFinishedHelper.php
+++ b/zmsadmin/src/Zmsadmin/Helper/ProcessFinishedHelper.php
@@ -26,7 +26,7 @@ class ProcessFinishedHelper extends Process
         array $input,
         RequestList $requestList,
         $source
-    ) {
+    ): static {
         if (array_key_exists('ignoreRequests', $input) && $input['ignoreRequests']) {
             $this->requests = new RequestList();
             $request = new Request([

--- a/zmsadmin/src/Zmsadmin/Helper/ProviderHandler.php
+++ b/zmsadmin/src/Zmsadmin/Helper/ProviderHandler.php
@@ -31,7 +31,11 @@ class ProviderHandler extends BaseController
         );
     }
 
-    public static function readProviderList($source)
+    /**
+     * @return (mixed|string)[][]
+     *
+     */
+    public static function readProviderList($source): array
     {
         return [
             ['name' => 'assigned', 'items' => static::readProviderAssigned($source)],

--- a/zmsadmin/src/Zmsadmin/Helper/QueueListHelper.php
+++ b/zmsadmin/src/Zmsadmin/Helper/QueueListHelper.php
@@ -78,7 +78,7 @@ class QueueListHelper
         return (self::getList()->getQueuePositionByNumber($entity->number));
     }
 
-    protected static function createFullList($clusterHelper, $dateTime)
+    protected static function createFullList(ClusterHelper $clusterHelper, \DateTimeImmutable|false $dateTime)
     {
         $fullList = $clusterHelper->getProcessList($dateTime->format('Y-m-d'));
         return ($fullList->count()) ? $fullList->toQueueList($dateTime) : new QueueList();

--- a/zmsadmin/src/Zmsadmin/Helper/TemplateFinder.php
+++ b/zmsadmin/src/Zmsadmin/Helper/TemplateFinder.php
@@ -7,7 +7,7 @@ class TemplateFinder
     /**
      * @todo check against ISO definition
      */
-    public static function getTemplatePath()
+    public static function getTemplatePath(): string
     {
         return realpath(__DIR__) . '/../../../templates';
     }

--- a/zmsadmin/src/Zmsadmin/Helper/WorkstationInfo.php
+++ b/zmsadmin/src/Zmsadmin/Helper/WorkstationInfo.php
@@ -16,7 +16,7 @@ use DateTime;
 
 class WorkstationInfo
 {
-    public static function getInfoBoxData(Workstation $workstation, $selectedDate)
+    public static function getInfoBoxData(Workstation $workstation, string $selectedDate)
     {
         $infoData = array(
             'waitingTimeEstimate' => 0,
@@ -73,7 +73,7 @@ class WorkstationInfo
         return $infoData;
     }
 
-    public static function stringTimeToMinute($time)
+    public static function stringTimeToMinute($time): int
     {
         $timeArray = explode(':', $time === null ? '' : $time);
 
@@ -103,7 +103,11 @@ class WorkstationInfo
             ->getCollection();
     }
 
-    protected static function getAdditionalInfoData($infoData, $queueListHelper)
+    /**
+     * @param (float|int|mixed)[] $infoData
+     *
+     */
+    protected static function getAdditionalInfoData(array $infoData, QueueListHelper $queueListHelper)
     {
         $infoData['waitingTimeEstimate'] = $queueListHelper->getEstimatedWaitingTime();
         $infoData['waitingTimeOptimistic'] = $queueListHelper->getOptimisticWaitingTime();

--- a/zmsadmin/src/Zmsadmin/Index.php
+++ b/zmsadmin/src/Zmsadmin/Index.php
@@ -155,7 +155,7 @@ class Index extends BaseController
         return $exceptionData;
     }
 
-    protected function getProviderList($config)
+    protected function getProviderList($config): array
     {
         $allowedProviderList = explode(',', $config->getPreference('oidc', 'provider') ?? '');
         $oidcproviderlist = [];

--- a/zmsadmin/src/Zmsadmin/Mail.php
+++ b/zmsadmin/src/Zmsadmin/Mail.php
@@ -69,7 +69,7 @@ class Mail extends BaseController
         );
     }
 
-    private function writeValidatedMail($process, $department)
+    private function writeValidatedMail($process, \BO\Zmsentities\Department $department)
     {
         if (! $process->scope->hasEmailFrom()) {
             throw new \BO\Zmsadmin\Exception\MailFromMissing();

--- a/zmsadmin/src/Zmsadmin/OrganisationAddDepartment.php
+++ b/zmsadmin/src/Zmsadmin/OrganisationAddDepartment.php
@@ -60,7 +60,11 @@ class OrganisationAddDepartment extends BaseController
         );
     }
 
-    protected function withCleanupLinks(array $input)
+    /**
+     * @return (array|mixed)[]
+     *
+     */
+    protected function withCleanupLinks(array $input): array
     {
         $links = $input['links'];
 
@@ -71,7 +75,11 @@ class OrganisationAddDepartment extends BaseController
         return $input;
     }
 
-    protected function withCleanupDayoffs(array $input)
+    /**
+     * @return (array|mixed)[]
+     *
+     */
+    protected function withCleanupDayoffs(array $input): array
     {
         $dayoffs = $input['dayoff'];
         $input['dayoff'] = array_filter($dayoffs, function ($dayoff) {

--- a/zmsadmin/src/Zmsadmin/OverallCalendarClosureLoadData.php
+++ b/zmsadmin/src/Zmsadmin/OverallCalendarClosureLoadData.php
@@ -7,6 +7,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class OverallCalendarClosureLoadData extends BaseController
 {
+    /**
+     * @return ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         RequestInterface $request,

--- a/zmsadmin/src/Zmsadmin/OverallCalendarLoadData.php
+++ b/zmsadmin/src/Zmsadmin/OverallCalendarLoadData.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class OverallCalendarLoadData extends BaseController
 {
+    /**
+     * @return ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         RequestInterface $request,

--- a/zmsadmin/src/Zmsadmin/ProcessChange.php
+++ b/zmsadmin/src/Zmsadmin/ProcessChange.php
@@ -63,7 +63,11 @@ class ProcessChange extends BaseController
         return $newProcess->withUpdatedData($input, $dateTime, $scope);
     }
 
-    protected static function getValidatedForm($validator, $process)
+    /**
+     * @return (bool|mixed)[]
+     *
+     */
+    protected static function getValidatedForm($validator, $process): array
     {
         $processValidator = new ProcessValidator($process);
         $delegatedProcess = $processValidator->getDelegatedProcess();
@@ -171,13 +175,13 @@ class ProcessChange extends BaseController
         return $newProcess;
     }
 
-    protected static function writeDeletedMail($oldProcess)
+    protected static function writeDeletedMail($oldProcess): void
     {
             $oldProcess->status = 'deleted';
             ProcessDelete::writeDeleteMailNotifications($oldProcess);
     }
 
-    protected static function writeConfirmedMail($input, $newProcess)
+    protected static function writeConfirmedMail($input, $newProcess): void
     {
         if ('confirmed' == $newProcess->getStatus()) {
             Helper\AppointmentFormHelper::updateMail($input, $newProcess);

--- a/zmsadmin/src/Zmsadmin/ProcessDelete.php
+++ b/zmsadmin/src/Zmsadmin/ProcessDelete.php
@@ -47,7 +47,7 @@ class ProcessDelete extends BaseController
         );
     }
 
-    public static function writeDeleteMailNotifications($process)
+    public static function writeDeleteMailNotifications($process): void
     {
         #email only for clients with appointment if email address is given
         if (

--- a/zmsadmin/src/Zmsadmin/ProcessQueue.php
+++ b/zmsadmin/src/Zmsadmin/ProcessQueue.php
@@ -30,6 +30,8 @@ class ProcessQueue extends BaseController
 {
     /**
      * @SuppressWarnings(Param)
+     *
+     * @return ResponseInterface
      */
     #[\Override]
     public function readResponse(
@@ -77,7 +79,11 @@ class ProcessQueue extends BaseController
         );
     }
 
-    public static function getValidatedForm($validator, $process)
+    /**
+     * @return (bool|mixed)[]
+     *
+     */
+    public static function getValidatedForm($validator, Process $process): array
     {
         $processValidator = new ProcessValidator($process);
         $delegatedProcess = $processValidator->getDelegatedProcess();
@@ -155,7 +161,7 @@ class ProcessQueue extends BaseController
         return $process->withUpdatedData($input, \App::$now, $scope, $notice);
     }
 
-    protected function writeQueuedProcess($input, $process)
+    protected function writeQueuedProcess($input, $process): Process
     {
         $process = \App::$http->readPostResult('/workstation/process/waitingnumber/', $process)->getEntity();
         AppointmentFormHelper::updateMail($input, $process);

--- a/zmsadmin/src/Zmsadmin/ProcessReserve.php
+++ b/zmsadmin/src/Zmsadmin/ProcessReserve.php
@@ -71,7 +71,11 @@ class ProcessReserve extends BaseController
         return $process->withUpdatedData($input, $dateTime, $scope);
     }
 
-    public static function getValidatedForm($validator, $process)
+    /**
+     * @return (bool|mixed)[]
+     *
+     */
+    public static function getValidatedForm($validator, Process $process): array
     {
         $processValidator = new ProcessValidator($process);
         $delegatedProcess = $processValidator->getDelegatedProcess();

--- a/zmsadmin/src/Zmsadmin/ProcessSave.php
+++ b/zmsadmin/src/Zmsadmin/ProcessSave.php
@@ -76,7 +76,7 @@ class ProcessSave extends BaseController
         );
     }
 
-    protected function getSuccessMessage(Process $process)
+    protected function getSuccessMessage(Process $process): string
     {
         return ($process->isWithAppointment()) ? 'process_updated' : 'process_withoutappointment_updated';
     }
@@ -114,7 +114,7 @@ class ProcessSave extends BaseController
         return $process;
     }
 
-    private function shouldSendNotifications($requestData, Process $process)
+    private function shouldSendNotifications($requestData, Process $process): bool
     {
         $requestIds = $requestData['requests'] ?? [];
         $currentRequestIds = [];

--- a/zmsadmin/src/Zmsadmin/RoleAdd.php
+++ b/zmsadmin/src/Zmsadmin/RoleAdd.php
@@ -8,6 +8,9 @@ use BO\Zmsentities\Role;
 
 class RoleAdd extends BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,
         \Psr\Http\Message\ResponseInterface $response,

--- a/zmsadmin/src/Zmsadmin/RoleDelete.php
+++ b/zmsadmin/src/Zmsadmin/RoleDelete.php
@@ -7,6 +7,9 @@ use BO\Zmsentities\Exception\UserAccountMissingRights;
 
 class RoleDelete extends BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,
         \Psr\Http\Message\ResponseInterface $response,

--- a/zmsadmin/src/Zmsadmin/RoleEdit.php
+++ b/zmsadmin/src/Zmsadmin/RoleEdit.php
@@ -9,6 +9,9 @@ use BO\Zmsentities\Role;
 
 class RoleEdit extends BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,
         \Psr\Http\Message\ResponseInterface $response,

--- a/zmsadmin/src/Zmsadmin/Roles.php
+++ b/zmsadmin/src/Zmsadmin/Roles.php
@@ -11,6 +11,8 @@ class Roles extends BaseController
 {
     /**
      * @SuppressWarnings(Param)
+     *
+     * @return ResponseInterface
      */
     public function readResponse(
         RequestInterface $request,

--- a/zmsadmin/src/Zmsadmin/Scope.php
+++ b/zmsadmin/src/Zmsadmin/Scope.php
@@ -96,7 +96,7 @@ class Scope extends BaseController
         return $source;
     }
 
-    protected function writeUpdatedEntity($input, $entityId = null, Entity $existingScope = null, $workstation = null)
+    protected function writeUpdatedEntity(array $input, $entityId = null, Entity $existingScope = null, $workstation = null)
     {
         $entity = (new Entity($input))->withCleanedUpFormData();
         if ($workstation && !$workstation->getUseraccount()->hasPermissions(['scope'])) {
@@ -116,7 +116,7 @@ class Scope extends BaseController
         });
     }
 
-    protected function writeUploadedImage(\Psr\Http\Message\RequestInterface $request, $entityId, $input)
+    protected function writeUploadedImage(\Psr\Http\Message\RequestInterface $request, $entityId, array $input): void
     {
         if (isset($input['removeImage']) && $input['removeImage']) {
             \App::$http->readDeleteResult('/scope/' . $entityId . '/imagedata/calldisplay/');

--- a/zmsadmin/src/Zmsadmin/ScopeAppointmentsByDay.php
+++ b/zmsadmin/src/Zmsadmin/ScopeAppointmentsByDay.php
@@ -55,7 +55,7 @@ class ScopeAppointmentsByDay extends BaseController
          return $selectedDate ? new \DateTimeImmutable($selectedDate) : \App::$now;
     }
 
-    public static function readSelectedScope($workstation, $workstationRequest, $scopeId)
+    public static function readSelectedScope(\BO\Zmsentities\Workstation $workstation, \BO\Zmsclient\WorkstationRequests $workstationRequest, $scopeId)
     {
         if ($workstation->getScope()->id != $scopeId) {
             $scope = \App::$http->readGetResult('/scope/' . $scopeId . '/', [
@@ -66,7 +66,7 @@ class ScopeAppointmentsByDay extends BaseController
         return $workstationRequest->getScope();
     }
 
-    public static function readProcessList($workstationRequest, $selectedDateTime)
+    public static function readProcessList(\BO\Zmsclient\WorkstationRequests $workstationRequest, $selectedDateTime)
     {
         $processList = $workstationRequest->readProcessListByDate(
             $selectedDateTime,

--- a/zmsadmin/src/Zmsadmin/ScopeAppointmentsByDayXlsExport.php
+++ b/zmsadmin/src/Zmsadmin/ScopeAppointmentsByDayXlsExport.php
@@ -121,8 +121,13 @@ class ScopeAppointmentsByDayXlsExport extends BaseController
         return $value;
     }
 
-    /** @psalm-api */
-    protected function convertspecialchars($string)
+    /**
+     * @psalm-api
+     *
+     * @return string|string[]
+     *
+     */
+    protected function convertspecialchars(string $string): array|string
     {
 
         $convert = array (

--- a/zmsadmin/src/Zmsadmin/ScopeAvailabilityDay.php
+++ b/zmsadmin/src/Zmsadmin/ScopeAvailabilityDay.php
@@ -47,7 +47,11 @@ class ScopeAvailabilityDay extends BaseController
         ])->getEntity();
     }
 
-    protected static function getSlotBuckets($availabilityList, $processList)
+    /**
+     * @return (int|mixed)[][]
+     *
+     */
+    protected static function getSlotBuckets($availabilityList, $processList): array
     {
         $availability = $availabilityList->getFirst();
 
@@ -92,7 +96,11 @@ class ScopeAvailabilityDay extends BaseController
         return $buckets;
     }
 
-    protected static function getAvailabilityData($scopeId, $dateString)
+    /**
+     * @return (\BO\Zmsentities\Process[]|int|mixed|string)[]
+     *
+     */
+    protected static function getAvailabilityData(int $scopeId, $dateString): array
     {
         $scope = static::getScope($scopeId);
         $dateTime = new DateTime($dateString);
@@ -131,7 +139,7 @@ class ScopeAvailabilityDay extends BaseController
         ];
     }
 
-    public static function readConflictList($scopeId, $dateTime)
+    public static function readConflictList($scopeId, DateTime $dateTime)
     {
         $processConflictList = \App::$http
             ->readGetResult('/scope/' . $scopeId . '/conflict/', [
@@ -147,7 +155,7 @@ class ScopeAvailabilityDay extends BaseController
             ->toProcessList() : null;
     }
 
-    public static function readAvailabilityList($scopeId, $dateTime)
+    public static function readAvailabilityList($scopeId, DateTime $dateTime)
     {
         try {
             $availabilityList = \App::$http

--- a/zmsadmin/src/Zmsadmin/ScopeAvailabilityDay.php
+++ b/zmsadmin/src/Zmsadmin/ScopeAvailabilityDay.php
@@ -139,7 +139,7 @@ class ScopeAvailabilityDay extends BaseController
         ];
     }
 
-    public static function readConflictList($scopeId, DateTime $dateTime)
+    public static function readConflictList($scopeId, \DateTimeInterface $dateTime)
     {
         $processConflictList = \App::$http
             ->readGetResult('/scope/' . $scopeId . '/conflict/', [
@@ -155,7 +155,7 @@ class ScopeAvailabilityDay extends BaseController
             ->toProcessList() : null;
     }
 
-    public static function readAvailabilityList($scopeId, DateTime $dateTime)
+    public static function readAvailabilityList($scopeId, \DateTimeInterface $dateTime)
     {
         try {
             $availabilityList = \App::$http

--- a/zmsadmin/src/Zmsadmin/ScopeAvailabilityMonth.php
+++ b/zmsadmin/src/Zmsadmin/ScopeAvailabilityMonth.php
@@ -88,7 +88,7 @@ class ScopeAvailabilityMonth extends BaseController
         );
     }
 
-    protected function getAvailabilityList($scope, $startDate, $endDate)
+    protected function getAvailabilityList(\BO\Zmsentities\Schema\Entity $scope, $startDate, $endDate)
     {
         try {
             $availabilityList = \App::$http

--- a/zmsadmin/src/Zmsadmin/Search.php
+++ b/zmsadmin/src/Zmsadmin/Search.php
@@ -221,7 +221,7 @@ class Search extends BaseController
         return [$processList, $processListOther];
     }
 
-    private function filterProcessListForUserRights(?ProcessList $processList, array $scopeIds)
+    private function filterProcessListForUserRights(?ProcessList $processList, array $scopeIds): ProcessList
     {
         if (empty($processList)) {
             return new ProcessList();
@@ -242,7 +242,7 @@ class Search extends BaseController
         ?LogList $logList,
         array $scopeIds,
         bool $bypassScopeFilter = false
-    ) {
+    ): LogList {
         if (!isset($logList) || !$logList) {
             $logList = new LogList();
         }

--- a/zmsadmin/src/Zmsadmin/SourceEdit.php
+++ b/zmsadmin/src/Zmsadmin/SourceEdit.php
@@ -77,7 +77,7 @@ class SourceEdit extends BaseController
         );
     }
 
-    protected function writeUpdatedEntity($input)
+    protected function writeUpdatedEntity(array $input)
     {
         $entity = (new Source($input))->withCleanedUpFormData();
         return $this->handleEntityWrite(function () use ($entity) {

--- a/zmsadmin/src/Zmsadmin/UrlParameterSigning.php
+++ b/zmsadmin/src/Zmsadmin/UrlParameterSigning.php
@@ -63,6 +63,9 @@ class UrlParameterSigning extends BaseController
         return Render::withJson($response, $data);
     }
 
+    /**
+     * @return void
+     */
     private function testData($data)
     {
         if (!isset($data['section']) || !isset($data['parameters'])) {
@@ -70,6 +73,9 @@ class UrlParameterSigning extends BaseController
         }
     }
 
+    /**
+     * @return void
+     */
     private function testScopeList($organisation, $collections)
     {
         $scopeIds = [];
@@ -89,6 +95,9 @@ class UrlParameterSigning extends BaseController
         }
     }
 
+    /**
+     * @return void
+     */
     private function testClusterList($organisation, $collections)
     {
         $clusterIds = [];

--- a/zmsadmin/src/Zmsadmin/WorkstationProcessFinished.php
+++ b/zmsadmin/src/Zmsadmin/WorkstationProcessFinished.php
@@ -95,7 +95,7 @@ class WorkstationProcessFinished extends BaseController
     protected function getFinishedResponse(
         Workstation $workstation,
         ?Process $process = null
-    ) {
+    ): \BO\Slim\Response {
         $process ??= clone $workstation->getProcess();
         $process['status'] = ('pending' != $process['status']) ? 'finished' : $process['status'];
         \App::$http->readPostResult('/process/status/finished/', new Process($process))->getEntity();
@@ -107,6 +107,9 @@ class WorkstationProcessFinished extends BaseController
     }
 
 
+    /**
+     * @return void
+     */
     protected function testProcess(Workstation $workstation)
     {
         if (! $workstation->getProcess()->hasId()) {

--- a/zmsbackend/src/Zmsbackend/Api/Response/Message.php
+++ b/zmsbackend/src/Zmsbackend/Api/Response/Message.php
@@ -38,12 +38,12 @@ class Message implements \JsonSerializable
         $this->setUpdatedMetaData();
     }
 
-    public static function create(RequestInterface $request)
+    public static function create(RequestInterface $request): self
     {
         return new self($request);
     }
 
-    public function hasData()
+    public function hasData(): bool
     {
         return (
             ($this->data instanceof \BO\Zmsentities\Schema\Entity && $this->data->hasId())
@@ -66,7 +66,7 @@ class Message implements \JsonSerializable
         return ($header) ? $header : $jsonCompressLevel;
     }
 
-    protected function getGraphQL()
+    protected function getGraphQL(): GraphQLInterpreter|null
     {
         $validator = $this->request->getAttribute('validator');
         if ($validator) {
@@ -84,9 +84,8 @@ class Message implements \JsonSerializable
     /**
      * Update meta-data
      * check for data in response
-     *
      */
-    public function setUpdatedMetaData()
+    public function setUpdatedMetaData(): static
     {
         $this->meta->generated = date('c');
         $version = \BO\Zmsbackend\Helper\Version::getString();

--- a/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiclient.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiclient.php
@@ -12,6 +12,10 @@ class Apiclient extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Quer
      */
     const string TABLE = 'apiclient';
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -25,7 +29,7 @@ class Apiclient extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Quer
         return $mapping;
     }
 
-    public function addConditionApiclientKey($clientKey)
+    public function addConditionApiclientKey($clientKey): static
     {
         $this->query->where('apiclient.clientKey', '=', $clientKey);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Apikey/Repository/Apikey.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Repository/Apikey.php
@@ -14,6 +14,9 @@ class Apikey extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
 
     const string QUOTATABLE = 'apiquota';
 
+    /**
+     * @return void
+     */
     #[\Override]
     protected function addRequiredJoins()
     {
@@ -26,6 +29,10 @@ class Apikey extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
     }
 
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -39,7 +46,7 @@ class Apikey extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
         return $mapping;
     }
 
-    public function addConditionApikey($apikey)
+    public function addConditionApikey($apikey): static
     {
         $this->query->where('apikey.key', '=', $apikey);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiquota.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Repository/Apiquota.php
@@ -12,14 +12,14 @@ class Apiquota extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query
      */
     const string TABLE = 'apiquota';
 
-    public static function getQueryReadApiQuotaListByKey()
+    public static function getQueryReadApiQuotaListByKey(): string
     {
         return '
             SELECT * FROM `apiquota` WHERE `key` = :key
         ';
     }
 
-    public static function getQueryReadApiQuotaExpired($dateTime)
+    public static function getQueryReadApiQuotaExpired(\DateTimeInterface $dateTime): string
     {
         $timeStamp = $dateTime->getTimestamp();
         return '
@@ -33,6 +33,10 @@ class Apiquota extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query
         ';
     }
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -46,19 +50,19 @@ class Apiquota extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query
         return $mapping;
     }
 
-    public function addConditionQuotaId($quotaId)
+    public function addConditionQuotaId($quotaId): static
     {
         $this->query->where('apiquota.quotaid', '=', $quotaId);
         return $this;
     }
 
-    public function addConditionApikey($apikey)
+    public function addConditionApikey($apikey): static
     {
         $this->query->where('apiquota.key', '=', $apikey);
         return $this;
     }
 
-    public function addConditionRoute($route)
+    public function addConditionRoute($route): static
     {
         $this->query->where('apiquota.route', '=', $route);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Apikey/Service/Apiclient.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Service/Apiclient.php
@@ -8,7 +8,7 @@ class Apiclient extends \BO\Zmsbackend\Base
 {
     public static $cache = [];
 
-    public function readEntity($clientKey)
+    public function readEntity($clientKey): Entity
     {
         $query = new \BO\Zmsbackend\Apikey\Repository\Apiclient(\BO\Zmsbackend\Query\Base::SELECT);
         $query

--- a/zmsbackend/src/Zmsbackend/Apikey/Service/Apikey.php
+++ b/zmsbackend/src/Zmsbackend/Apikey/Service/Apikey.php
@@ -8,7 +8,7 @@ class Apikey extends \BO\Zmsbackend\Base
 {
     public static $cache = [];
 
-    public function readEntity($apiKey)
+    public function readEntity($apiKey): Entity
     {
         $query = new \BO\Zmsbackend\Apikey\Repository\Apikey(\BO\Zmsbackend\Query\Base::SELECT);
         $query

--- a/zmsbackend/src/Zmsbackend/Application.php
+++ b/zmsbackend/src/Zmsbackend/Application.php
@@ -86,8 +86,10 @@ class Application extends \BO\Slim\Application
     public static $data = '/data';
     public static $now = null;
 
-    /** @psalm-api */
-    public static function getNow()
+    /**
+     * @psalm-api
+     */
+    public static function getNow(): \DateTimeInterface
     {
         if (self::$now instanceof \DateTimeInterface) {
             return self::$now;

--- a/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilityClosureRead.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilityClosureRead.php
@@ -9,6 +9,9 @@ use DateTimeImmutable;
 
 class AvailabilityClosureRead extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,

--- a/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilityListByScope.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilityListByScope.php
@@ -47,20 +47,26 @@ class AvailabilityListByScope extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function getAvailabilityList($scope, $startDate, $endDate)
+    protected function getAvailabilityList(\BO\Zmsentities\Scope|null $scope, \BO\Zmsentities\Helper\DateTime|null $startDate, \BO\Zmsentities\Helper\DateTime|null $endDate)
     {
         $availabilityList = (new Query())->readList($scope->getId(), 0, $startDate, $endDate);
         $this->validateAvailabilityList($availabilityList);
         return $availabilityList->withScope($scope);
     }
 
-    protected function validateScope($scope)
+    /**
+     * @return void
+     */
+    protected function validateScope(\BO\Zmsentities\Scope|null $scope)
     {
         if (! $scope) {
             throw new \BO\Zmsbackend\Scope\Exception\ScopeNotFound();
         }
     }
 
+    /**
+     * @return void
+     */
     protected function validateAvailabilityList($availabilityList)
     {
         if (! $availabilityList->count()) {
@@ -68,7 +74,10 @@ class AvailabilityListByScope extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    protected function validateAccessRights($request, $scope)
+    /**
+     * @return void
+     */
+    protected function validateAccessRights(\Psr\Http\Message\RequestInterface $request, \BO\Zmsentities\Scope|null $scope)
     {
         try {
             (new \BO\Zmsbackend\Helper\User($request, 2))->checkPermissions(

--- a/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilityListUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilityListUpdate.php
@@ -99,7 +99,7 @@ class AvailabilityListUpdate extends \BO\Zmsbackend\Api\BaseController
         return $updatedAvailabilities;
     }
 
-    protected function updateAvailability($availability, $resolveReferences): ?Availability
+    protected function updateAvailability(Availability $availability, int $resolveReferences): ?Availability
     {
         $repository = new AvailabilityRepository();
         $updatedAvailability = null;

--- a/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilitySlotsUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Api/AvailabilitySlotsUpdate.php
@@ -62,7 +62,7 @@ class AvailabilitySlotsUpdate extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    public static function writeCalculatedSlots(Entity $availability, bool $checkConfigOnSave = false)
+    public static function writeCalculatedSlots(Entity $availability, bool $checkConfigOnSave = false): void
     {
         $config = (new ConfigRepository())->readEntity();
         if (

--- a/zmsbackend/src/Zmsbackend/Availability/Repository/Availability.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Repository/Availability.php
@@ -18,6 +18,9 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         SELECT OeffnungszeitID FROM oeffnungszeit WHERE OeffnungszeitID = :availabilityId FOR UPDATE
     ';
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function addRequiredJoins()
     {
@@ -29,6 +32,10 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
          );
     }
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping($type = null)
     {
@@ -83,6 +90,10 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $mapping;
     }
 
+    /**
+     * @return \BO\Zmsbackend\Query\Builder\Expression[]
+     *
+     */
     #[\Override]
     public function getReferenceMapping()
     {
@@ -91,19 +102,19 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         ];
     }
 
-    public function addConditionAvailabilityId($availabilityId)
+    public function addConditionAvailabilityId(int|string $availabilityId): static
     {
         $this->query->where('availability.OeffnungszeitID', '=', $availabilityId);
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->query->where('availabilityscope.StandortID', '=', $scopeId);
         return $this;
     }
 
-    public function addConditionAppointmentHours()
+    public function addConditionAppointmentHours(): static
     {
         $this->query
             ->where('availability.Terminanfangszeit', '!=', '00:00:00')
@@ -111,7 +122,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function addConditionOpeningHours()
+    public function addConditionOpeningHours(): static
     {
         $this->query
             ->where('availability.Anfangszeit', '!=', '00:00:00')
@@ -124,7 +135,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
      *
      * @psalm-api
      */
-    public function addConditionDoubleTypes()
+    public function addConditionDoubleTypes(): static
     {
         $this->query
             ->where('availability.Terminanfangszeit', '!=', '00:00:00')
@@ -134,7 +145,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function addConditionSkipOld(\DateTimeInterface $dateTime)
+    public function addConditionSkipOld(\DateTimeInterface $dateTime): static
     {
         $date = $dateTime->format('Y-m-d');
         $this->query
@@ -147,7 +158,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
      *
      * @psalm-api
      */
-    public function addConditionOnlyOld(\DateTimeInterface $dateTime)
+    public function addConditionOnlyOld(\DateTimeInterface $dateTime): static
     {
         $date = $dateTime->format('Y-m-d');
         $this->query
@@ -157,9 +168,8 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
 
    /**
      * Identify availabilities between two dates
-     *
      */
-    public function addConditionTimeframe(\DateTimeInterface $startDate, \DateTimeInterface $endDate)
+    public function addConditionTimeframe(\DateTimeInterface $startDate, \DateTimeInterface $endDate): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) use ($startDate, $endDate) {
             $condition
@@ -169,7 +179,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function addConditionDate(\DateTimeInterface $dateTime)
+    public function addConditionDate(\DateTimeInterface $dateTime): static
     {
         $date = $dateTime->format('Y-m-d');
         $this->query
@@ -207,7 +217,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function addConditionAppointmentTime(\DateTimeInterface $dateTime)
+    public function addConditionAppointmentTime(\DateTimeInterface $dateTime): static
     {
         $time = $dateTime->format('H:i:s');
         $this->query->where("availability.Terminanfangszeit", '<=', $time);
@@ -216,7 +226,11 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Availability $entity)
+    /**
+     * @return (int|mixed|string)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Availability $entity): array
     {
         $data = array();
         $data['StandortID'] = $entity->scope['id'];
@@ -267,7 +281,7 @@ class Availability extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
             return $data;
     }
 
-    public static function getJoinExpression($process, $availability)
+    public static function getJoinExpression(string $process, string $availability): \BO\Zmsbackend\Query\Builder\Expression
     {
         // UNIX_TIMESTAMP is relative here, no dependency to TIMEZONE
         return self::expression("

--- a/zmsbackend/src/Zmsbackend/Availability/Repository/Closure.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Repository/Closure.php
@@ -17,6 +17,10 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
      */
     protected $resolveLevel = 0;
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -30,8 +34,10 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         ];
     }
 
-    /** @psalm-api */
-    public function addConditionDate(DateTime $date)
+    /**
+     * @psalm-api
+     */
+    public function addConditionDate(DateTime $date): static
     {
         $this->query->where('closure.year', '=', $date->format('Y'));
         $this->query->where('closure.month', '=', $date->format('m'));
@@ -39,7 +45,7 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId(int $scopeId): static
     {
         $this->query->where('closure.StandortID', '=', $scopeId);
         return $this;
@@ -74,8 +80,10 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionDateRange(\DateTimeInterface $from, \DateTimeInterface $until)
+    /**
+     * @psalm-api
+     */
+    public function addConditionDateRange(\DateTimeInterface $from, \DateTimeInterface $until): static
     {
         $dateExpr = self::expression(
             "DATE(CONCAT(closure.year,'-',LPAD(closure.month,2,'0'),'-',LPAD(closure.day,2,'0')))"
@@ -85,7 +93,7 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addSelectVirtualDate()
+    public function addSelectVirtualDate(): static
     {
         $this->query->select([
             $this->getPrefixed('date') => self::expression(
@@ -95,7 +103,7 @@ class Closure extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionId($id)
+    public function addConditionId($id): static
     {
         $this->query->where('closure.id', '=', $id);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Availability/Service/Availability.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Service/Availability.php
@@ -12,7 +12,11 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
 {
     public static $cache = [];
 
-    public function readEntity($availabilityId, $resolveReferences = 0, $preferCache = false)
+    /**
+     * @param false|int|string $availabilityId
+     *
+     */
+    public function readEntity(string|int|false $availabilityId, int $resolveReferences = 0, $preferCache = false)
     {
         $cacheKey = "$availabilityId-$resolveReferences";
         if (!$preferCache || !array_key_exists($cacheKey, self::$cache)) {
@@ -28,6 +32,9 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
         return clone self::$cache[$cacheKey];
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(
         \BO\Zmsentities\Schema\Entity $entity,
@@ -66,7 +73,7 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
 
     public function readList(
         $scopeId,
-        $resolveReferences = 0,
+        int $resolveReferences = 0,
         \DateTimeInterface $startDate = null,
         \DateTimeInterface $endDate = null
     ) {
@@ -106,10 +113,10 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
 
     public function readAvailabilityListByScope(
         \BO\Zmsentities\Scope $scope,
-        $resolveReferences = 0,
+        int $resolveReferences = 0,
         \DateTimeImmutable $startDate = null,
         \DateTimeImmutable $endDate = null
-    ) {
+    ): Collection {
         $collection = new Collection();
         $query = new \BO\Zmsbackend\Availability\Repository\Availability(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -163,7 +170,7 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
     /*
     ** Returns a list of availabilities with end date older than 4 weeks
     */
-    public function readAvailabilityListBefore(\DateTimeImmutable $datetime, $resolveReferences = 0)
+    public function readAvailabilityListBefore(\DateTimeImmutable $datetime, $resolveReferences = 0): Collection
     {
         $collection = new Collection();
         $query = new \BO\Zmsbackend\Availability\Repository\Availability(\BO\Zmsbackend\Query\Base::SELECT);
@@ -184,7 +191,7 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
         return $collection;
     }
 
-    public function readOpeningHoursListByDate($scopeId, \DateTimeInterface $now, $resolveReferences = 0)
+    public function readOpeningHoursListByDate($scopeId, \DateTimeInterface $now, int $resolveReferences = 0): Collection
     {
         $collection = new Collection();
         $query = new \BO\Zmsbackend\Availability\Repository\Availability(\BO\Zmsbackend\Query\Base::SELECT);
@@ -248,8 +255,9 @@ class Availability extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfa
      * @param int|string $entityId
      *
      * @return Entity
+     *
      */
-    public function updateEntity($entityId, \BO\Zmsentities\Availability $entity, $resolveReferences = 0)
+    public function updateEntity($entityId, \BO\Zmsentities\Availability $entity, int $resolveReferences = 0)
     {
         self::$cache = [];
         $entity->testValid();

--- a/zmsbackend/src/Zmsbackend/Availability/Service/Closure.php
+++ b/zmsbackend/src/Zmsbackend/Availability/Service/Closure.php
@@ -40,7 +40,7 @@ class Closure extends \BO\Zmsbackend\Base
         return $closureList;
     }
 
-    public function readByScopeIdAndDate($scopeId, DateTime $date)
+    public function readByScopeIdAndDate($scopeId, DateTime $date): Entity
     {
         $query = new \BO\Zmsbackend\Availability\Repository\Closure(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -74,7 +74,7 @@ class Closure extends \BO\Zmsbackend\Base
         return $result ;
     }
 
-    public function deleteEntity($closure)
+    public function deleteEntity($closure): bool
     {
         $query = new \BO\Zmsbackend\Availability\Repository\Closure(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionId($closure->getId());
@@ -108,7 +108,7 @@ class Closure extends \BO\Zmsbackend\Base
         return $this->readEntity($id);
     }
 
-    public function readEntity($id)
+    public function readEntity(string|false $id): Entity
     {
         $query = new \BO\Zmsbackend\Availability\Repository\Closure(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()

--- a/zmsbackend/src/Zmsbackend/Base.php
+++ b/zmsbackend/src/Zmsbackend/Base.php
@@ -41,7 +41,7 @@ abstract class Base
         $this->readDb = $readConnection;
     }
 
-    public static function init(Connection\Pdo $writeConnection = null, Connection\Pdo $readConnection = null)
+    public static function init(Connection\Pdo $writeConnection = null, Connection\Pdo $readConnection = null): static
     {
         $instance = new static($writeConnection, $readConnection);
         return $instance;
@@ -68,7 +68,7 @@ abstract class Base
         return $this->readDb;
     }
 
-    public function fetchPreparedStatement($query)
+    public function fetchPreparedStatement(Query\Base|string $query)
     {
         $sql = "$query";
         $reader = $this->getReader();
@@ -84,7 +84,7 @@ abstract class Base
         return static::$preparedCache[$sql];
     }
 
-    public function startExecute($statement, $parameters)
+    public function startExecute($statement, array $parameters)
     {
         $statement = static::pdoExceptionHandler(function () use ($statement, $parameters) {
             $statement->execute($parameters);
@@ -142,7 +142,7 @@ abstract class Base
         return $entity;
     }
 
-    public function fetchRow($query, $parameters = null)
+    public function fetchRow(Query\Base|string $query, array|null $parameters = null)
     {
         return static::pdoExceptionHandler(function () use ($query, $parameters) {
             $prepared = $this->fetchPreparedStatement($query);
@@ -153,7 +153,7 @@ abstract class Base
         });
     }
 
-    public function fetchValue($query, $parameters = null)
+    public function fetchValue(Query\Base|string $query, array|null $parameters = null)
     {
         return static::pdoExceptionHandler(function () use ($query, $parameters) {
             $prepared = $this->fetchPreparedStatement($query);
@@ -164,7 +164,7 @@ abstract class Base
         });
     }
 
-    public function fetchAll($query, $parameters = null)
+    public function fetchAll(Query\Base|string $query, array|null $parameters = null)
     {
         return static::pdoExceptionHandler(function () use ($query, $parameters) {
             $prepared = $this->fetchPreparedStatement($query);
@@ -175,7 +175,7 @@ abstract class Base
         });
     }
 
-    public function fetchHandle($query, $parameters = null)
+    public function fetchHandle(Query\Base|string $query, array|null $parameters = null)
     {
         return static::pdoExceptionHandler(function () use ($query, $parameters) {
             $prepared = $this->fetchPreparedStatement($query);
@@ -184,7 +184,7 @@ abstract class Base
         });
     }
 
-    public function fetchList(Query\Base $query, \BO\Zmsentities\Schema\Entity $entity, $resultList = [])
+    public function fetchList(Query\Base $query, \BO\Zmsentities\Schema\Entity $entity, array|\ArrayAccess $resultList = [])
     {
         $statement = $this->fetchStatement($query);
         while ($data = $statement->fetch(\PDO::FETCH_ASSOC)) {
@@ -223,7 +223,7 @@ abstract class Base
         return $this->writeItem($query);
     }
 
-    public function perform($sql, $parameters = null)
+    public function perform(string $sql, array|null $parameters = null)
     {
         return static::pdoExceptionHandler(function () use ($sql, $parameters) {
             $this->getWriter(); //Switch to writer for perform
@@ -234,7 +234,7 @@ abstract class Base
         });
     }
 
-    public function fetchAffected($sql, $parameters = null)
+    public function fetchAffected(string $sql, array|null $parameters = null)
     {
         return static::pdoExceptionHandler(function () use ($sql, $parameters) {
             $this->getWriter(); //Switch to writer for perform
@@ -248,10 +248,12 @@ abstract class Base
 
     /**
      * @SuppressWarnings(Param)
+     *
      * @codeCoverageIgnore
      *
+     * @return \BO\Zmsentities\Schema\Entity
      */
-    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
+    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, int $resolveReferences)
     {
         return $entity;
     }

--- a/zmsbackend/src/Zmsbackend/Calendar/Api/OverallCalendarRead.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Api/OverallCalendarRead.php
@@ -11,6 +11,9 @@ use DateTimeImmutable;
 
 class OverallCalendarRead extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     #[\Override]
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,

--- a/zmsbackend/src/Zmsbackend/Calendar/Service/Calendar.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Service/Calendar.php
@@ -14,7 +14,7 @@ class Calendar extends \BO\Zmsbackend\Base
     public function readResolvedEntity(
         Entity $calendar,
         \DateTimeInterface $now,
-        bool|null $resolveOnlyScopes = false,
+        $resolveOnlyScopes = false,
         string $slotType = 'public',
         $slotsRequired = 0,
         bool $resolveScopeReferences = true

--- a/zmsbackend/src/Zmsbackend/Calendar/Service/Calendar.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Service/Calendar.php
@@ -14,10 +14,10 @@ class Calendar extends \BO\Zmsbackend\Base
     public function readResolvedEntity(
         Entity $calendar,
         \DateTimeInterface $now,
-        $resolveOnlyScopes = false,
-        $slotType = 'public',
+        bool|null $resolveOnlyScopes = false,
+        string $slotType = 'public',
         $slotsRequired = 0,
-        $resolveScopeReferences = true
+        bool $resolveScopeReferences = true
     ) {
         $calendar['freeProcesses'] = new \BO\Zmsentities\Collection\ProcessList();
         $calendar['scopes'] = $calendar->getScopeList();
@@ -38,9 +38,8 @@ class Calendar extends \BO\Zmsbackend\Base
 
     /**
      * Resolve calendar scopes
-     *
      */
-    protected function readResolvedScopes(Entity $calendar)
+    protected function readResolvedScopes(Entity $calendar): Entity
     {
         $scopeList = new \BO\Zmsentities\Collection\ScopeList();
         $scopeReader = new \BO\Zmsbackend\Scope\Service\Scope();
@@ -56,9 +55,8 @@ class Calendar extends \BO\Zmsbackend\Base
 
     /**
      * Resolve Reference dayoff for departments, but do not resolve circular scope->department->scopes
-     *
      */
-    protected function readResolvedScopeReferences(Entity $calendar)
+    protected function readResolvedScopeReferences(Entity $calendar): Entity
     {
         foreach ($calendar->scopes as $scope) {
             $scope['dayoff'] = (new \BO\Zmsbackend\Dayoff\Service\DayOff())->readByScopeId($scope['id']);
@@ -66,7 +64,7 @@ class Calendar extends \BO\Zmsbackend\Base
         return $calendar;
     }
 
-    protected function readResolvedRequests(Entity $calendar)
+    protected function readResolvedRequests(Entity $calendar): Entity
     {
         $requestReader = new \BO\Zmsbackend\Request\Service\Request();
         $requestRelationQuery = new \BO\Zmsbackend\RequestRelation\Service\RequestRelation();
@@ -96,7 +94,7 @@ class Calendar extends \BO\Zmsbackend\Base
         return $calendar;
     }
 
-    protected function readResolvedClusters(Entity $calendar)
+    protected function readResolvedClusters(Entity $calendar): Entity
     {
         $scopeReader = new \BO\Zmsbackend\Scope\Service\Scope();
         foreach ($calendar['clusters'] as $cluster) {
@@ -107,7 +105,7 @@ class Calendar extends \BO\Zmsbackend\Base
         return $calendar;
     }
 
-    protected function readResolvedProviders(Entity $calendar)
+    protected function readResolvedProviders(Entity $calendar): Entity
     {
         $scopeReader = new \BO\Zmsbackend\Scope\Service\Scope();
         $providerReader = new \BO\Zmsbackend\Provider\Service\Provider();
@@ -126,7 +124,7 @@ class Calendar extends \BO\Zmsbackend\Base
         \DateTimeInterface $now,
         $slotType,
         $slotsRequiredForce
-    ) {
+    ): Entity {
         if (!$resolveOnlyScopes) {
             $dayQuery = new \BO\Zmsbackend\Day\Service\Day();
             $dayList = $dayQuery->readByCalendar($calendar, $slotsRequiredForce);

--- a/zmsbackend/src/Zmsbackend/Calendar/Service/CalendarAvailability.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Service/CalendarAvailability.php
@@ -549,7 +549,7 @@ class CalendarAvailability extends \BO\Zmsbackend\Base
         return null;
     }
 
-    private function formatDayIso(mixed $day): string
+    private function formatDayIso(\BO\Zmsentities\Day $day): string
     {
         $dayData = $this->dayToArray($day);
 

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayQueue.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Api/CalldisplayQueue.php
@@ -62,7 +62,7 @@ class CalldisplayQueue extends \BO\Zmsbackend\Api\BaseController
     }
 
     // full queueList for calculation optimistic and estimated waiting Time and number of waiting clients
-    protected function readFullQueueList($calldisplay, $resolveReferences)
+    protected function readFullQueueList(\BO\Zmsentities\Calldisplay $calldisplay, int $resolveReferences): \BO\Zmsentities\Collection\QueueList
     {
         $queueList = new \BO\Zmsentities\Collection\QueueList();
         foreach ($calldisplay->getFullScopeList() as $scope) {
@@ -71,7 +71,7 @@ class CalldisplayQueue extends \BO\Zmsbackend\Api\BaseController
         return $queueList;
     }
 
-    protected function readQueueListFromScopeAndStatus($scope, $status, $resolveReferences)
+    protected function readQueueListFromScopeAndStatus($scope, $status, $resolveReferences): \BO\Zmsentities\Collection\QueueList
     {
         $query = new \BO\Zmsbackend\Process\Service\Process();
         return $query
@@ -81,7 +81,7 @@ class CalldisplayQueue extends \BO\Zmsbackend\Api\BaseController
     }
 
     // short queueList only with status called and processing
-    protected function readQueueListByStatus($calldisplay, $statusList, $resolveReferences)
+    protected function readQueueListByStatus(\BO\Zmsentities\Calldisplay $calldisplay, $statusList, int $resolveReferences): \BO\Zmsentities\Collection\QueueList
     {
         $queueList = new \BO\Zmsentities\Collection\QueueList();
         foreach ($calldisplay->getFullScopeList() as $scope) {

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Repository/Calldisplay.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Repository/Calldisplay.php
@@ -9,7 +9,7 @@ class Calldisplay extends \BO\Zmsbackend\Query\Base
      */
     const string TABLE = 'imagedata';
 
-    public function getQueryImage()
+    public function getQueryImage(): string
     {
         return 'SELECT imagename as name, imagecontent as data FROM `imagedata`
             WHERE `imagename` LIKE :name LIMIT 1';

--- a/zmsbackend/src/Zmsbackend/Calldisplay/Service/Calldisplay.php
+++ b/zmsbackend/src/Zmsbackend/Calldisplay/Service/Calldisplay.php
@@ -71,7 +71,11 @@ class Calldisplay extends \BO\Zmsbackend\Base
         return $organisation;
     }
 
-    public function readImage(Entity $entity)
+    /**
+     * @return (mixed|string)[]
+     *
+     */
+    public function readImage(Entity $entity): array
     {
         $name = $entity->getImageName();
         $image = null;
@@ -99,7 +103,7 @@ class Calldisplay extends \BO\Zmsbackend\Base
         return $image;
     }
 
-    public function readContactData(Entity $entity)
+    public function readContactData(Entity $entity): \BO\Zmsentities\Contact
     {
         $contact = new \BO\Zmsentities\Contact();
         $contactNames = [];

--- a/zmsbackend/src/Zmsbackend/Cli/Config.php
+++ b/zmsbackend/src/Zmsbackend/Cli/Config.php
@@ -11,6 +11,7 @@ class Config extends \BO\Zmsbackend\Base
     /**
      * @SuppressWarnings(Parameter)
      *
+     * @return void
      */
     public function cli(array $argv, \League\CLImate\CLImate $climate)
     {
@@ -50,21 +51,27 @@ class Config extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function testType($config, $type)
+    /**
+     * @return void
+     */
+    protected function testType(\BO\Zmsentities\Config $config, $type)
     {
         if (!$config->hasType($type)) {
             throw new \Exception("Could not find type of '$type'");
         }
     }
 
-    protected function testKey($config, $type, $key)
+    /**
+     * @return void
+     */
+    protected function testKey(\BO\Zmsentities\Config $config, $type, $key)
     {
         if (!$config->hasPreference($type, $key)) {
             throw new \Exception("Could not find preference of '$type.$key'");
         }
     }
 
-    protected function printType(\League\CLImate\CLImate $climate, $type, $subconfig)
+    protected function printType(\League\CLImate\CLImate $climate, $type, $subconfig): void
     {
         $climate->blue("[$type]");
         if (is_array($subconfig)) {
@@ -75,7 +82,7 @@ class Config extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function printValue(\League\CLImate\CLImate $climate, $key, $value)
+    protected function printValue(\League\CLImate\CLImate $climate, $key, $value): void
     {
         $padding = $climate->padding(25)->char(' ');
         $padding->label("\"$key\"")->result("= \"" . (string)$value . '"');

--- a/zmsbackend/src/Zmsbackend/Cli/Db.php
+++ b/zmsbackend/src/Zmsbackend/Cli/Db.php
@@ -10,7 +10,7 @@ class Db
 {
     public static $baseDSN = '';
 
-    public static function startExecuteSqlFile($file, $databaseName = null, $verbose = true)
+    public static function startExecuteSqlFile(string $file, $databaseName = null, bool $verbose = true): void
     {
         $databaseConnection = self::startUsingDatabase($databaseName, $verbose);
         $startedAt = microtime(true);
@@ -55,14 +55,20 @@ class Db
         }
     }
 
-    /** @psalm-api */
-    public static function executeSql($query, $databaseName = null)
+    /**
+     * @psalm-api
+     */
+    public static function executeSql($query, $databaseName = null): void
     {
         $databaseConnection = self::startUsingDatabase($databaseName, false);
         $databaseConnection->exec($query);
     }
 
-    public static function startUsingDatabase($databaseName = null, $verbose = true): \BO\Zmsbackend\Connection\Pdo
+    /**
+     * @param null|string $databaseName
+     *
+     */
+    public static function startUsingDatabase(string|null $databaseName = null, bool $verbose = true): \BO\Zmsbackend\Connection\Pdo
     {
         if (!self::$baseDSN) {
             self::$baseDSN = \BO\Zmsbackend\Connection\Select::$writeSourceName;
@@ -80,7 +86,7 @@ class Db
         return \BO\Zmsbackend\Connection\Select::getWriteConnection();
     }
 
-    public static function startTestDataImport($fixturesDirectory, $filename = 'mysql_zmsbo.sql')
+    public static function startTestDataImport($fixturesDirectory, $filename = 'mysql_zmsbo.sql'): void
     {
         $defaultDatabaseName = \BO\Zmsbackend\Connection\Select::$dbname_zms;
 
@@ -91,13 +97,13 @@ class Db
         self::startExecuteSqlFile($fixturesDirectory . '/' . $filename);
     }
 
-    public static function startConfigDataImport()
+    public static function startConfigDataImport(): void
     {
         $defaults = new \BO\Zmsentities\Config();
         (new \BO\Zmsbackend\Config\Service\Config())->updateEntity($defaults);
     }
 
-    public static function startMigrations($migrationList, $commit = true, ?string $phase = null)
+    public static function startMigrations($migrationList, $commit = true, ?string $phase = null): int
     {
         $migrationFiles = self::resolveMigrationFileList($migrationList);
         $migrationFiles = self::filterMigrationFilesByPhase($migrationFiles, $phase);
@@ -135,6 +141,9 @@ class Db
         return $addedMigrationCount;
     }
 
+    /**
+     * @return void
+     */
     public static function executeTestData(string $testName, string $step)
     {
         $fixturesDirectory = realpath(__DIR__ . '/../../../tests/Zmsbackend/Service/fixtures/');

--- a/zmsbackend/src/Zmsbackend/Cli/Info.php
+++ b/zmsbackend/src/Zmsbackend/Cli/Info.php
@@ -6,10 +6,10 @@ class Info extends \BO\Zmsbackend\Base
 {
     /**
      * @SuppressWarnings(Parameter)
-     * @codeCoverageIgnore
      *
+     * @codeCoverageIgnore
      */
-    public function cli(array $argv, \League\CLImate\CLImate $climate)
+    public function cli(array $argv, \League\CLImate\CLImate $climate): void
     {
         $version = \BO\Zmsbackend\Helper\Version::getString();
         $climate->out("API Version $version");

--- a/zmsbackend/src/Zmsbackend/Cli/Status.php
+++ b/zmsbackend/src/Zmsbackend/Cli/Status.php
@@ -6,10 +6,10 @@ class Status extends \BO\Zmsbackend\Base
 {
     /**
      * @SuppressWarnings(Parameter)
-     * @codeCoverageIgnore
      *
+     * @codeCoverageIgnore
      */
-    public function cli(array $argv, \League\CLImate\CLImate $climate)
+    public function cli(array $argv, \League\CLImate\CLImate $climate): void
     {
         $status = (new \BO\Zmsbackend\Status\Service\Status())->readEntity(\App::$now);
         $climate->json($status);

--- a/zmsbackend/src/Zmsbackend/Cluster/Repository/Cluster.php
+++ b/zmsbackend/src/Zmsbackend/Cluster/Repository/Cluster.php
@@ -9,7 +9,7 @@ class Cluster extends \BO\Zmsbackend\Query\Base
      */
     const string TABLE = 'standortcluster';
 
-    public function getQueryWriteAssignedScopes()
+    public function getQueryWriteAssignedScopes(): string
     {
         return '
             REPLACE INTO `clusterzuordnung`
@@ -19,7 +19,7 @@ class Cluster extends \BO\Zmsbackend\Query\Base
         ';
     }
 
-    public function getQueryDeleteAssignedScopes()
+    public function getQueryDeleteAssignedScopes(): string
     {
         return '
             DELETE FROM `clusterzuordnung`
@@ -28,8 +28,13 @@ class Cluster extends \BO\Zmsbackend\Query\Base
         ';
     }
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'id' => 'cluster.clusterID',
@@ -40,13 +45,13 @@ class Cluster extends \BO\Zmsbackend\Query\Base
         ];
     }
 
-    public function addConditionClusterId($clusterId)
+    public function addConditionClusterId($clusterId): static
     {
         $this->query->where('cluster.clusterID', '=', $clusterId);
         return $this;
     }
 
-    public function addConditionDepartmentId($departementId)
+    public function addConditionDepartmentId($departementId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('standort', 'scope'),
@@ -58,7 +63,7 @@ class Cluster extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('standort', 'scope'),
@@ -70,7 +75,11 @@ class Cluster extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Cluster $entity)
+    /**
+     * @return (int|mixed)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Cluster $entity): array
     {
         $data = array();
         $data['name'] = $entity->name;
@@ -84,6 +93,9 @@ class Cluster extends \BO\Zmsbackend\Query\Base
         return $data;
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function addRequiredJoins()
     {

--- a/zmsbackend/src/Zmsbackend/Cluster/Service/Cluster.php
+++ b/zmsbackend/src/Zmsbackend/Cluster/Service/Cluster.php
@@ -18,7 +18,7 @@ class Cluster extends \BO\Zmsbackend\Base
      * @param false|int|string $itemId
      *
      */
-    public function readEntity(string|int|false $itemId, int $resolveReferences = 0, bool $disableCache = false)
+    public function readEntity(string|int|false $itemId, int $resolveReferences = 0, $disableCache = false)
     {
         $cacheKey = "cluster-$itemId-$resolveReferences";
 

--- a/zmsbackend/src/Zmsbackend/Cluster/Service/Cluster.php
+++ b/zmsbackend/src/Zmsbackend/Cluster/Service/Cluster.php
@@ -14,7 +14,11 @@ use BO\Zmsentities\Collection\ClusterList as Collection;
  */
 class Cluster extends \BO\Zmsbackend\Base
 {
-    public function readEntity($itemId, $resolveReferences = 0, $disableCache = false)
+    /**
+     * @param false|int|string $itemId
+     *
+     */
+    public function readEntity(string|int|false $itemId, int $resolveReferences = 0, bool $disableCache = false)
     {
         $cacheKey = "cluster-$itemId-$resolveReferences";
 
@@ -45,6 +49,9 @@ class Cluster extends \BO\Zmsbackend\Base
         return $this->readResolvedReferences($cluster, $resolveReferences, $disableCache);
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(
         \BO\Zmsentities\Schema\Entity $entity,
@@ -65,7 +72,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readList($resolveReferences = 0)
+    public function readList($resolveReferences = 0): Collection
     {
         $clusterList = new Collection();
         $query = new \BO\Zmsbackend\Cluster\Repository\Cluster(\BO\Zmsbackend\Query\Base::SELECT);
@@ -84,7 +91,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $clusterList;
     }
 
-    public function readByScopeId($scopeId, $resolveReferences = 0)
+    public function readByScopeId($scopeId, int $resolveReferences = 0)
     {
         $query = new \BO\Zmsbackend\Cluster\Repository\Cluster(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -99,7 +106,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readByDepartmentId($departmentId, $resolveReferences = 0, $disableCache = false)
+    public function readByDepartmentId($departmentId, $resolveReferences = 0, $disableCache = false): Collection
     {
         $clusterList = new Collection();
         $query = new \BO\Zmsbackend\Cluster\Repository\Cluster(\BO\Zmsbackend\Query\Base::SELECT);
@@ -119,11 +126,15 @@ class Cluster extends \BO\Zmsbackend\Base
         return $clusterList;
     }
 
+    /**
+     * @param string[] $withEntities
+     *
+     */
     public function readQueueList(
         $clusterId,
         \DateTimeInterface $dateTime,
-        $resolveReferences = 0,
-        $withEntities = []
+        int $resolveReferences = 0,
+        array $withEntities = []
     ) {
         $cluster = $this->readEntity($clusterId, 1);
 
@@ -132,7 +143,7 @@ class Cluster extends \BO\Zmsbackend\Base
             ->withSortedWaitingTime();
     }
 
-    public function readOpenedScopeList($clusterId, \DateTimeInterface $dateTime)
+    public function readOpenedScopeList($clusterId, \DateTimeInterface $dateTime): \BO\Zmsentities\Collection\ScopeList
     {
         $scopeList = new \BO\Zmsentities\Collection\ScopeList();
         $cluster = $this->readEntity($clusterId, 1);
@@ -148,7 +159,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $scopeList;
     }
 
-    public function readEnabledScopeList($clusterId, \DateTimeInterface $dateTime)
+    public function readEnabledScopeList($clusterId, \DateTimeInterface $dateTime): \BO\Zmsentities\Collection\ScopeList
     {
         $scopeList = new \BO\Zmsentities\Collection\ScopeList();
         foreach ($this->readOpenedScopeList($clusterId, $dateTime) as $scope) {
@@ -202,7 +213,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $cluster;
     }
 
-    public function writeImageData($clusterId, \BO\Zmsentities\Mimepart $entity)
+    public function writeImageData($clusterId, \BO\Zmsentities\Mimepart $entity): \BO\Zmsentities\Mimepart
     {
         if ($entity->mime && $entity->content) {
             $this->deleteImage($clusterId);
@@ -223,7 +234,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readImageData($clusterId)
+    public function readImageData($clusterId): \BO\Zmsentities\Mimepart
     {
         $imageName = 'c_' . $clusterId . '_bild';
         $imageData = new \BO\Zmsentities\Mimepart();
@@ -300,7 +311,7 @@ class Cluster extends \BO\Zmsbackend\Base
         return $this->readEntity($clusterId, 1, true);
     }
 
-    protected function writeAssignedScopes($clusterId, $scopeList)
+    protected function writeAssignedScopes(string|false $clusterId, $scopeList): void
     {
         $cluster = $this->readEntity($clusterId);
         $this->perform(
@@ -322,7 +333,10 @@ class Cluster extends \BO\Zmsbackend\Base
         $this->removeCache($cluster);
     }
 
-    public function removeCache($cluster)
+    /**
+     * @return void
+     */
+    public function removeCache(Entity $cluster)
     {
         if (!\App::$cache || !isset($cluster->id)) {
             return;

--- a/zmsbackend/src/Zmsbackend/Config/Repository/Config.php
+++ b/zmsbackend/src/Zmsbackend/Config/Repository/Config.php
@@ -27,7 +27,7 @@ class Config extends \BO\Zmsbackend\Query\Base
             ';
 
 
-    public function addConditionName($itemName)
+    public function addConditionName($itemName): static
     {
         $this->query->where(self::TABLE . '.name', '=', $itemName);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Config/Service/Config.php
+++ b/zmsbackend/src/Zmsbackend/Config/Service/Config.php
@@ -11,7 +11,7 @@ class Config extends \BO\Zmsbackend\Base
      *
      * @return \BO\Zmsentities\Config
      */
-    public function readEntity($disableCache = false)
+    public function readEntity(bool $disableCache = false)
     {
         $cacheKey = "config";
 
@@ -32,7 +32,7 @@ class Config extends \BO\Zmsbackend\Base
         return $config;
     }
 
-    public function updateEntity(Entity $config)
+    public function updateEntity(Entity $config): Entity|null
     {
         $compareEntity = $this->readEntity(true);
         $result = false;
@@ -66,7 +66,7 @@ class Config extends \BO\Zmsbackend\Base
         return ($result) ? $this->readEntity(true) : null;
     }
 
-    public function readProperty($property, $forUpdate = false)
+    public function readProperty(string $property, bool $forUpdate = false)
     {
         $sql = \BO\Zmsbackend\Config\Repository\Config::QUERY_SELECT_PROPERTY;
         if ($forUpdate) {
@@ -75,7 +75,7 @@ class Config extends \BO\Zmsbackend\Base
         return $this->fetchValue($sql, [$property]);
     }
 
-    public function replaceProperty($property, $value)
+    public function replaceProperty(string $property, string $value)
     {
         if (App::$cache && App::$cache->has('config')) {
             App::$cache->delete('config');
@@ -105,7 +105,7 @@ class Config extends \BO\Zmsbackend\Base
         return $this->deleteItem($query);
     }
 
-    protected function fetchData($querySql)
+    protected function fetchData(string $querySql): Entity
     {
         $splittedHash = array();
         $dataList = $this->getReader()->fetchAll($querySql);
@@ -115,7 +115,7 @@ class Config extends \BO\Zmsbackend\Base
         return new Entity($splittedHash);
     }
 
-    protected function getSpecifiedValue($value)
+    protected function getSpecifiedValue($value): int|string
     {
         if (is_bool($value)) {
             return ($value) ? 1 : 0;

--- a/zmsbackend/src/Zmsbackend/Connection/Select.php
+++ b/zmsbackend/src/Zmsbackend/Connection/Select.php
@@ -102,7 +102,7 @@ class Select
      */
     protected static $useQueryCache = true;
 
-    protected static function sanitizeStackTrace($trace)
+    protected static function sanitizeStackTrace(string $trace)
     {
         return Sanitizer::sanitizeStackTrace($trace);
     }
@@ -138,7 +138,10 @@ class Select
      * Usually this function is only required to set mockups for testing
      *
      * @param PdoInterface $connection
+     *
      * @psalm-api
+     *
+     * @return void
      */
     public static function setReadConnection(PdoInterface $connection)
     {
@@ -175,18 +178,16 @@ class Select
 
     /**
      * Test if a read connection is established
-     *
      */
-    public static function hasReadConnection()
+    public static function hasReadConnection(): bool
     {
         return (null === self::$readConnection) ? false : true;
     }
 
     /**
      * Close a connection for reading data
-     *
      */
-    public static function closeReadConnection()
+    public static function closeReadConnection(): void
     {
         self::$readConnection = null;
     }
@@ -247,18 +248,16 @@ class Select
 
     /**
      * Test if a write connection is established
-     *
      */
-    public static function hasWriteConnection()
+    public static function hasWriteConnection(): bool
     {
         return (null === self::$writeConnection) ? false : true;
     }
 
     /**
      * Close a connection for writing data
-     *
      */
-    public static function closeWriteConnection()
+    public static function closeWriteConnection(): void
     {
         self::$writeConnection = null;
     }
@@ -267,9 +266,8 @@ class Select
      * Set query cache
      *
      * @param Bool $useQueryCache
-     *
      */
-    public static function setQueryCache($useQueryCache = true)
+    public static function setQueryCache($useQueryCache = true): void
     {
         static::$useQueryCache = $useQueryCache;
     }
@@ -278,18 +276,18 @@ class Select
      * Set profiling
      *
      * @param Bool $useProfiling
-     *
      */
-    public static function setProfiling($useProfiling = true)
+    public static function setProfiling($useProfiling = true): void
     {
         static::$useProfiling = $useProfiling;
     }
 
     /**
      * Set cluster wide causality checks, needed for critical reads across different nodes
+     *
      * @param Bool $wsrepStatus Set to true for critical reads
      */
-    public static function setCriticalReadSession($wsrepStatus = true)
+    public static function setCriticalReadSession($wsrepStatus = true): void
     {
         static::$enableWsrepSyncWait = $wsrepStatus;
         static::getWriteConnection();
@@ -299,18 +297,16 @@ class Select
      * Set transaction
      *
      * @param Bool $useTransaction
-     *
      */
-    public static function setTransaction($useTransaction = true)
+    public static function setTransaction($useTransaction = true): void
     {
         static::$useTransaction = $useTransaction;
     }
 
     /**
      * Rollback transaction if started
-     *
      */
-    public static function writeRollback()
+    public static function writeRollback(): bool|null
     {
         if (self::$useTransaction && self::getWriteConnection()->inTransaction()) {
             return self::getWriteConnection()->rollBack();
@@ -320,9 +316,8 @@ class Select
 
     /**
      * Commit transaction if started
-     *
      */
-    public static function writeCommit()
+    public static function writeCommit(): bool|null
     {
         if (self::$useTransaction && null !== self::$writeConnection && self::getWriteConnection()->inTransaction()) {
             $status = self::getWriteConnection()->commit();
@@ -332,7 +327,7 @@ class Select
         return null;
     }
 
-    public static function writeCommitWithStartLock()
+    public static function writeCommitWithStartLock(): bool
     {
         return self::writeCommit() && (new \BO\Zmsbackend\Config\Service\Config())->readProperty('status__calculateSlotsLastRun', true);
     }

--- a/zmsbackend/src/Zmsbackend/Day/Service/Day.php
+++ b/zmsbackend/src/Zmsbackend/Day/Service/Day.php
@@ -4,14 +4,11 @@ namespace BO\Zmsbackend\Day\Service;
 
 use BO\Zmsentities\Day as Entity;
 
-/**
- *
- */
 class Day extends \BO\Zmsbackend\Base
 {
     protected $tempScopeListExists = false;
 
-    public function writeTemporaryScopeList(\BO\Zmsentities\Calendar $calendar, $slotsRequiredForce = null)
+    public function writeTemporaryScopeList(\BO\Zmsentities\Calendar $calendar, $slotsRequiredForce = null): void
     {
         $this->getReader()->exec(\BO\Zmsbackend\Day\Repository\Day::QUERY_CREATE_TEMPORARY_SCOPELIST);
         $monthList = $calendar->getMonthList();
@@ -37,7 +34,7 @@ class Day extends \BO\Zmsbackend\Base
      * Drop and rebuild calendarscope for the calendar's current firstDay/lastDay months.
      * Used to shrink the daylist window (painted month) or scan one neighbor month at a time.
      */
-    public function rewriteTemporaryScopeList(\BO\Zmsentities\Calendar $calendar, $slotsRequiredForce = null)
+    public function rewriteTemporaryScopeList(\BO\Zmsentities\Calendar $calendar, $slotsRequiredForce = null): void
     {
         if ($this->tempScopeListExists) {
             $this->getReader()->exec(\BO\Zmsbackend\Day\Repository\Day::QUERY_DROP_TEMPORARY_SCOPELIST);
@@ -54,7 +51,7 @@ class Day extends \BO\Zmsbackend\Base
         return $this->readListFromPreparedTemporaryScopeList($slotsRequiredForce);
     }
 
-    public function readListFromPreparedTemporaryScopeList($slotsRequiredForce = null, ?string $daylistQuery = null)
+    public function readListFromPreparedTemporaryScopeList($slotsRequiredForce = null, ?string $daylistQuery = null): \BO\Zmsentities\Collection\DayList
     {
         $dayList = new \BO\Zmsentities\Collection\DayList();
         $dayData = $this->getReader()->fetchAll(

--- a/zmsbackend/src/Zmsbackend/Dayoff/Repository/DayOff.php
+++ b/zmsbackend/src/Zmsbackend/Dayoff/Repository/DayOff.php
@@ -14,6 +14,10 @@ class DayOff extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
      */
     protected $resolveLevel = 0;
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -25,38 +29,40 @@ class DayOff extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
         ];
     }
 
-    public function addConditionYear($year)
+    public function addConditionYear($year): static
     {
         $this->query->where(self::expression('YEAR(`dayOff`.`Datum`)'), '=', $year);
         return $this;
     }
 
-    public function addConditionDate($date)
+    public function addConditionDate(string $date): static
     {
         $this->query->where('dayOff`.`Datum', '=', $date);
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionName($name)
+    /**
+     * @psalm-api
+     */
+    public function addConditionName($name): static
     {
         $this->query->where('dayOff`.`Feiertag', '=', $name);
         return $this;
     }
 
-    public function addConditionCommon()
+    public function addConditionCommon(): static
     {
         $this->query->where('dayOff.BehoerdenID', '=', 0);
         return $this;
     }
 
-    public function addConditionDayOffId($itemId)
+    public function addConditionDayOffId($itemId): static
     {
         $this->query->where('dayOff.FeiertagID', '=', $itemId);
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('standort', 'scope_dayoff'),
@@ -68,13 +74,13 @@ class DayOff extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
         return $this;
     }
 
-    public function addConditionDepartmentId($departmentId)
+    public function addConditionDepartmentId($departmentId): static
     {
         $this->query->where('dayOff.BehoerdenID', '=', $departmentId);
         return $this;
     }
 
-    public function addConditionDayoffDeleteInterval($deleteInSeconds)
+    public function addConditionDayoffDeleteInterval($deleteInSeconds): static
     {
         $this->query->where(
             self::expression(

--- a/zmsbackend/src/Zmsbackend/Dayoff/Service/DayOff.php
+++ b/zmsbackend/src/Zmsbackend/Dayoff/Service/DayOff.php
@@ -123,7 +123,7 @@ class DayOff extends \BO\Zmsbackend\Base
         return $dayOffListCommon->addList($dayOffList);
     }
 
-    public function readByYear($year)
+    public function readByYear($year): Collection
     {
         $dayOffList = new Collection();
         $query = new \BO\Zmsbackend\Dayoff\Repository\DayOff(\BO\Zmsbackend\Query\Base::SELECT);
@@ -141,7 +141,7 @@ class DayOff extends \BO\Zmsbackend\Base
         return $dayOffList;
     }
 
-    public function readCommonByYear($year)
+    public function readCommonByYear($year): Collection
     {
         $dayOffList = new Collection();
         $query = new \BO\Zmsbackend\Dayoff\Repository\DayOff(\BO\Zmsbackend\Query\Base::SELECT);
@@ -170,7 +170,7 @@ class DayOff extends \BO\Zmsbackend\Base
      *
      * @return \BO\Zmsentities\Collection\DayoffList
      */
-    public function writeCommonDayoffsByYear($dayoffList, $year = null, $drop = true)
+    public function writeCommonDayoffsByYear($dayoffList, $year = null, bool $drop = true)
     {
         if ($drop && $year) {
             static::$commonList = null;
@@ -226,7 +226,7 @@ class DayOff extends \BO\Zmsbackend\Base
         $this->removeCache();
     }
 
-    public function deleteEntity($itemId)
+    public function deleteEntity($itemId): bool
     {
         $query = new \BO\Zmsbackend\Dayoff\Repository\DayOff(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionDayOffId($itemId);
@@ -236,6 +236,9 @@ class DayOff extends \BO\Zmsbackend\Base
         return ($this->deleteItem($query));
     }
 
+    /**
+     * @return void
+     */
     public function removeCache()
     {
         if (!App::$cache) {

--- a/zmsbackend/src/Zmsbackend/Department/Repository/Department.php
+++ b/zmsbackend/src/Zmsbackend/Department/Repository/Department.php
@@ -23,6 +23,10 @@ class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
         DELETE FROM email WHERE BehoerdenID=?
     ';
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -50,6 +54,9 @@ class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
         ];
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function addRequiredJoins()
     {
@@ -61,7 +68,7 @@ class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
         );
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('standort', 'scope_department'),
@@ -73,13 +80,13 @@ class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
         return $this;
     }
 
-    public function addConditionDepartmentId($departmentId)
+    public function addConditionDepartmentId($departmentId): static
     {
         $this->query->where('department.BehoerdenID', '=', $departmentId);
         return $this;
     }
 
-    public function addConditionDepartmentIds(array $departmentIds)
+    public function addConditionDepartmentIds(array $departmentIds): static
     {
         if (!empty($departmentIds)) {
             $this->query->whereIn('department.BehoerdenID', $departmentIds);
@@ -87,13 +94,17 @@ class Department extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
         return $this;
     }
 
-    public function addConditionOrganisationId($organisationId)
+    public function addConditionOrganisationId($organisationId): static
     {
         $this->query->where('department.OrganisationsID', '=', $organisationId);
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Department $entity, $parentId = null)
+    /**
+     * @return (mixed|string)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Department $entity, $parentId = null): array
     {
         $data = array();
         if (null !== $parentId) {

--- a/zmsbackend/src/Zmsbackend/Department/Service/Department.php
+++ b/zmsbackend/src/Zmsbackend/Department/Service/Department.php
@@ -14,7 +14,11 @@ class Department extends \BO\Zmsbackend\Base
 {
     public static $departmentCache = array();
 
-    public function readEntity($departmentId, $resolveReferences = 0, $disableCache = false)
+    /**
+     * @param false|string $departmentId
+     *
+     */
+    public function readEntity(string|false $departmentId, int $resolveReferences = 0, bool $disableCache = false)
     {
         $cacheKey = "department-$departmentId-$resolveReferences";
 
@@ -45,6 +49,9 @@ class Department extends \BO\Zmsbackend\Base
         return null;
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(
         \BO\Zmsentities\Schema\Entity $entity,
@@ -66,7 +73,7 @@ class Department extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readList($resolveReferences = 0)
+    public function readList($resolveReferences = 0): Collection
     {
         $departmentList = new Collection();
         $query = new \BO\Zmsbackend\Department\Repository\Department(\BO\Zmsbackend\Query\Base::SELECT);
@@ -84,7 +91,12 @@ class Department extends \BO\Zmsbackend\Base
         return $departmentList;
     }
 
-    public function readEntitiesByIds(array $departmentIds, $resolveReferences = 0)
+    /**
+     *
+     * @return Entity[]
+     *
+     */
+    public function readEntitiesByIds(array $departmentIds, int $resolveReferences = 0): array
     {
         if (empty($departmentIds)) {
             return [];
@@ -110,7 +122,7 @@ class Department extends \BO\Zmsbackend\Base
         return $departments;
     }
 
-    public function readByScopeId($scopeId, $resolveReferences = 0)
+    public function readByScopeId($scopeId, int $resolveReferences = 0)
     {
         $query = new \BO\Zmsbackend\Department\Repository\Department(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -121,7 +133,7 @@ class Department extends \BO\Zmsbackend\Base
         return (isset($department['id']) && $department['id']) ? $department->withOutClusterDuplicates() : null;
     }
 
-    public function readByOrganisationId($organisationId, $resolveReferences = 0)
+    public function readByOrganisationId($organisationId, int $resolveReferences = 0): Collection
     {
         $departmentList = new Collection();
         $query = new \BO\Zmsbackend\Department\Repository\Department(\BO\Zmsbackend\Query\Base::SELECT);
@@ -224,7 +236,12 @@ class Department extends \BO\Zmsbackend\Base
         return $this->readEntity($departmentId, 0, true);
     }
 
-    protected function writeDepartmentDayoffs($departmentId, $dayoffList)
+    /**
+     * @param false|string $departmentId
+     *
+     * @return void
+     */
+    protected function writeDepartmentDayoffs(string|false $departmentId, $dayoffList)
     {
         if (!$departmentId) {
             throw new \BO\Zmsbackend\Department\Exception\InvalidId();
@@ -250,7 +267,12 @@ class Department extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function writeDepartmentLinks($departmentId, $links)
+    /**
+     * @param false|string $departmentId
+     *
+     * @return void
+     */
+    protected function writeDepartmentLinks(string|false $departmentId, $links)
     {
         if (!$departmentId) {
             throw new \BO\Zmsbackend\Department\Exception\InvalidId();
@@ -270,8 +292,11 @@ class Department extends \BO\Zmsbackend\Base
         }
     }
 
+    /**
+     * @param false|string $departmentId
+     */
     protected function updateDepartmentMail(
-        $departmentId,
+        string|false $departmentId,
         $email,
         $sendEmailReminderEnabled,
         $sendEmailReminderMinutesBefore
@@ -290,7 +315,7 @@ class Department extends \BO\Zmsbackend\Base
         $departmentId,
         \DateTimeInterface $dateTime,
         $resolveReferences = 0
-    ) {
+    ): \BO\Zmsentities\Collection\QueueList {
         $queueList = new \BO\Zmsentities\Collection\QueueList();
         $department = $this->readEntity($departmentId, 2);
 
@@ -305,7 +330,10 @@ class Department extends \BO\Zmsbackend\Base
         return $queueList;
     }
 
-    public function removeCache($department)
+    /**
+     * @return void
+     */
+    public function removeCache(Entity $department)
     {
         if (!\App::$cache || !isset($department->id)) {
             return;

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeWaitingscope.php
@@ -289,7 +289,7 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Query\Base
      * For backward compatibility on db table optimization, we have to convert the field name
      * Drawback: No prepared statement using the date
      */
-    public static function getQuerySelectByDateTime(\DateTimeInterface $date, bool $withAppointment = false)
+    public static function getQuerySelectByDateTime(\DateTimeInterface $date, bool $withAppointment = false): string
     {
         $hourSuffix = $withAppointment ? 'appointment' : 'spontaneous';
 
@@ -321,7 +321,7 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Query\Base
      * For backward compatibility on db table optimization, we have to convert the field name
      * Drawback: No prepared statement using the date
      */
-    public static function getQueryUpdateByDateTime(\DateTimeInterface $date, bool $withAppointment = false)
+    public static function getQueryUpdateByDateTime(\DateTimeInterface $date, bool $withAppointment = false): string
     {
         $hourSuffix = $withAppointment ? 'appointment' : 'spontaneous';
 

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientdepartment.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientdepartment.php
@@ -17,7 +17,7 @@ class ExchangeClientdepartment extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $department = (new \BO\Zmsbackend\Department\Service\Department())->readEntity($subjectid);
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readByDepartmentId($subjectid);
         $entity = new Exchange();
@@ -51,7 +51,7 @@ class ExchangeClientdepartment extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeClientdepartment::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -68,7 +68,7 @@ class ExchangeClientdepartment extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $department = (new \BO\Zmsbackend\Department\Service\Department())->readEntity($subjectid);
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readByDepartmentId($subjectid);

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientorganisation.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientorganisation.php
@@ -17,7 +17,7 @@ class ExchangeClientorganisation extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Kundenstatistik $organisation->name";
@@ -50,7 +50,7 @@ class ExchangeClientorganisation extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeClientorganisation::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -65,7 +65,7 @@ class ExchangeClientorganisation extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readEntity($subjectid);
         $entity = new Exchange();

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientowner.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientowner.php
@@ -17,7 +17,7 @@ class ExchangeClientowner extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $owner = (new \BO\Zmsbackend\Owner\Service\Owner())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Kundenstatistik $owner->name";
@@ -50,7 +50,7 @@ class ExchangeClientowner extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeClientowner::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -65,7 +65,7 @@ class ExchangeClientowner extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $owner = (new \BO\Zmsbackend\Owner\Service\Owner())->readEntity($subjectid);
         $entity = new Exchange();

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeClientscope.php
@@ -17,7 +17,7 @@ class ExchangeClientscope extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Kundenstatistik " . (($scope && $scope->contact) ? $scope->contact->name : 'Unknown') . " " . ($scope ? $scope->shortName : 'Unknown');
@@ -82,7 +82,7 @@ class ExchangeClientscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeClientscope::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -98,7 +98,7 @@ class ExchangeClientscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectid);
         $entity = new Exchange();

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestdepartment.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestdepartment.php
@@ -17,7 +17,7 @@ class ExchangeRequestdepartment extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $department = (new \BO\Zmsbackend\Department\Service\Department())->readEntity($subjectid);
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readByDepartmentId($subjectid);
         $entity = new Exchange();
@@ -50,7 +50,7 @@ class ExchangeRequestdepartment extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeRequestdepartment::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -67,7 +67,7 @@ class ExchangeRequestdepartment extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $department = (new \BO\Zmsbackend\Department\Service\Department())->readEntity($subjectid);
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readByDepartmentId($subjectid);

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestorganisation.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestorganisation.php
@@ -17,7 +17,7 @@ class ExchangeRequestorganisation extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Dienstleistungsstatistik $organisation->name";
@@ -48,7 +48,7 @@ class ExchangeRequestorganisation extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeRequestorganisation::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -64,7 +64,7 @@ class ExchangeRequestorganisation extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readEntity($subjectid);
         $entity = new Exchange();

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestowner.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestowner.php
@@ -17,7 +17,7 @@ class ExchangeRequestowner extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $owner = (new \BO\Zmsbackend\Owner\Service\Owner())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Dienstleistungsstatistik $owner->name";
@@ -48,7 +48,7 @@ class ExchangeRequestowner extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeRequestowner::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -64,7 +64,7 @@ class ExchangeRequestowner extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $owner = (new \BO\Zmsbackend\Owner\Service\Owner())->readEntity($subjectid);
         $entity = new Exchange();

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestscope.php
@@ -17,7 +17,7 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Base
         \DateTimeInterface $datestart,
         \DateTimeInterface $dateend,
         $period = 'day'
-    ) {
+    ): Exchange {
         $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Dienstleistungsstatistik " . $scope->contact->name . " " . $scope->shortName;
@@ -49,7 +49,7 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeRequestscope::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -65,7 +65,7 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectid);
         $entity = new Exchange();

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeSimpleQuery.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeSimpleQuery.php
@@ -6,7 +6,7 @@ use BO\Zmsentities\Exchange;
 
 abstract class ExchangeSimpleQuery extends \BO\Zmsbackend\Base
 {
-    protected function fetchDataSet(Exchange $entity, $sql)
+    protected function fetchDataSet(Exchange $entity, string $sql): Exchange
     {
         $raw = $this
             ->getReader()

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeSlotscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeSlotscope.php
@@ -8,7 +8,7 @@ class ExchangeSlotscope extends \BO\Zmsbackend\Base
 {
     public function readEntity(
         $subjectid
-    ) {
+    ): Exchange {
         $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectid);
         $entity = new Exchange();
         $entity['title'] = "Slotbelegung " . $scope->contact->name . " " . $scope->shortName;
@@ -37,7 +37,7 @@ class ExchangeSlotscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $raw = $this->getReader()->fetchAll(\BO\Zmsbackend\Exchange\Repository\ExchangeSlotscope::QUERY_SUBJECTS, []);
         $entity = new Exchange();
@@ -55,7 +55,7 @@ class ExchangeSlotscope extends \BO\Zmsbackend\Base
     /**
      * @SuppressWarnings(Unused)
      */
-    public function readPeriodList($subjectid, $period = 'day')
+    public function readPeriodList($subjectid, $period = 'day'): Exchange
     {
         $entity = new Exchange();
         $entity['title'] = "Slotbelegung ";

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeUnassignedscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeUnassignedscope.php
@@ -6,7 +6,7 @@ use BO\Zmsentities\Exchange;
 
 class ExchangeUnassignedscope extends \BO\Zmsbackend\Base
 {
-    public function readEntity()
+    public function readEntity(): Exchange
     {
         $entity = new Exchange();
         $entity['title'] = "Nicht der DLDB zugeordnete Standorte mit Terminen";
@@ -24,7 +24,7 @@ class ExchangeUnassignedscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSubjectList()
+    public function readSubjectList(): Exchange
     {
         $entity = new Exchange();
         $entity['title'] = "Nicht der DLDB zugeordnete Standorte mit Terminen";
@@ -37,7 +37,7 @@ class ExchangeUnassignedscope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readPeriodList()
+    public function readPeriodList(): Exchange
     {
         $entity = new Exchange();
         $entity['title'] = "Nicht der DLDB zugeordnete Standorte mit Terminen";

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingdepartment.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingdepartment.php
@@ -6,6 +6,9 @@ use BO\Zmsentities\Exchange;
 
 class ExchangeWaitingdepartment extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\ExchangeSubject
 {
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readEntity(
         $subjectid,
@@ -63,6 +66,9 @@ class ExchangeWaitingdepartment extends \BO\Zmsbackend\Base implements \BO\Zmsba
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readSubjectList()
     {
@@ -81,6 +87,9 @@ class ExchangeWaitingdepartment extends \BO\Zmsbackend\Base implements \BO\Zmsba
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readPeriodList($subjectid, $period = 'day')
     {

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingorganisation.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingorganisation.php
@@ -6,6 +6,9 @@ use BO\Zmsentities\Exchange;
 
 class ExchangeWaitingorganisation extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\ExchangeSubject
 {
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readEntity(
         $subjectid,
@@ -65,6 +68,9 @@ class ExchangeWaitingorganisation extends \BO\Zmsbackend\Base implements \BO\Zms
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readSubjectList()
     {
@@ -83,6 +89,9 @@ class ExchangeWaitingorganisation extends \BO\Zmsbackend\Base implements \BO\Zms
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readPeriodList($subjectid, $period = 'day')
     {

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingowner.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingowner.php
@@ -6,6 +6,9 @@ use BO\Zmsentities\Exchange;
 
 class ExchangeWaitingowner extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\ExchangeSubject
 {
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readEntity(
         $subjectid,
@@ -65,6 +68,9 @@ class ExchangeWaitingowner extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readSubjectList()
     {
@@ -83,6 +89,9 @@ class ExchangeWaitingowner extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readPeriodList($subjectid, $period = 'day')
     {

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeWaitingscope.php
@@ -6,6 +6,9 @@ use BO\Zmsentities\Exchange;
 
 class ExchangeWaitingscope extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\ExchangeSubject
 {
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readEntity(
         $subjectid,
@@ -62,6 +65,9 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readSubjectList()
     {
@@ -79,6 +85,9 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
         return $entity;
     }
 
+    /**
+     * @return Exchange
+     */
     #[\Override]
     public function readPeriodList($subjectid, $period = 'day')
     {
@@ -149,7 +158,7 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
         \BO\Zmsentities\Scope $scope,
         \DateTimeInterface $now,
         bool $isWithAppointment = false
-    ) {
+    ): static {
         if ($now > (new \DateTime())) {
             return $this;
         }
@@ -183,7 +192,7 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
     public function writeWaitingTime(
         \BO\Zmsentities\Process $process,
         \DateTimeInterface $now
-    ) {
+    ): static {
         if ($now > (new \DateTime())) {
             return $this;
         }
@@ -218,7 +227,7 @@ class ExchangeWaitingscope extends \BO\Zmsbackend\Base implements \BO\Zmsbackend
     public function updateWaitingStatistics(
         \BO\Zmsentities\Process $process,
         \DateTimeInterface $now
-    ) {
+    ): static {
         if ($now > (new \DateTime())) {
             return $this;
         }

--- a/zmsbackend/src/Zmsbackend/Helper/AnonymizeStatisticDataByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/AnonymizeStatisticDataByCron.php
@@ -33,7 +33,7 @@ class AnonymizeStatisticDataByCron
         }
     }
 
-    public function startAnonymizing(\DateTimeImmutable $currentDate, $commit = false)
+    public function startAnonymizing(\DateTimeImmutable $currentDate, $commit = false): void
     {
         // Adjust the currentDate based on the numeric timespan
         $targetDate = $currentDate->modify("-{$this->timespan} days");

--- a/zmsbackend/src/Zmsbackend/Helper/ApiQuotaDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/ApiQuotaDeleteByCron.php
@@ -20,7 +20,7 @@ class ApiQuotaDeleteByCron
         $this->quotaList = $query->readExpiredQuotaListByPeriod($dateTime);
     }
 
-    public function startProcessing($commit)
+    public function startProcessing($commit): void
     {
         $verbose = $this->verbose;
         if ($this->quotaList) {
@@ -37,7 +37,7 @@ class ApiQuotaDeleteByCron
         }
     }
 
-    protected function removeQuota($quotaId)
+    protected function removeQuota($quotaId): void
     {
         $verbose = $this->verbose;
         if (! $verbose) {

--- a/zmsbackend/src/Zmsbackend/Helper/AppointmentDeallocateByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/AppointmentDeallocateByCron.php
@@ -32,7 +32,7 @@ class AppointmentDeallocateByCron
         }
     }
 
-    protected function log($message, string $level = 'info')
+    protected function log(string $message, string $level = 'info'): void
     {
         $this->writeVerboseCronLog($message, $level);
     }
@@ -42,24 +42,24 @@ class AppointmentDeallocateByCron
         return $this->count;
     }
 
-    public function setLimit($limit)
+    public function setLimit($limit): void
     {
         $this->limit = $limit;
     }
 
-    public function setLoopCount($loopCount)
+    public function setLoopCount($loopCount): void
     {
         $this->loopCount = $loopCount;
     }
 
-    public function startProcessing($commit)
+    public function startProcessing($commit): void
     {
         $this->count['deallocated'] = 0;
         $this->deallocateProcessList($commit);
         $this->log("\nSUMMARY: Deallocated processes: " . var_export($this->count, true));
     }
 
-    protected function deallocateProcessList($commit)
+    protected function deallocateProcessList($commit): void
     {
         $this->log("\nDeallocate cancelled processes");
         $count = $this->deleteByCallback($commit, function ($limit, $offset) {
@@ -70,7 +70,7 @@ class AppointmentDeallocateByCron
         $this->count["deallocated"] += $count;
     }
 
-    protected function deleteByCallback($commit, \Closure $callback)
+    protected function deleteByCallback($commit, \Closure $callback): int
     {
         $processCount = 0;
         $startposition = 0;
@@ -89,7 +89,7 @@ class AppointmentDeallocateByCron
         return $processCount;
     }
 
-    protected function handleProcess(\BO\Zmsentities\Process $process, $commit, $processCount)
+    protected function handleProcess(\BO\Zmsentities\Process $process, $commit, int $processCount): int
     {
         $verbose = $this->verbose;
         if (in_array($process->status, $this->statuslist)) {
@@ -108,7 +108,7 @@ class AppointmentDeallocateByCron
      * It is important to know that the slots in writeBlockedEntity are unblocked again,
      * but the ID remains blocked until the next day
      */
-    protected function writeDeallocatedProcess(\BO\Zmsentities\Process $process)
+    protected function writeDeallocatedProcess(\BO\Zmsentities\Process $process): void
     {
         $verbose = $this->verbose;
         $query = new \BO\Zmsbackend\Process\Service\Process();

--- a/zmsbackend/src/Zmsbackend/Helper/AppointmentDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/AppointmentDeleteByCron.php
@@ -53,7 +53,7 @@ class AppointmentDeleteByCron
         }
     }
 
-    protected function log($message, string $level = 'info')
+    protected function log(string $message, string $level = 'info'): void
     {
         $this->writeVerboseCronLog($message, $level);
     }
@@ -63,17 +63,17 @@ class AppointmentDeleteByCron
         return $this->count;
     }
 
-    public function setLimit($limit)
+    public function setLimit($limit): void
     {
         $this->limit = $limit;
     }
 
-    public function setLoopCount($loopCount)
+    public function setLoopCount($loopCount): void
     {
         $this->loopCount = $loopCount;
     }
 
-    public function startProcessing($commit, $pending = false)
+    public function startProcessing($commit, $pending = false): void
     {
         if ($pending) {
             $this->statuslist[] = "pending";
@@ -84,7 +84,7 @@ class AppointmentDeleteByCron
         $this->log("\nSUMMARY: Deleted processes: " . var_export($this->count, true));
     }
 
-    protected function deleteExpiredProcesses($commit)
+    protected function deleteExpiredProcesses($commit): void
     {
         foreach ($this->statuslist as $status) {
             $this->log("\nDelete expired processes with status $status:");
@@ -97,7 +97,7 @@ class AppointmentDeleteByCron
         }
     }
 
-    protected function deleteBlockedProcesses($commit)
+    protected function deleteBlockedProcesses($commit): void
     {
         $this->log("\nDelete blocked processes in the future:");
         $count = $this->deleteByCallback($commit, function ($limit, $offset) {
@@ -108,7 +108,7 @@ class AppointmentDeleteByCron
         $this->count["blocked"] += $count;
     }
 
-    protected function deleteByCallback($commit, \Closure $callback)
+    protected function deleteByCallback($commit, \Closure $callback): int
     {
         $processCount = 0;
         $startposition = 0;
@@ -127,7 +127,7 @@ class AppointmentDeleteByCron
         return $processCount;
     }
 
-    protected function removeProcess(\BO\Zmsentities\Process $process, $commit, $processCount)
+    protected function removeProcess(\BO\Zmsentities\Process $process, $commit, int $processCount): int
     {
         $verbose = $this->verbose;
         if (in_array($process->status, $this->statuslist)) {
@@ -149,7 +149,7 @@ class AppointmentDeleteByCron
         return 0;
     }
 
-    protected function updateProcessStatus(\BO\Zmsentities\Process $process)
+    protected function updateProcessStatus(\BO\Zmsentities\Process $process): \BO\Zmsentities\Process
     {
         if (in_array($process->status, ["confirmed", "queued", "called"])) {
             $process->status = 'missed';
@@ -170,7 +170,7 @@ class AppointmentDeleteByCron
         return true;
     }
 
-    protected function archiveProcess(\BO\Zmsentities\Process $process)
+    protected function archiveProcess(\BO\Zmsentities\Process $process): void
     {
         $verbose = $this->verbose;
         $now = new \DateTimeImmutable();
@@ -181,7 +181,7 @@ class AppointmentDeleteByCron
         }
     }
 
-    protected function deleteProcess(\BO\Zmsentities\Process $process)
+    protected function deleteProcess(\BO\Zmsentities\Process $process): void
     {
         $verbose = $this->verbose;
         $query = new \BO\Zmsbackend\Process\Service\Process();

--- a/zmsbackend/src/Zmsbackend/Helper/ArchivedDataIntoStatisticByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/ArchivedDataIntoStatisticByCron.php
@@ -72,7 +72,7 @@ class ArchivedDataIntoStatisticByCron
         return $this->archivedList;
     }
 
-    protected function logMessage($message, string $level = 'info')
+    protected function logMessage(string $message, string $level = 'info'): void
     {
         $this->writeVerboseCronLog($message, $level);
     }
@@ -84,9 +84,9 @@ class ArchivedDataIntoStatisticByCron
         $department,
         $organisation,
         $owner,
-        $dateTime,
+        \DateTimeImmutable|false $dateTime,
         bool $commit = false
-    ) {
+    ): void {
         $requestIds = (new \BO\Zmsbackend\Request\Service\Request())
             ->readRequestIdsByArchiveId($process->archiveId);
         $processingTime = null;

--- a/zmsbackend/src/Zmsbackend/Helper/AvailabilityDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/AvailabilityDeleteByCron.php
@@ -18,7 +18,7 @@ class AvailabilityDeleteByCron
         }
     }
 
-    public function startProcessing(\DateTimeImmutable $datetime, $commit = false)
+    public function startProcessing(\DateTimeImmutable $datetime, $commit = false): void
     {
         $availabilityList = $this->query->readAvailabilityListBefore($datetime);
         if ($this->verbose) {
@@ -33,7 +33,7 @@ class AvailabilityDeleteByCron
         }
     }
 
-    protected function deleteAvailability(string $availabilityId)
+    protected function deleteAvailability(string $availabilityId): void
     {
         if ($this->query->deleteEntity($availabilityId)) {
             if ($this->verbose) {

--- a/zmsbackend/src/Zmsbackend/Helper/AvailabilitySnapShot.php
+++ b/zmsbackend/src/Zmsbackend/Helper/AvailabilitySnapShot.php
@@ -21,7 +21,7 @@ class AvailabilitySnapShot
         $this->dateTime = $dateTime;
     }
 
-    public function hasOutdatedAvailability()
+    public function hasOutdatedAvailability(): bool
     {
         // Lower compared date by one second to make a "<=" comparision
         return $this->availability->isNewerThan($this->dateTime->modify("-1 second"));
@@ -40,29 +40,29 @@ class AvailabilitySnapShot
         return $this->availability->scope->dayoff->isNewerThan($this->dateTime, $this->availability, $this->dateTime);
     }
 
-    public function hasBookableDateTime(\DateTimeInterface $proposedDateTime)
+    public function hasBookableDateTime(\DateTimeInterface $proposedDateTime): bool
     {
         return $this->availability->hasDate($proposedDateTime, $this->dateTime);
     }
 
-    public function getLastBookableDateTime()
+    public function getLastBookableDateTime(): \DateTimeInterface
     {
         return $this->availability->getBookableEnd($this->dateTime);
     }
 
-    public function isOpenedOnLastBookableDay()
+    public function isOpenedOnLastBookableDay(): bool
     {
         return $this->availability->isOpenedOnDate($this->availability->getBookableEnd($this->dateTime));
     }
 
-    public function isTimeOpenedOnLastBookableDay()
+    public function isTimeOpenedOnLastBookableDay(): bool
     {
         return $this->availability->isOpened(
             $this->availability->getBookableEnd($this->dateTime)->modify($this->dateTime->format('H:i:s'))
         );
     }
 
-    public function hasBookableDateTimeAfter(\DateTimeInterface $proposedDateTime)
+    public function hasBookableDateTimeAfter(\DateTimeInterface $proposedDateTime): bool
     {
         return $this->availability->hasDateBetween(
             $proposedDateTime,

--- a/zmsbackend/src/Zmsbackend/Helper/CalculateDailyWaitingStatisticByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/CalculateDailyWaitingStatisticByCron.php
@@ -14,7 +14,7 @@ use DateTimeImmutable;
  */
 class CalculateDailyWaitingStatisticByCron extends \BO\Zmsbackend\Base
 {
-    public function run(DateTimeImmutable $day, bool $commit = false)
+    public function run(DateTimeImmutable $day, bool $commit = false): void
     {
                     \App::$log->info('CalculateDailyWaitingStatisticByCron started', ['date' => $day->format('Y-m-d')]);
 

--- a/zmsbackend/src/Zmsbackend/Helper/CalculateDayOff.php
+++ b/zmsbackend/src/Zmsbackend/Helper/CalculateDayOff.php
@@ -37,7 +37,7 @@ class CalculateDayOff
         $this->verbose = $verbose;
     }
 
-    protected function calculateDayOffByYear($year)
+    protected function calculateDayOffByYear($year): \BO\Zmsentities\Collection\DayoffList
     {
         $collection = new \BO\Zmsentities\Collection\DayoffList();
         $dateEaster = $this->calculateEaster($year);
@@ -62,7 +62,7 @@ class CalculateDayOff
         return $collection;
     }
 
-    protected function calculateEaster($year)
+    protected function calculateEaster($year): \DateTime
     {
         $date = clone $this->dateTime;
         if ($year) {
@@ -92,7 +92,7 @@ class CalculateDayOff
         }
     }
 
-    protected function readDayoffList($query, $year)
+    protected function readDayoffList(\BO\Zmsbackend\Dayoff\Service\DayOff $query, string $year)
     {
         $collection = $query->readCommonByYear($year);
         $newDayOffList = $this->calculateDayOffByYear($year);

--- a/zmsbackend/src/Zmsbackend/Helper/CalculateSlots.php
+++ b/zmsbackend/src/Zmsbackend/Helper/CalculateSlots.php
@@ -19,7 +19,7 @@ class CalculateSlots
         $this->startTime = microtime(true);
     }
 
-    public function log($message)
+    public function log(string $message): static
     {
         $time = $this->getSpendTime();
         $memory = memory_get_usage() / (1024 * 1024);
@@ -35,7 +35,7 @@ class CalculateSlots
         return $this;
     }
 
-    public function dumpLogs()
+    public function dumpLogs(): void
     {
         foreach ($this->logList as $text) {
             if (!$this->verbose) {
@@ -45,7 +45,7 @@ class CalculateSlots
         $this->verbose = true;
     }
 
-    public function getSpendTime()
+    public function getSpendTime(): float
     {
         $time = round(microtime(true) - $this->startTime, 3);
         return $time;
@@ -92,7 +92,7 @@ class CalculateSlots
     }
 
 
-    public function writeCalculations(\DateTimeInterface $now, $daily = false)
+    public function writeCalculations(\DateTimeInterface $now, $daily = false): bool
     {
         \BO\Zmsbackend\Connection\Select::setTransaction();
         \BO\Zmsbackend\Connection\Select::getWriteConnection();
@@ -145,7 +145,7 @@ class CalculateSlots
         return true;
     }
 
-    protected function writeCalculatedScope(\BO\Zmsentities\Scope $scope, \DateTimeInterface $now)
+    protected function writeCalculatedScope(\BO\Zmsentities\Scope $scope, \DateTimeInterface $now): bool
     {
         $slotQuery = new \BO\Zmsbackend\Slot\Service\Slot();
         $updatedList = $slotQuery->writeByScope($scope, $now);
@@ -161,7 +161,7 @@ class CalculateSlots
         return false;
     }
 
-    public function writePostProcessingByScope(\BO\Zmsentities\Scope $scope, \DateTimeInterface $now)
+    public function writePostProcessingByScope(\BO\Zmsentities\Scope $scope, \DateTimeInterface $now): void
     {
         $slotQuery = new \BO\Zmsbackend\Slot\Service\Slot();
         if ($slotsProcessed = $slotQuery->deleteSlotProcessOnProcess($scope->id)) {
@@ -176,7 +176,7 @@ class CalculateSlots
         }
     }
 
-    public function writeCanceledSlots(\DateTimeInterface $now, $modify = '+5 minutes')
+    public function writeCanceledSlots(\DateTimeInterface $now, $modify = '+5 minutes'): bool
     {
         \BO\Zmsbackend\Connection\Select::getWriteConnection();
         $slotQuery = new \BO\Zmsbackend\Slot\Service\Slot();
@@ -188,7 +188,7 @@ class CalculateSlots
         return false;
     }
 
-    public function deleteOldSlots(\DateTimeInterface $now)
+    public function deleteOldSlots(\DateTimeInterface $now): void
     {
         $this->log("Maintenance: Delete slots older than " . $now->format('Y-m-d'));
         $slotQuery = new \BO\Zmsbackend\Slot\Service\Slot();

--- a/zmsbackend/src/Zmsbackend/Helper/CleanProcessArchivedToday.php
+++ b/zmsbackend/src/Zmsbackend/Helper/CleanProcessArchivedToday.php
@@ -18,14 +18,14 @@ class CleanProcessArchivedToday
         }
     }
 
-    protected function log($message)
+    protected function log(string $message): void
     {
         if ($this->verbose) {
             \App::$log->info($message);
         }
     }
 
-    public static function startProcessing($commit = false)
+    public static function startProcessing($commit = false): void
     {
         $logRepo = new \BO\Zmsbackend\Process\Service\ProcessStatusArchived();
         if ($commit) {

--- a/zmsbackend/src/Zmsbackend/Helper/DayoffDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/DayoffDeleteByCron.php
@@ -7,7 +7,7 @@ namespace BO\Zmsbackend\Helper;
  */
 class DayoffDeleteByCron
 {
-    public static function init($timeInterval)
+    public static function init($timeInterval): void
     {
         $deleteInSeconds = (365 * 24 * 60 * 60 / 12) * $timeInterval;
         $query = new \BO\Zmsbackend\Dayoff\Service\DayOff();

--- a/zmsbackend/src/Zmsbackend/Helper/EventLogCleanUpByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/EventLogCleanUpByCron.php
@@ -22,14 +22,14 @@ class EventLogCleanUpByCron
         }
     }
 
-    protected function log($message)
+    protected function log(string $message): void
     {
         if ($this->verbose) {
             \App::$log->info($message);
         }
     }
 
-    public static function startProcessing($commit = false)
+    public static function startProcessing($commit = false): void
     {
         $eventLogRepo  = new EventLogRepository();
         if ($commit) {

--- a/zmsbackend/src/Zmsbackend/Helper/ExchangeAccessFilter.php
+++ b/zmsbackend/src/Zmsbackend/Helper/ExchangeAccessFilter.php
@@ -52,8 +52,10 @@ class ExchangeAccessFilter
         return static::$filteredEntity;
     }
 
-    /** @psalm-api */
-    protected static function getFilteredEntityByUseraccountPermissions($permission, $filteredKey)
+    /**
+     * @psalm-api
+     */
+    protected static function getFilteredEntityByUseraccountPermissions($permission, $filteredKey): void
     {
         if (! static::$workstation->getUseraccount()->hasPermissions([$permission])) {
             unset(static::$filteredEntity->data[$filteredKey]);
@@ -62,17 +64,20 @@ class ExchangeAccessFilter
 
     /**
      * @SuppressWarnings(UnusedFormalParameter)
+     *
      * @psalm-api
      */
-    protected static function getFilteredEntityByUseraccountSuperuser($unused, $filteredKey)
+    protected static function getFilteredEntityByUseraccountSuperuser($unused, $filteredKey): void
     {
         if (! static::$workstation->getUseraccount()->isSuperUser()) {
             unset(static::$filteredEntity->data[$filteredKey]);
         }
     }
 
-    /** @psalm-api */
-    protected static function getFilteredEntityByScope($entityId, $filteredKey)
+    /**
+     * @psalm-api
+     */
+    protected static function getFilteredEntityByScope($entityId, $filteredKey): void
     {
         if (static::$workstation->getUseraccount()->hasPermissions(['scope'])) {
             if (! static::$workstation->getScopeListFromAssignedDepartments()->hasEntity($entityId)) {
@@ -81,8 +86,10 @@ class ExchangeAccessFilter
         }
     }
 
-    /** @psalm-api */
-    protected static function getFilteredEntityByDepartment($entityId, $filteredKey)
+    /**
+     * @psalm-api
+     */
+    protected static function getFilteredEntityByDepartment($entityId, $filteredKey): void
     {
         if (static::$workstation->getUseraccount()->hasPermissions(['department'])) {
             if (! static::$workstation->getDepartmentList()->hasEntity($entityId)) {
@@ -91,8 +98,10 @@ class ExchangeAccessFilter
         }
     }
 
-    /** @psalm-api */
-    protected static function getFilteredEntityByOrganisation($entityId, $filteredKey)
+    /**
+     * @psalm-api
+     */
+    protected static function getFilteredEntityByOrganisation($entityId, $filteredKey): void
     {
         if (static::$workstation->getUseraccount()->hasPermissions(['organisation'])) {
             if (! static::$organisationList->hasEntity($entityId)) {
@@ -101,7 +110,7 @@ class ExchangeAccessFilter
         }
     }
 
-    protected static function getOrganisationListByDepartments()
+    protected static function getOrganisationListByDepartments(): \BO\Zmsentities\Collection\OrganisationList
     {
         $organisationList = new \BO\Zmsentities\Collection\OrganisationList();
         foreach (static::$workstation->getDepartmentList() as $department) {

--- a/zmsbackend/src/Zmsbackend/Helper/LogCleanUp.php
+++ b/zmsbackend/src/Zmsbackend/Helper/LogCleanUp.php
@@ -23,14 +23,14 @@ class LogCleanUp
         }
     }
 
-    protected function log($message)
+    protected function log(string $message): void
     {
         if ($this->verbose) {
             \App::$log->info($message);
         }
     }
 
-    public static function startProcessing($commit = false)
+    public static function startProcessing($commit = false): void
     {
         \App::$log->info('Starting log cleanup process');
 

--- a/zmsbackend/src/Zmsbackend/Helper/LogOperatorMiddleware.php
+++ b/zmsbackend/src/Zmsbackend/Helper/LogOperatorMiddleware.php
@@ -19,7 +19,11 @@ class LogOperatorMiddleware
         return $next->handle($request);
     }
 
-    private function getAuthorityWithoutPassword($authority)
+    /**
+     * @return null|string|string[]
+     *
+     */
+    private function getAuthorityWithoutPassword(string $authority): array|string|null
     {
         $regex = '/((:)(.+)(?=@))/';
         return preg_replace($regex, '', $authority);

--- a/zmsbackend/src/Zmsbackend/Helper/MailTemplateProvider.php
+++ b/zmsbackend/src/Zmsbackend/Helper/MailTemplateProvider.php
@@ -35,7 +35,7 @@ class MailTemplateProvider
         return $this->templates;
     }
 
-    protected function loadTemplates()
+    protected function loadTemplates(): void
     {
 
         $this->templates = array(

--- a/zmsbackend/src/Zmsbackend/Helper/Matching.php
+++ b/zmsbackend/src/Zmsbackend/Helper/Matching.php
@@ -37,7 +37,7 @@ class Matching
         return $result;
     }
 
-    public static function isRequestExisting($session)
+    public static function isRequestExisting($session): bool
     {
         $result = true;
         if ($session->hasRequests()) {
@@ -48,7 +48,10 @@ class Matching
         return $result;
     }
 
-    public static function testCurrentScopeHasRequest($process)
+    /**
+     * @return void
+     */
+    public static function testCurrentScopeHasRequest(\BO\Zmsentities\Process $process)
     {
         $testProcess = clone $process;
         $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($testProcess->getScopeId(), 2);

--- a/zmsbackend/src/Zmsbackend/Helper/ProcessStatus.php
+++ b/zmsbackend/src/Zmsbackend/Helper/ProcessStatus.php
@@ -15,7 +15,7 @@ class ProcessStatus extends \BO\Zmsbackend\Process\Service\Process
         \DateTimeInterface $dateTime,
         $resolveReferences,
         $userAccount
-    ) {
+    ): \BO\Zmsentities\Process {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::UPDATE);
         $query->addConditionProcessId($process['id']);
         $query->addConditionAuthKey($process['authKey']);

--- a/zmsbackend/src/Zmsbackend/Helper/ReservedDataDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/ReservedDataDeleteByCron.php
@@ -75,7 +75,7 @@ class ReservedDataDeleteByCron
         $this->log(PHP_EOL . "SUMMARY: Processed reservations: " . var_export($filteredCount, true));
     }
 
-    protected function log($message): bool
+    protected function log(string $message): bool
     {
         if ($this->verbose) {
             \App::$log->info($message);
@@ -141,6 +141,9 @@ class ReservedDataDeleteByCron
         return $processList;
     }
 
+    /**
+     * @return void
+     */
     protected function writeDeleteProcess(Process $process)
     {
         if ($this->isDryRun) {

--- a/zmsbackend/src/Zmsbackend/Helper/SendMailReminder.php
+++ b/zmsbackend/src/Zmsbackend/Helper/SendMailReminder.php
@@ -47,7 +47,7 @@ class SendMailReminder
         }
     }
 
-    protected function log($message)
+    protected function log(string $message): void
     {
         if ($this->verbose) {
             \App::$log->info($message);
@@ -59,17 +59,17 @@ class SendMailReminder
         return $this->count;
     }
 
-    public function setLimit($limit)
+    public function setLimit($limit): void
     {
         $this->limit = $limit;
     }
 
-    public function setLoopCount($loopCount)
+    public function setLoopCount($loopCount): void
     {
         $this->loopCount = $loopCount;
     }
 
-    public function startProcessing($commit)
+    public function startProcessing($commit): void
     {
         if ($commit) {
             (new MailRepository())->writeReminderLastRun($this->dateTime);
@@ -79,7 +79,7 @@ class SendMailReminder
         $this->log("\nSUMMARY: Sent mail reminder: " . $this->count);
     }
 
-    protected function writeMailReminderList($commit)
+    protected function writeMailReminderList($commit): void
     {
         // The offset parameter was removed here, because with each loop the processes are searched, which have not
         // been processed yet. An offset leads to the fact that with the renewed search the first results are skipped.
@@ -97,7 +97,7 @@ class SendMailReminder
         $this->count += $count;
     }
 
-    protected function writeByCallback($commit, \Closure $callback)
+    protected function writeByCallback($commit, \Closure $callback): int
     {
         $processCount = 0;
         while ($processCount < $this->limit) {
@@ -115,7 +115,7 @@ class SendMailReminder
         return $processCount;
     }
 
-    protected function writeReminder(Process $process, $commit, $processCount)
+    protected function writeReminder(Process $process, $commit, int $processCount): void
     {
         $department = (new DepartmentRepository())->readByScopeId($process->getScopeId(), 0);
         if ($process->getFirstClient()->hasEmail() && $department->hasMail()) {
@@ -142,7 +142,7 @@ class SendMailReminder
         }
     }
 
-    protected function getProcessListOverview(Process $process, \BO\Zmsentities\Config $config)
+    protected function getProcessListOverview(Process $process, \BO\Zmsentities\Config $config): Collection
     {
         $collection  = (new Collection())->addEntity($process);
         if (in_array(getenv('ZMS_ENV'), explode(',', $config->getPreference('appointments', 'enableSummaryByMail')))) {

--- a/zmsbackend/src/Zmsbackend/Helper/SendProcessListToScopeAdmin.php
+++ b/zmsbackend/src/Zmsbackend/Helper/SendProcessListToScopeAdmin.php
@@ -28,7 +28,7 @@ class SendProcessListToScopeAdmin
         }
     }
 
-    public function startProcessing($commit)
+    public function startProcessing($commit): void
     {
         foreach ($this->scopeList as $scope) {
             if ($this->verbose) {
@@ -55,7 +55,7 @@ class SendProcessListToScopeAdmin
         }
     }
 
-    protected function sendListToQueue($scope, $processList)
+    protected function sendListToQueue($scope, \BO\Zmsentities\Collection\ProcessList $processList): void
     {
         $entity = (new \BO\Zmsentities\Mail())->toScopeAdminProcessList($processList, $scope, $this->dateTime);
         if (! (new \BO\Zmsbackend\Mail\Service\Mail())->writeInQueueWithDailyProcessList($scope, $entity)) {

--- a/zmsbackend/src/Zmsbackend/Helper/TicketprinterAccess.php
+++ b/zmsbackend/src/Zmsbackend/Helper/TicketprinterAccess.php
@@ -12,7 +12,7 @@ class TicketprinterAccess
      *
      * @return array $useraccount
     */
-    public static function testTicketprinter($entity)
+    public static function testTicketprinter(\BO\Zmsentities\Ticketprinter $entity)
     {
         if ($entity->hasId()) {
             $organisation = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readByHash($entity->hash);
@@ -22,6 +22,9 @@ class TicketprinterAccess
         self::testMatchingClusterAndScopes($entity, $organisation->getId());
     }
 
+    /**
+     * @return void
+     */
     public static function testMatchingClusterAndScopes($entity, $organisationId)
     {
         if (isset($entity->buttons) && $entity->buttons) {
@@ -38,6 +41,9 @@ class TicketprinterAccess
         }
     }
 
+    /**
+     * @return void
+     */
     public static function testTicketprinterNotFound($entity)
     {
         if (! $entity->hasId() || ! (new \BO\Zmsbackend\Ticketprinter\Service\Ticketprinter())->readByHash($entity->getId())->hasId()) {
@@ -45,7 +51,11 @@ class TicketprinterAccess
         }
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     *
+     * @return void
+     */
     public static function testTicketprinterIsProtectedEnabled($entity, $isProtectionEnabled)
     {
         if ($isProtectionEnabled && ! $entity->isEnabled()) {
@@ -53,6 +63,9 @@ class TicketprinterAccess
         }
     }
 
+    /**
+     * @return void
+     */
     public static function testTicketprinterValidHash($entity)
     {
         if (

--- a/zmsbackend/src/Zmsbackend/Helper/TicketprinterDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/TicketprinterDeleteByCron.php
@@ -23,7 +23,7 @@ class TicketprinterDeleteByCron
         $this->scopeList = (new \BO\Zmsbackend\Scope\Service\Scope())->readList();
     }
 
-    public function startProcessing($commit)
+    public function startProcessing($commit): void
     {
         $ticketprinterList = (new \BO\Zmsbackend\Ticketprinter\Service\Ticketprinter())->readExpiredTicketprinterList($this->deleteDateTime);
         foreach ($ticketprinterList as $entity) {
@@ -36,7 +36,7 @@ class TicketprinterDeleteByCron
         }
     }
 
-    protected function deleteTicketpinter(\BO\Zmsentities\Ticketprinter $entity)
+    protected function deleteTicketpinter(\BO\Zmsentities\Ticketprinter $entity): void
     {
         $query = new \BO\Zmsbackend\Ticketprinter\Service\Ticketprinter();
         if ($query->deleteEntity($entity->id) && $this->verbose) {

--- a/zmsbackend/src/Zmsbackend/Helper/UnconfirmedAppointmentDeleteByCron.php
+++ b/zmsbackend/src/Zmsbackend/Helper/UnconfirmedAppointmentDeleteByCron.php
@@ -32,7 +32,7 @@ class UnconfirmedAppointmentDeleteByCron
         $this->scopeList = (new \BO\Zmsbackend\Scope\Service\Scope())->readList();
     }
 
-    protected function log($message, string $level = 'info')
+    protected function log(string $message, string $level = 'info'): void
     {
         $this->writeVerboseCronLog($message, $level);
     }
@@ -43,25 +43,29 @@ class UnconfirmedAppointmentDeleteByCron
         return $this->count;
     }
 
-    /** @psalm-api */
-    public function setLimit($limit)
+    /**
+     * @psalm-api
+     */
+    public function setLimit($limit): void
     {
         $this->limit = $limit;
     }
 
-    /** @psalm-api */
-    public function setLoopCount($loopCount)
+    /**
+     * @psalm-api
+     */
+    public function setLoopCount($loopCount): void
     {
         $this->loopCount = $loopCount;
     }
 
-    public function startProcessing($commit)
+    public function startProcessing($commit): void
     {
         $this->deleteUnconfirmedProcesses($commit);
         $this->log("\nSUMMARY: Deleted processes: " . var_export($this->count, true));
     }
 
-    protected function deleteUnconfirmedProcesses($commit)
+    protected function deleteUnconfirmedProcesses($commit): void
     {
         foreach ($this->scopeList as $scope) {
             $count = $this->deleteByCallback($commit, function ($limit, $offset) use ($scope) {
@@ -92,7 +96,7 @@ class UnconfirmedAppointmentDeleteByCron
         }
     }
 
-    protected function deleteByCallback($commit, \Closure $callback)
+    protected function deleteByCallback($commit, \Closure $callback): int
     {
         $processCount = 0;
         $startposition = 0;
@@ -116,7 +120,7 @@ class UnconfirmedAppointmentDeleteByCron
         return $processCount;
     }
 
-    protected function removeProcess(\BO\Zmsentities\Process $process, $commit)
+    protected function removeProcess(\BO\Zmsentities\Process $process, $commit): int
     {
         $verbose = $this->verbose;
         if (in_array($process->status, $this->statusListForDeletion)) {
@@ -130,7 +134,7 @@ class UnconfirmedAppointmentDeleteByCron
         return 0;
     }
 
-    protected function deleteProcess(\BO\Zmsentities\Process $process)
+    protected function deleteProcess(\BO\Zmsentities\Process $process): void
     {
         $verbose = $this->verbose;
         $query = new \BO\Zmsbackend\Process\Service\Process();

--- a/zmsbackend/src/Zmsbackend/Helper/User.php
+++ b/zmsbackend/src/Zmsbackend/Helper/User.php
@@ -31,7 +31,7 @@ class User
         static::readWorkstation($resolveReferences);
     }
 
-    public static function readWorkstation($resolveReferences = 0)
+    public static function readWorkstation(int $resolveReferences = 0)
     {
         $request = (static::$request) ? static::$request : Render::$request;
         if (! static::$workstation) {
@@ -57,6 +57,8 @@ class User
      * @throws \BO\Zmsbackend\Workstation\Exception\WorkstationAlreadyAssigned
      *
      * @psalm-api
+     *
+     * @return void
      */
     public static function testWorkstationAssigend(\BO\Zmsentities\Workstation $entity, $resolveReferences = 0)
     {
@@ -81,8 +83,9 @@ class User
     /**
      * @throws \BO\Zmsentities\Exception\UserAccountAccessRightsFailed
      *
+     * @return void
      */
-    public static function testWorkstationAccessRights($useraccount)
+    public static function testWorkstationAccessRights(\BO\Zmsentities\Useraccount $useraccount)
     {
         if (
             (
@@ -99,7 +102,7 @@ class User
     }
 
 
-    public static function testWorkstationAssignedRoles($useraccount): void
+    public static function testWorkstationAssignedRoles(\BO\Zmsentities\Useraccount $useraccount): void
     {
         if (! $useraccount->offsetExists('roles') || ! is_array($useraccount['roles'])) {
             throw new \BO\Zmsbackend\Useraccount\Exception\UseraccountInvalidRoleAssignment();
@@ -138,7 +141,10 @@ class User
         return $userAccount->hasId();
     }
 
-    public static function checkPermissions(...$requiredPermissions)
+    /**
+     * @param \BO\Zmsentities\Useraccount\EntityAccess|string $requiredPermissions
+     */
+    public static function checkPermissions(string|\BO\Zmsentities\Useraccount\EntityAccess ...$requiredPermissions)
     {
         $workstation = static::readWorkstation();
 
@@ -149,7 +155,7 @@ class User
         return $workstation;
     }
 
-    public static function checkAnyPermission(...$requiredPermissions)
+    public static function checkAnyPermission(string ...$requiredPermissions)
     {
         $workstation = static::readWorkstation();
 
@@ -160,7 +166,7 @@ class User
         return $workstation;
     }
 
-    public static function checkDepartments($departmentIds)
+    public static function checkDepartments($departmentIds): DepartmentList
     {
         $normalizedIds = self::normalizeDepartmentIds($departmentIds);
         $departments = new DepartmentList();
@@ -251,9 +257,8 @@ class User
 
     /**
      * Get X-Api-Key from header
-     *
-    */
-    public static function hasXApiKey($request)
+     */
+    public static function hasXApiKey(\Psr\Http\Message\RequestInterface $request): bool
     {
         $xApiKeyEntity = null;
         $xApiKey = $request->getHeaderLine('x-api-key');
@@ -263,7 +268,10 @@ class User
         return ($xApiKeyEntity && $xApiKeyEntity->hasId());
     }
 
-    public static function testWorkstationIsOveraged($workstation)
+    /**
+     * @return void
+     */
+    public static function testWorkstationIsOveraged(\BO\Zmsentities\Workstation $workstation)
     {
         if ($workstation->hasId() && $workstation->getUseraccount()->isOveraged(\App::$now)) {
             $exception = new \BO\Zmsbackend\Useraccount\Exception\AuthKeyFound();
@@ -280,7 +288,11 @@ class User
         return $department;
     }
 
-    public static function normalizeDepartmentIds(array $departmentIds)
+    /**
+     * @return int[]
+     *
+     */
+    public static function normalizeDepartmentIds(array $departmentIds): array
     {
         $normalized = [];
         foreach ($departmentIds as $departmentId) {

--- a/zmsbackend/src/Zmsbackend/Helper/UserAuth.php
+++ b/zmsbackend/src/Zmsbackend/Helper/UserAuth.php
@@ -26,7 +26,10 @@ class UserAuth
         return $useraccount;
     }
 
-    public static function testPasswordMatching($useraccount, $password)
+    /**
+     * @return true
+     */
+    public static function testPasswordMatching(array $useraccount, $password): bool
     {
         // Do you have old, turbo-legacy, non-crypt hashes?
         // TODO: Remove the password fields when password authentication is removed in the future

--- a/zmsbackend/src/Zmsbackend/Helper/UserAuth.php
+++ b/zmsbackend/src/Zmsbackend/Helper/UserAuth.php
@@ -29,7 +29,7 @@ class UserAuth
     /**
      * @return true
      */
-    public static function testPasswordMatching(array $useraccount, $password): bool
+    public static function testPasswordMatching($useraccount, $password): bool
     {
         // Do you have old, turbo-legacy, non-crypt hashes?
         // TODO: Remove the password fields when password authentication is removed in the future

--- a/zmsbackend/src/Zmsbackend/Helper/Version.php
+++ b/zmsbackend/src/Zmsbackend/Helper/Version.php
@@ -4,7 +4,7 @@ namespace BO\Zmsbackend\Helper;
 
 class Version
 {
-    public static function getString($path = null)
+    public static function getString($path = null): string
     {
         $path = ($path) ? $path : \App::APP_PATH;
         $file = $path . '/VERSION';
@@ -14,7 +14,11 @@ class Version
         return "version.unknown";
     }
 
-    public static function getArray($path = null)
+    /**
+     * @return string[]
+     *
+     */
+    public static function getArray($path = null): array
     {
         $version = static::getString($path);
         $array = [];

--- a/zmsbackend/src/Zmsbackend/Interfaces/ResolveReferences.php
+++ b/zmsbackend/src/Zmsbackend/Interfaces/ResolveReferences.php
@@ -4,5 +4,5 @@ namespace BO\Zmsbackend\Interfaces;
 
 interface ResolveReferences
 {
-    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences);
+    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, int $resolveReferences);
 }

--- a/zmsbackend/src/Zmsbackend/Link/Repository/Link.php
+++ b/zmsbackend/src/Zmsbackend/Link/Repository/Link.php
@@ -14,8 +14,13 @@ class Link extends \BO\Zmsbackend\Query\Base
      */
     protected $resolveLevel = 0;
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'id' => 'link.linkid',
@@ -27,13 +32,13 @@ class Link extends \BO\Zmsbackend\Query\Base
         ];
     }
 
-    public function addConditionLinkId($linkId)
+    public function addConditionLinkId($linkId): static
     {
         $this->query->where('link.linkid', '=', $linkId);
         return $this;
     }
 
-    public function addConditionDepartmentId($departmentId)
+    public function addConditionDepartmentId($departmentId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('behoerde', 'link_department'),
@@ -46,7 +51,11 @@ class Link extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Link $entity, $departmentId)
+    /**
+     * @return (int|mixed)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Link $entity, $departmentId): array
     {
         $data = array();
         $data['behoerdenid'] = ($entity->organisation) ? 0 : $departmentId;

--- a/zmsbackend/src/Zmsbackend/Link/Service/Link.php
+++ b/zmsbackend/src/Zmsbackend/Link/Service/Link.php
@@ -63,7 +63,7 @@ class Link extends \BO\Zmsbackend\Base
         return $this->writeItem($query);
     }
 
-    public function deleteEntity($itemId)
+    public function deleteEntity($itemId): bool
     {
         $query = new \BO\Zmsbackend\Link\Repository\Link(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionLinkId($itemId);

--- a/zmsbackend/src/Zmsbackend/Log/Repository/Log.php
+++ b/zmsbackend/src/Zmsbackend/Log/Repository/Log.php
@@ -21,8 +21,13 @@ class Log extends \BO\Zmsbackend\Query\Base
         WHERE mq.processID=?
     ';
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'type' => 'log.type',
@@ -47,7 +52,7 @@ class Log extends \BO\Zmsbackend\Query\Base
         ];
     }
 
-    public function addConditionProcessId($processId)
+    public function addConditionProcessId($processId): static
     {
         $this->query->where('log.reference_id', '=', $processId);
         $this->query->where('log.type', '=', 'buerger');
@@ -62,7 +67,7 @@ class Log extends \BO\Zmsbackend\Query\Base
         return $data;
     }
 
-    public function addConditionOlderThan(\DateTime $olderThanDate)
+    public function addConditionOlderThan(\DateTime $olderThanDate): void
     {
         $this->query->where('log.ts', '<', $olderThanDate->format('Y-m-d H:i:s'));
     }

--- a/zmsbackend/src/Zmsbackend/Log/Service/Log.php
+++ b/zmsbackend/src/Zmsbackend/Log/Service/Log.php
@@ -73,9 +73,9 @@ class Log extends \BO\Zmsbackend\Base
     public static $operator = 'lib';
 
     public static function writeLogEntry(
-        $message,
-        $referenceId,
-        $type = self::PROCESS,
+        string $message,
+        int $referenceId,
+        string $type = self::PROCESS,
         ?int $scopeId = null,
         ?string $userId = null,
         ?array $indexedFields = null
@@ -112,6 +112,9 @@ class Log extends \BO\Zmsbackend\Base
         return $log->perform($sql, $parameters);
     }
 
+    /**
+     * @return void
+     */
     public static function writeProcessLog(
         string $method,
         string $action,
@@ -187,7 +190,7 @@ class Log extends \BO\Zmsbackend\Base
         return Entity::formatDisplayFields($log);
     }
 
-    public function readByProcessId($processId)
+    public function readByProcessId($processId): LogList
     {
         $query = new \BO\Zmsbackend\Log\Repository\Log(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping();
@@ -197,13 +200,13 @@ class Log extends \BO\Zmsbackend\Base
     }
 
     public function readByProcessData(
-        $generalSearch,
+        string $generalSearch,
         $service,
         $provider,
-        $date,
+        DateTime|null $date,
         $userAction,
-        $page = 1,
-        $perPage = 100,
+        int $page = 1,
+        int $perPage = 100,
         ?array $scopeIds = null
     ) {
         $fieldValues = [];
@@ -234,7 +237,7 @@ class Log extends \BO\Zmsbackend\Base
         int $perPage,
         int $offset,
         ?array $scopeIds = null
-    ) {
+    ): LogList {
         $params = ['logType' => self::PROCESS];
         $conditions = array_merge(
             ['type = :logType'],
@@ -351,8 +354,10 @@ class Log extends \BO\Zmsbackend\Base
         return $row;
     }
 
-    /** @psalm-api */
-    public function delete($processId)
+    /**
+     * @psalm-api
+     */
+    public function delete($processId): LogList
     {
         $query = new \BO\Zmsbackend\Log\Repository\Log(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping();
@@ -361,7 +366,7 @@ class Log extends \BO\Zmsbackend\Base
         return $logList;
     }
 
-    protected static function backtraceLogEntry()
+    protected static function backtraceLogEntry(): string
     {
         $trace = debug_backtrace();
         $short = '';

--- a/zmsbackend/src/Zmsbackend/Log/Service/Log.php
+++ b/zmsbackend/src/Zmsbackend/Log/Service/Log.php
@@ -200,7 +200,7 @@ class Log extends \BO\Zmsbackend\Base
     }
 
     public function readByProcessData(
-        string $generalSearch,
+        $generalSearch,
         $service,
         $provider,
         DateTime|null $date,

--- a/zmsbackend/src/Zmsbackend/Mail/Repository/MailQueue.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Repository/MailQueue.php
@@ -23,8 +23,13 @@ class MailQueue extends \BO\Zmsbackend\Query\Base
         WHERE mq.id IN (?)
     ';
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'id' => 'mailQueue.id',
@@ -38,19 +43,19 @@ class MailQueue extends \BO\Zmsbackend\Query\Base
         ];
     }
 
-    public function addConditionItemId($itemId)
+    public function addConditionItemId($itemId): static
     {
         $this->query->where('mailQueue.id', '=', $itemId);
         return $this;
     }
 
-    public function addOrderBy($parameter, $order = 'ASC')
+    public function addOrderBy(string $parameter, $order = 'ASC'): static
     {
         $this->query->orderBy('mailQueue.' . $parameter, $order);
         return $this;
     }
 
-    public function addWhereIn($column, array $itemIds)
+    public function addWhereIn(string $column, array $itemIds): static
     {
         if (!empty($itemIds)) {
             $this->query->where($column, 'IN', $itemIds);
@@ -58,7 +63,7 @@ class MailQueue extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function selectFields(array $fields)
+    public function selectFields(array $fields): static
     {
         $this->query->select($fields);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Mail/Repository/Mailtemplate.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Repository/Mailtemplate.php
@@ -29,31 +29,31 @@ class Mailtemplate extends \BO\Zmsbackend\Query\Base
 
     protected $resolveLevel = 1;
 
-    public function addConditionName($itemName)
+    public function addConditionName($itemName): static
     {
         $this->query->where(self::TABLE . '.name', '=', $itemName);
         return $this;
     }
 
-    public function addConditionWithoutProvider()
+    public function addConditionWithoutProvider(): static
     {
         $this->query->where(self::TABLE . '.provider', '=', '')->orWhere(self::TABLE . '.provider', 'IS', null);
         return $this;
     }
 
-    public function addConditionProviderId($providerId)
+    public function addConditionProviderId($providerId): static
     {
         $this->query->where(self::TABLE . '.provider', '=', $providerId);
         return $this;
     }
 
-    public function addConditionId($templateId)
+    public function addConditionId($templateId): static
     {
         $this->query->where(self::TABLE . '.id', '=', $templateId);
         return $this;
     }
 
-    public function addTemplateContent($templateContent)
+    public function addTemplateContent($templateContent): static
     {
         $this->query->values(array(
             'mailtemplate.value' => $templateContent
@@ -61,8 +61,13 @@ class Mailtemplate extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'id' => 'mailtemplate.id',

--- a/zmsbackend/src/Zmsbackend/Mail/Repository/Mimepart.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Repository/Mimepart.php
@@ -14,8 +14,13 @@ class Mimepart extends \BO\Zmsbackend\Query\Base
      */
     protected $resolveLevel = 0;
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'mime' => 'mimepart.mime',
@@ -24,7 +29,7 @@ class Mimepart extends \BO\Zmsbackend\Query\Base
         ];
     }
 
-    public function addConditionQueueId($queueId)
+    public function addConditionQueueId($queueId): static
     {
         $this->query->where('mimepart.queueId', '=', $queueId);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Mail/Service/Mail.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Service/Mail.php
@@ -17,8 +17,10 @@ class Mail extends \BO\Zmsbackend\Base
      * Fetch status from db
      *
      * @return \BO\Zmsentities\Mail
+     *
+     * @param false|string $itemId
      */
-    public function readEntity($itemId, $resolveReferences = 1)
+    public function readEntity(string|false $itemId, $resolveReferences = 1)
     {
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -31,7 +33,7 @@ class Mail extends \BO\Zmsbackend\Base
         return $mail;
     }
 
-    public function readEntities(array $itemIds, $resolveReferences = 1, $limit = 300, $order = 'ASC')
+    public function readEntities(array $itemIds, $resolveReferences = 1, $limit = 300, string $order = 'ASC'): Collection
     {
         $mailList = new Collection();
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::SELECT);
@@ -54,7 +56,7 @@ class Mail extends \BO\Zmsbackend\Base
     }
 
 
-    public function readEntitiesIds(array $itemIds, $resolveReferences = 1, $limit = 300, $order = 'ASC')
+    public function readEntitiesIds(array $itemIds, $resolveReferences = 1, $limit = 300, string $order = 'ASC')
     {
 
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::SELECT);
@@ -68,7 +70,7 @@ class Mail extends \BO\Zmsbackend\Base
         return $this->fetchList($query, new Entity());
     }
 
-    public function readList($resolveReferences = 1, $limit = 300, $order = 'ASC')
+    public function readList($resolveReferences = 1, $limit = 300, string $order = 'ASC'): Collection
     {
         $mailList = new Collection();
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::SELECT);
@@ -90,7 +92,7 @@ class Mail extends \BO\Zmsbackend\Base
     }
 
 
-    public function readListIds($resolveReferences = 1, $limit = 300, $order = 'ASC')
+    public function readListIds($resolveReferences = 1, $limit = 300, string $order = 'ASC')
     {
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::SELECT);
         $query->selectFields(['id', 'createTimestamp'])
@@ -104,6 +106,9 @@ class Mail extends \BO\Zmsbackend\Base
 
 
 
+    /**
+     * @return Entity
+     */
     #[\Override]
     public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
     {
@@ -127,7 +132,7 @@ class Mail extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function writeInQueueWithAdmin(Entity $mail)
+    public function writeInQueueWithAdmin(Entity $mail): Entity
     {
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::INSERT);
         $process = new \BO\Zmsentities\Process($mail->process);
@@ -149,7 +154,7 @@ class Mail extends \BO\Zmsbackend\Base
         return $this->readEntity($queueId);
     }
 
-    public function writeInQueue(Entity $mail, \DateTimeInterface $dateTime, $count = true)
+    public function writeInQueue(Entity $mail, \DateTimeInterface $dateTime, bool $count = true): Entity
     {
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::INSERT);
         $process = new \BO\Zmsentities\Process($mail->process);
@@ -184,7 +189,7 @@ class Mail extends \BO\Zmsbackend\Base
     public function writeInQueueWithDailyProcessList(
         \BO\Zmsentities\Scope $scope,
         Entity $mail
-    ) {
+    ): Entity {
         $query = new \BO\Zmsbackend\Mail\Repository\MailQueue(\BO\Zmsbackend\Query\Base::INSERT);
         $department = (new \BO\Zmsbackend\Department\Service\Department())->readByScopeId($scope->getId(), 0);
         $query->addValues(
@@ -203,7 +208,12 @@ class Mail extends \BO\Zmsbackend\Base
         return $this->readEntity($queueId);
     }
 
-    protected function writeMimeparts($queueId, $multipart)
+    /**
+     * @param false|string $queueId
+     *
+     * @return true
+     */
+    protected function writeMimeparts(string|false $queueId, $multipart): bool
     {
         $success = true;
         foreach ($multipart as $part) {
@@ -242,14 +252,14 @@ class Mail extends \BO\Zmsbackend\Base
         return $this->perform($query, $itemIds);
     }
 
-    public function readReminderLastRun($now)
+    public function readReminderLastRun(\DateTimeInterface $now)
     {
         $lastRun = (new \BO\Zmsbackend\Config\Service\Config())->readProperty('status__mailReminderLastRun', false);
         $lastRunDateTime = ($lastRun) ? new \DateTimeImmutable($lastRun) : $now;
         return $lastRunDateTime;
     }
 
-    public function writeReminderLastRun($now)
+    public function writeReminderLastRun(\DateTimeInterface $now): void
     {
         (new \BO\Zmsbackend\Config\Service\Config())->replaceProperty('status__mailReminderLastRun', $now->format('Y-m-d H:i:s'));
     }

--- a/zmsbackend/src/Zmsbackend/Mail/Service/MailTemplates.php
+++ b/zmsbackend/src/Zmsbackend/Mail/Service/MailTemplates.php
@@ -18,8 +18,10 @@ class MailTemplates extends \BO\Zmsbackend\Base
     }
 
 
-    /** @psalm-api */
-    public function readList()
+    /**
+     * @psalm-api
+     */
+    public function readList(): \BO\Zmsentities\Collection\MailtemplateList
     {
         $query = new \BO\Zmsbackend\Mail\Repository\Mailtemplate(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping();
@@ -27,7 +29,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return $logList;
     }
 
-    public function readListWithoutProvider()
+    public function readListWithoutProvider(): \BO\Zmsentities\Collection\MailtemplateList
     {
         $query = new \BO\Zmsbackend\Mail\Repository\Mailtemplate(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping();
@@ -36,7 +38,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return $logList;
     }
 
-    public function readListByProvider($providerId)
+    public function readListByProvider($providerId): \BO\Zmsentities\Collection\MailtemplateList
     {
         $query = new \BO\Zmsbackend\Mail\Repository\Mailtemplate(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping();
@@ -53,7 +55,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
     }
 
 
-    public function readTemplate($templateName)
+    public function readTemplate($templateName): Mailtemplate
     {
         $query = new \BO\Zmsbackend\Mail\Repository\Mailtemplate(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -61,7 +63,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return $this->fetchOne($query, new Mailtemplate());
     }
 
-    public function readTemplateById($templateId)
+    public function readTemplateById($templateId): Mailtemplate
     {
         $query = new \BO\Zmsbackend\Mail\Repository\Mailtemplate(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -69,7 +71,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return $this->fetchOne($query, new Mailtemplate());
     }
 
-    public function deleteTemplateById($templateId)
+    public function deleteTemplateById($templateId): bool
     {
         $query = new \BO\Zmsbackend\Mail\Repository\Mailtemplate(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionId($templateId);
@@ -111,8 +113,10 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return $this->readTemplate($templateName);
     }
 
-    /** @psalm-api */
-    public function updateEntity(MailTemplate $config)
+    /**
+     * @psalm-api
+     */
+    public function updateEntity(MailTemplate $config): Mailtemplate|null
     {
         $compareEntity = $this->readEntity();
         $result = false;
@@ -174,7 +178,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return $this->deleteItem($query);
     }
 
-    protected function fetchData($querySql)
+    protected function fetchData(string $querySql): Mailtemplate
     {
         $splittedHash = array();
         $dataList = $this->getReader()->fetchAll($querySql);
@@ -185,7 +189,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return new Mailtemplate($splittedHash);
     }
 
-    protected function getSpecifiedValue($value)
+    protected function getSpecifiedValue($value): int|string
     {
         if (is_bool($value)) {
             return ($value) ? 1 : 0;
@@ -193,7 +197,7 @@ class MailTemplates extends \BO\Zmsbackend\Base
         return trim($value);
     }
 
-    protected function mergeMailTemplatesWithCustomizations($generalTemplates, $customTemplates)
+    protected function mergeMailTemplatesWithCustomizations($generalTemplates, $customTemplates): array
     {
 
         $customTemplatesByName = [];

--- a/zmsbackend/src/Zmsbackend/Organisation/Repository/Organisation.php
+++ b/zmsbackend/src/Zmsbackend/Organisation/Repository/Organisation.php
@@ -9,6 +9,10 @@ class Organisation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
      */
     const string TABLE = 'organisation';
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -36,19 +40,19 @@ class Organisation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         ];
     }
 
-    public function addConditionOrganisationId($organisationId)
+    public function addConditionOrganisationId($organisationId): static
     {
         $this->query->where('organisation.OrganisationsID', '=', $organisationId);
         return $this;
     }
 
-    public function addConditionOwnerId($ownerId)
+    public function addConditionOwnerId($ownerId): static
     {
         $this->query->where('organisation.KundenID', '=', $ownerId);
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('behoerde', 'department'),
@@ -66,7 +70,7 @@ class Organisation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function addConditionDepartmentId($departmentId)
+    public function addConditionDepartmentId($departmentId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('behoerde', 'department'),
@@ -78,7 +82,11 @@ class Organisation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Q
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Organisation $entity, $parentId = null)
+    /**
+     * @return (int|mixed|string)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Organisation $entity, $parentId = null): array
     {
         $data = array();
         if (null !== $parentId) {

--- a/zmsbackend/src/Zmsbackend/Organisation/Service/Organisation.php
+++ b/zmsbackend/src/Zmsbackend/Organisation/Service/Organisation.php
@@ -12,7 +12,11 @@ use BO\Zmsentities\Collection\OrganisationList as Collection;
  */
 class Organisation extends \BO\Zmsbackend\Base
 {
-    public function readEntity($itemId, $resolveReferences = 0)
+    /**
+     * @param false|int|string $itemId
+     *
+     */
+    public function readEntity(string|int|false $itemId, int $resolveReferences = 0)
     {
         $query = new \BO\Zmsbackend\Organisation\Repository\Organisation(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -25,6 +29,9 @@ class Organisation extends \BO\Zmsbackend\Base
         return array();
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
     {
@@ -47,7 +54,7 @@ class Organisation extends \BO\Zmsbackend\Base
         return $this->readResolvedReferences($organisation, $resolveReferences);
     }
 
-    public function readByDepartmentId($departmentId, $resolveReferences = 0)
+    public function readByDepartmentId($departmentId, int $resolveReferences = 0)
     {
         $query = new \BO\Zmsbackend\Organisation\Repository\Organisation(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -66,7 +73,7 @@ class Organisation extends \BO\Zmsbackend\Base
         return $this->readByScopeId($scope->id, $resolveReferences);
     }
 
-    public function readByOwnerId($ownerId, $resolveReferences = 0)
+    public function readByOwnerId($ownerId, $resolveReferences = 0): Collection
     {
         $organisationList = new Collection();
         $query = new \BO\Zmsbackend\Organisation\Repository\Organisation(\BO\Zmsbackend\Query\Base::SELECT);
@@ -94,7 +101,7 @@ class Organisation extends \BO\Zmsbackend\Base
         return $this->readEntity($organisationId);
     }
 
-    public function readList($resolveReferences = 0)
+    public function readList($resolveReferences = 0): Collection
     {
         $organisationList = new Collection();
         $query = new \BO\Zmsbackend\Organisation\Repository\Organisation(\BO\Zmsbackend\Query\Base::SELECT);
@@ -149,7 +156,7 @@ class Organisation extends \BO\Zmsbackend\Base
         return $this->readEntity($organisationId, 1, true);
     }
 
-    protected function writeOrganisationTicketprinters($organisationId, $ticketprinterList)
+    protected function writeOrganisationTicketprinters(string|false $organisationId, $ticketprinterList): void
     {
         $deleteQuery = new \BO\Zmsbackend\Ticketprinter\Repository\Ticketprinter(\BO\Zmsbackend\Query\Base::DELETE);
         $deleteQuery->addConditionOrganisationId($organisationId);
@@ -162,7 +169,7 @@ class Organisation extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function updateOrganisationTicketprinters($ticketprinterList, $organisationId)
+    protected function updateOrganisationTicketprinters($ticketprinterList, $organisationId): void
     {
         foreach ($ticketprinterList as $item) {
             $query = new \BO\Zmsbackend\Ticketprinter\Repository\Ticketprinter(\BO\Zmsbackend\Query\Base::UPDATE);

--- a/zmsbackend/src/Zmsbackend/Owner/Repository/Owner.php
+++ b/zmsbackend/src/Zmsbackend/Owner/Repository/Owner.php
@@ -9,6 +9,10 @@ class Owner extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Ma
      */
     const string TABLE = 'kunde';
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -36,7 +40,7 @@ class Owner extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Ma
         ];
     }
 
-    public function addConditionOrganisationId($organisationId)
+    public function addConditionOrganisationId($organisationId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Organisation\Repository\Organisation::TABLE, 'ownerorganisation'),
@@ -48,13 +52,13 @@ class Owner extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Ma
         return $this;
     }
 
-    public function addConditionOwnerId($ownerId)
+    public function addConditionOwnerId(int|string $ownerId): static
     {
         $this->query->where('owner.KundenID', '=', $ownerId);
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Owner $entity)
+    public function reverseEntityMapping(\BO\Zmsentities\Owner $entity): array
     {
         $data = array();
         $data['Anschrift'] = $entity->contact['street'] ?? null;

--- a/zmsbackend/src/Zmsbackend/Owner/Service/Owner.php
+++ b/zmsbackend/src/Zmsbackend/Owner/Service/Owner.php
@@ -26,8 +26,11 @@ class Owner extends \BO\Zmsbackend\Base
         return $this->readResolvedReferences($owner, $resolveReferences);
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
-    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
+    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, int $resolveReferences)
     {
         if (0 < $resolveReferences && isset($entity['id'])) {
             $entity['organisations'] = (new \BO\Zmsbackend\Organisation\Service\Organisation())->readByOwnerId($entity['id'], $resolveReferences - 1);
@@ -59,7 +62,7 @@ class Owner extends \BO\Zmsbackend\Base
         return $ownerList;
     }
 
-    public function readByOrganisationId($organisationId, $resolveReferences = 0)
+    public function readByOrganisationId(int $organisationId, $resolveReferences = 0)
     {
         $query = new \BO\Zmsbackend\Owner\Repository\Owner(\BO\Zmsbackend\Query\Base::SELECT);
         $query

--- a/zmsbackend/src/Zmsbackend/Permission/Api/PermissionListGet.php
+++ b/zmsbackend/src/Zmsbackend/Permission/Api/PermissionListGet.php
@@ -7,6 +7,9 @@ use BO\Zmsbackend\Permission\Service\Permission as PermissionRepository;
 
 class PermissionListGet extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse($request, $response, array $args)
     {
         (new \BO\Zmsbackend\Helper\User($request, 1))->checkPermissions('superuser');

--- a/zmsbackend/src/Zmsbackend/Permission/Repository/Permission.php
+++ b/zmsbackend/src/Zmsbackend/Permission/Repository/Permission.php
@@ -9,6 +9,10 @@ class Permission extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Que
      */
     const string TABLE = 'permission';
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {

--- a/zmsbackend/src/Zmsbackend/Preferences/Service/Preferences.php
+++ b/zmsbackend/src/Zmsbackend/Preferences/Service/Preferences.php
@@ -6,7 +6,7 @@ class Preferences extends \BO\Zmsbackend\Base
 {
     const string REPLACE_SKIPPED = 'skipped';
 
-    public function readProperty($entityName, $entityId, $groupName, $name, $forUpdate = false)
+    public function readProperty(string $entityName, $entityId, string $groupName, string $name, bool $forUpdate = false)
     {
         $sql = \BO\Zmsbackend\Preferences\Repository\Preferences::QUERY_SELECT_PROPERTY;
         if ($forUpdate) {
@@ -20,7 +20,7 @@ class Preferences extends \BO\Zmsbackend\Base
         ]);
     }
 
-    public function readChangeDateTime($entityName, $entityId, $groupName, $name, $forUpdate = false)
+    public function readChangeDateTime(string $entityName, $entityId, string $groupName, string $name, $forUpdate = false): \DateTimeImmutable
     {
         $sql = \BO\Zmsbackend\Preferences\Repository\Preferences::QUERY_SELECT_TIMESTAMP;
         if ($forUpdate) {
@@ -40,7 +40,7 @@ class Preferences extends \BO\Zmsbackend\Base
         return new \DateTimeImmutable($timeString);
     }
 
-    public function replaceProperty($entityName, $entityId, $groupName, $name, $value)
+    public function replaceProperty(string $entityName, $entityId, $groupName, $name, $value)
     {
         $this->getWriter();
         $currentValue = $this->readProperty($entityName, $entityId, $groupName, $name, true);
@@ -60,8 +60,11 @@ class Preferences extends \BO\Zmsbackend\Base
      * remove Preferences data
      *
      * @return bool
+     *
+     * @param key-of<TArray> $name
+     *
      */
-    public function deleteProperty($entityName, $entityId, $groupName, $name)
+    public function deleteProperty(string $entityName, $entityId, $groupName, $name)
     {
         return $this->perform(\BO\Zmsbackend\Preferences\Repository\Preferences::QUERY_DELETE_PROPERTY, [
             "entityName" => $entityName,

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessConfirm.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessConfirm.php
@@ -61,7 +61,7 @@ class ProcessConfirm extends \BO\Zmsbackend\Api\BaseController
         $response = Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
         return $response;
     }
-    protected function writeMails($request, $process)
+    protected function writeMails(\Psr\Http\Message\RequestInterface $request, \BO\Zmsentities\Process|null $process): void
     {
         if ($process->hasScopeAdmin() && $process->sendAdminMailOnConfirmation()) {
             $authority = $request->getUri()->getAuthority();
@@ -101,7 +101,10 @@ class ProcessConfirm extends \BO\Zmsbackend\Api\BaseController
         );
     }
 
-    protected function testProcessData($entity)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process $entity)
     {
         $authCheck = (new \BO\Zmsbackend\Process\Service\Process())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
@@ -111,7 +114,11 @@ class ProcessConfirm extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     *
+     * @return void
+     */
     protected function validateProcessLimits(\BO\Zmsentities\Process $process)
     {
         if (! (new \BO\Zmsbackend\Process\Service\Process())->isAppointmentSlotCountAllowed($process)) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessConfirmationMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessConfirmationMail.php
@@ -66,7 +66,10 @@ class ProcessConfirmationMail extends \BO\Zmsbackend\Api\BaseController
         return $mail;
     }
 
-    protected function testProcessData($process)
+    /**
+     * @return void
+     */
+    protected function testProcessData(Process $process)
     {
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
@@ -81,7 +84,7 @@ class ProcessConfirmationMail extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    public static function getProcessListOverview(Process $process, \BO\Zmsentities\Config $config)
+    public static function getProcessListOverview(Process $process, \BO\Zmsentities\Config $config): Collection
     {
         $collection  = (new Collection())->addEntity($process);
         if (

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessDelete.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessDelete.php
@@ -62,7 +62,7 @@ class ProcessDelete extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function writeMails($request, $process)
+    protected function writeMails(\Psr\Http\Message\RequestInterface $request, \BO\Zmsentities\Process|null $process): void
     {
         if ($process->hasScopeAdmin() && $process->sendAdminMailOnDeleted() && $process->getStatus() !== 'blocked') {
             $authority = $request->getUri()->getAuthority();
@@ -79,7 +79,10 @@ class ProcessDelete extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    protected function testProcessData($process, $authKey)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process|null $process, $authKey)
     {
         if (!$process) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessNotFound();

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteMail.php
@@ -67,7 +67,10 @@ class ProcessDeleteMail extends \BO\Zmsbackend\Api\BaseController
         return $mail;
     }
 
-    protected function testProcessData($process)
+    /**
+     * @return void
+     */
+    protected function testProcessData(Process $process)
     {
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->getId());
         if (! $authCheck) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteQuick.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteQuick.php
@@ -52,7 +52,10 @@ class ProcessDeleteQuick extends ProcessDelete
         return $response;
     }
 
-    protected function testProcess($workstation, $process)
+    /**
+     * @return void
+     */
+    protected function testProcess($workstation, \BO\Zmsentities\Process|null $process)
     {
         if (!$process->hasId()) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessNotFound();

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessFinished.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessFinished.php
@@ -63,14 +63,17 @@ class ProcessFinished extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testProcessInWorkstation($process, $workstation)
+    protected function testProcessInWorkstation(\BO\Zmsentities\Process $process, $workstation): void
     {
         $department = (new \BO\Zmsbackend\Department\Service\Department())->readByScopeId($workstation->scope['id'], 1);
         $workstation->process = $process;
         $workstation->validateProcessScopeAccess($department->getScopeList());
     }
 
-    protected function testProcessData($process)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process $process)
     {
         $hasValidId = (
             $process->hasId() &&
@@ -88,7 +91,7 @@ class ProcessFinished extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    protected function writeSurveyMail($process)
+    protected function writeSurveyMail($process): void
     {
         $process = clone $process;
         foreach ($process->getClients() as $client) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessGet.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessGet.php
@@ -34,6 +34,9 @@ class ProcessGet extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
+    /**
+     * @return void
+     */
     protected function testProcessData($processId, $authKey)
     {
         $authCheck = (new \BO\Zmsbackend\Process\Service\Process())->readAuthKeyByProcessId($processId);

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessIcs.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessIcs.php
@@ -40,6 +40,9 @@ class ProcessIcs extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
+    /**
+     * @return void
+     */
     protected function testProcessData($processId, $authKey)
     {
         $authCheck = (new \BO\Zmsbackend\Process\Service\Process())->readAuthKeyByProcessId($processId);

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessListSummaryMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessListSummaryMail.php
@@ -34,9 +34,12 @@ class ProcessListSummaryMail extends \BO\Zmsbackend\Api\BaseController
 
     /**
      * @SuppressWarnings(Param)
+     *
      * @param RequestInterface $request
      * @param ResponseInterface $response
      * @param array $args
+     *
+     * @return ResponseInterface
      */
     #[\Override]
     public function readResponse(
@@ -78,7 +81,7 @@ class ProcessListSummaryMail extends \BO\Zmsbackend\Api\BaseController
         return Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
     }
 
-    protected function readDepartment($config, $process = null): Department
+    protected function readDepartment(\BO\Zmsentities\Config $config, Process|null $process = null): Department
     {
         $department = (null != $process && null != $process->getScopeId()) ?
             (new DepartmentRepository())->readByScopeId($process->getScopeId(), 0) :
@@ -89,7 +92,7 @@ class ProcessListSummaryMail extends \BO\Zmsbackend\Api\BaseController
         return $department;
     }
 
-    protected function setWithProcessClient(Mail $entity, $mailAddress): Mail
+    protected function setWithProcessClient(Mail $entity, string $mailAddress): Mail
     {
         $process = new Process();
         $client = $entity->getClient();
@@ -101,7 +104,7 @@ class ProcessListSummaryMail extends \BO\Zmsbackend\Api\BaseController
         return $entity;
     }
 
-    protected function writeLogEntry($mailAddress, ProcessList $collection)
+    protected function writeLogEntry(string $mailAddress, ProcessList $collection): void
     {
         $logRepository = new EventLogRepository();
         $newLogEntry = new EventLog();
@@ -116,6 +119,9 @@ class ProcessListSummaryMail extends \BO\Zmsbackend\Api\BaseController
         $logRepository->writeEntity($newLogEntry);
     }
 
+    /**
+     * @return void
+     */
     protected function testEventLogEntries($mailAddress)
     {
         $logRepository = new EventLogRepository();

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessNextByScope.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessNextByScope.php
@@ -44,7 +44,7 @@ class ProcessNextByScope extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    public static function getProcess($queueList, $dateTime, $exclude = null)
+    public static function getProcess($queueList, \DateTimeInterface $dateTime, $exclude = null)
     {
         $process = $queueList->getNextProcess($dateTime, $exclude);
         return ($process) ? $process : new \BO\Zmsentities\Process();

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessPreconfirm.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessPreconfirm.php
@@ -57,7 +57,10 @@ class ProcessPreconfirm extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testProcessData($entity)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process $entity)
     {
         $authCheck = (new \BO\Zmsbackend\Process\Service\Process())->readAuthKeyByProcessId($entity->id);
 
@@ -72,7 +75,11 @@ class ProcessPreconfirm extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     *
+     * @return void
+     */
     protected function validateProcessLimits(\BO\Zmsentities\Process $process)
     {
         if (! (new \BO\Zmsbackend\Process\Service\Process())->isAppointmentSlotCountAllowed($process)) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessPreconfirmationMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessPreconfirmationMail.php
@@ -64,7 +64,10 @@ class ProcessPreconfirmationMail extends \BO\Zmsbackend\Api\BaseController
         return $mail;
     }
 
-    protected function testProcessData($process)
+    /**
+     * @return void
+     */
+    protected function testProcessData(Process $process)
     {
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
@@ -79,7 +82,7 @@ class ProcessPreconfirmationMail extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    public static function getProcessListOverview(Process $process, \BO\Zmsentities\Config $config)
+    public static function getProcessListOverview(Process $process, \BO\Zmsentities\Config $config): Collection
     {
         $collection  = (new Collection())->addEntity($process);
         if (

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessQueued.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessQueued.php
@@ -61,7 +61,10 @@ class ProcessQueued extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testProcessData($entity)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process $entity)
     {
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessRedirect.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessRedirect.php
@@ -53,6 +53,9 @@ class ProcessRedirect extends \BO\Zmsbackend\Api\BaseController
         return Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
     }
 
+    /**
+     * @return void
+     */
     protected function testProcessData($entity)
     {
         $entity->testValid();
@@ -64,6 +67,9 @@ class ProcessRedirect extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
+    /**
+     * @return void
+     */
     protected function testProcessAccess($workstation, $process)
     {
         $cluster = (new \BO\Zmsbackend\Cluster\Service\Cluster())->readByScopeId($workstation->scope['id'], 1);
@@ -77,7 +83,7 @@ class ProcessRedirect extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    protected function readValidProcess($workstation, $entity, $input)
+    protected function readValidProcess($workstation, \BO\Zmsentities\Process $entity, $input)
     {
         if ($entity->hasProcessCredentials()) {
             $this->testProcessData($entity);

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessUpdate.php
@@ -102,7 +102,10 @@ class ProcessUpdate extends \BO\Zmsbackend\Api\BaseController
         return Render::withJson($response, $message->setUpdatedMetaData(), $message->getStatuscode());
     }
 
-    protected function testProcessData($entity, bool $checkMailLimit = true)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process $entity, bool $checkMailLimit = true)
     {
         $authCheck = (new \BO\Zmsbackend\Process\Service\Process())->readAuthKeyByProcessId($entity->id);
 

--- a/zmsbackend/src/Zmsbackend/Process/Repository/Process.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/Process.php
@@ -91,7 +91,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         WHERE istFolgeterminvon = :processID
         ";
 
-    public function getQueryNewProcessId()
+    public function getQueryNewProcessId(): string
     {
         $random = rand(20, 999);
         return 'SELECT pseq.processId AS `nextid`
@@ -104,12 +104,12 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
             FOR UPDATE';
     }
 
-    public function getLockProcessId()
+    public function getLockProcessId(): string
     {
         return 'SELECT p.`BuergerID` FROM `' . self::getTablename() . '` p WHERE p.`BuergerID` = :processId FOR UPDATE';
     }
 
-    public function getLockAssignedWorkstationId()
+    public function getLockAssignedWorkstationId(): string
     {
         return 'SELECT p.`NutzerID`
             FROM `' . self::getTablename() . '` p
@@ -136,7 +136,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     /**
      * Add Availability to the dataset
      */
-    protected function addJoinAvailability()
+    protected function addJoinAvailability(): \BO\Zmsbackend\Availability\Repository\Availability
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Availability\Repository\Availability::TABLE, 'availability'),
@@ -149,7 +149,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     /**
      * Add Scope to the dataset
      */
-    protected function addJoinScope()
+    protected function addJoinScope(): \BO\Zmsbackend\Query\Scope
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Query\Scope::TABLE, 'scope'),
@@ -166,21 +166,27 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $joinQuery;
     }
 
-    public function addConditionDate($date)
+    public function addConditionDate($date): static
     {
         $this->query->where('process.Datum', '=', $date);
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionDisplayNumber($displayNumber)
+    /**
+     * @psalm-api
+     */
+    public function addConditionDisplayNumber($displayNumber): static
     {
         $this->query->where('process.displayNumber', '=', $displayNumber);
         return $this;
     }
 
-    /** @psalm-api */
-    protected function calculateStatus()
+    /**
+     * @psalm-api
+     *
+     * @return null|string
+     */
+    protected function calculateStatus(): string|null
     {
         if ($this->query->value('Name') === '(abgesagt)') {
             return 'deleted';
@@ -253,6 +259,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return null;
     }
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -354,7 +364,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         ], 'strlen');
     }
 
-    public function addCountValue()
+    public function addCountValue(): static
     {
         $this->query->select([
             'processCount' => self::expression('COUNT(*)'),
@@ -362,8 +372,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionHasTelephone()
+    /**
+     * @psalm-api
+     */
+    public function addConditionHasTelephone(): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) {
             $condition
@@ -373,7 +385,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionProcessDeleteInterval(\DateTimeInterface $expirationDate)
+    public function addConditionProcessDeleteInterval(\DateTimeInterface $expirationDate): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($expirationDate) {
             $query->andWith(
@@ -388,8 +400,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionProcessExpiredIPTimeStamp(\DateTimeInterface $expirationDate)
+    /**
+     * @psalm-api
+     */
+    public function addConditionProcessExpiredIPTimeStamp(\DateTimeInterface $expirationDate): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($expirationDate) {
             $query->andWith('process.IPTimeStamp', '<=', $expirationDate->getTimestamp());
@@ -398,8 +412,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionProcessReminderInterval(\DateTimeInterface $dateTime)
+    /**
+     * @psalm-api
+     */
+    public function addConditionProcessReminderInterval(\DateTimeInterface $dateTime): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($dateTime) {
             $query
@@ -414,7 +430,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         \DateTimeInterface $now,
         \DateTimeInterface $lastRun,
         $defaultReminderInMinutes
-    ) {
+    ): static {
         $this->query
             ->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($now, $lastRun, $defaultReminderInMinutes) {
                 $query
@@ -461,7 +477,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionProcessId($processId)
+    public function addConditionProcessId(int $processId): static
     {
         $this->query->where('process.BuergerID', '=', $processId);
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) {
@@ -472,7 +488,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionProcessIdFollow($processId)
+    public function addConditionProcessIdFollow($processId): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) use ($processId) {
             $condition
@@ -482,8 +498,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionIgnoreSlots()
+    /**
+     * @psalm-api
+     */
+    public function addConditionIgnoreSlots(): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) {
             $condition
@@ -493,7 +511,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId(int $scopeId): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($scopeId) {
             $query
@@ -503,7 +521,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionScopeIds($scopeIds)
+    public function addConditionScopeIds(array|int $scopeIds)
     {
         if (count($scopeIds) === 0) {
             $this->query->where(self::expression('1'), '=', 0);
@@ -523,8 +541,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionQueueNumber($queueNumber, $queueLimit = 10000)
+    /**
+     * @psalm-api
+     */
+    public function addConditionQueueNumber($queueNumber, $queueLimit = 10000): static
     {
         ($queueLimit > $queueNumber)
             ? $this->query->where('process.wartenummer', '=', $queueNumber)
@@ -532,7 +552,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionWorkstationId($workstationId)
+    public function addConditionWorkstationId($workstationId): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($workstationId) {
             $query->andWith('process.NutzerID', '=', $workstationId);
@@ -541,7 +561,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionTime($dateTime)
+    public function addConditionTime(\DateTimeInterface|null $dateTime): static
     {
         $this->query->where('process.Datum', '=', $dateTime->format('Y-m-d'));
         return $this;
@@ -549,9 +569,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
 
     /**
      * Identify processes between two dates
+     *
      * @psalm-api
      */
-    public function addConditionTimeframe(\DateTimeInterface $startDate, \DateTimeInterface $endDate)
+    public function addConditionTimeframe(\DateTimeInterface $startDate, \DateTimeInterface $endDate): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) use ($startDate, $endDate) {
             $condition
@@ -561,27 +582,32 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionAuthKey($authKey)
+    public function addConditionAuthKey($authKey): static
     {
         $authKey = urldecode($authKey);
         $this->query->where('process.absagecode', '=', $authKey);
         return $this;
     }
 
+    /**
+     * @return static
+     */
     public function addConditionAssigned()
     {
         $this->query->where('process.StandortID', '!=', "0");
         return $this;
     }
 
-    public function addConditionStatus($status)
+    public function addConditionStatus(string $status): static
     {
         $this->query->where('process.status', '=', $status);
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionIsReserved()
+    /**
+     * @psalm-api
+     */
+    public function addConditionIsReserved(): static
     {
         $this->query->where('process.name', 'NOT IN', array(
             'dereferenced',
@@ -597,7 +623,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionSearch($queryString, $orWhere = false)
+    public function addConditionSearch($queryString, bool $orWhere = false): static
     {
         $queryString = trim((string) $queryString);
         $terms = $this->parseSearchTerms($queryString);
@@ -660,7 +686,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $query->orWith('process.custom_text_field2', 'LIKE', $likeContains);
     }
 
-    public function addConditionUpcomingOnly(\DateTimeInterface $now)
+    public function addConditionUpcomingOnly(\DateTimeInterface $now): static
     {
         $today = $now->format('Y-m-d');
         $time = $now->format('H:i:s');
@@ -676,7 +702,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addOrderByAppointmentDate()
+    public function addOrderByAppointmentDate(): static
     {
         $this->query->orderBy('process.Datum', 'ASC');
         $this->query->orderBy('process.Uhrzeit', 'ASC');
@@ -684,7 +710,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addOrderBySearchRelevance($queryString)
+    public function addOrderBySearchRelevance(string $queryString): static
     {
         $queryString = trim($queryString);
         if ($queryString === '') {
@@ -785,12 +811,12 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         }
     }
 
-    private function isNumericSearchQuery($queryString): bool
+    private function isNumericSearchQuery(string $queryString): bool
     {
         return (bool) preg_match('#^\d+$#', $queryString);
     }
 
-    private function escapeLikeValue($value): string
+    private function escapeLikeValue(string $value): string
     {
         return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
     }
@@ -805,7 +831,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return str_replace("'", "''", $value);
     }
 
-    public function addConditionName($name, $exactMatching = false)
+    public function addConditionName($name, $exactMatching = false): static
     {
         if ($exactMatching) {
             $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($name) {
@@ -819,7 +845,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionMail($mailAddress, $exactMatching = false)
+    public function addConditionMail(string $mailAddress, bool $exactMatching = false): static
     {
         if ($exactMatching) {
             $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($mailAddress) {
@@ -833,8 +859,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionCustomTextfield($customText, $exactMatching = false)
+    /**
+     * @psalm-api
+     */
+    public function addConditionCustomTextfield($customText, $exactMatching = false): static
     {
         if ($exactMatching) {
             $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($customText) {
@@ -848,8 +876,10 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionCustomTextfield2($customText2, $exactMatching = false)
+    /**
+     * @psalm-api
+     */
+    public function addConditionCustomTextfield2($customText2, $exactMatching = false): static
     {
         if ($exactMatching) {
             $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($customText2) {
@@ -863,7 +893,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionAmendment($amendment)
+    public function addConditionAmendment($amendment): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($amendment) {
             $query->andWith('process.Anmerkung', 'LIKE', "%$amendment%");
@@ -874,7 +904,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     /**
      * Add Requests Join
      */
-    public function addConditionRequestId($requestId)
+    public function addConditionRequestId($requestId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias("buergeranliegen", 'buergeranliegen'),
@@ -886,7 +916,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionScopeNameSearch(string $scopeName)
+    public function addConditionScopeNameSearch(string $scopeName): static
     {
         $likeValue = '%' . $this->escapeLikeValue($scopeName) . '%';
         $this->leftJoin(
@@ -914,7 +944,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addConditionServiceNameSearch(string $serviceName)
+    public function addConditionServiceNameSearch(string $serviceName): static
     {
         $likeValue = '%' . $this->escapeLikeValue($serviceName) . '%';
         $this->leftJoin(
@@ -938,7 +968,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     /**
      * add condition to get process if deallocation time < now
      */
-    public function addConditionDeallocate($now)
+    public function addConditionDeallocate(\DateTimeInterface $now): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($now) {
             $query
@@ -949,7 +979,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    public function addValuesNewProcess(ProcessEntity $process, $parentProcess = 0, $childProcessCount = 0)
+    public function addValuesNewProcess(ProcessEntity $process, $parentProcess = 0, $childProcessCount = 0): void
     {
         $values = [
             'BuergerID' => $process->id,
@@ -971,7 +1001,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValues($values);
     }
 
-    public function getNewDisplayNumber($process)
+    public function getNewDisplayNumber(ProcessEntity $process)
     {
         if (empty($process->scope->getPreference('queue', 'displayNumberPrefix'))) {
             return $process->id;
@@ -997,7 +1027,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $newDisplayNumber;
     }
 
-    public function checkIfDisplayNumberOnSameDateExists($scopeId, $displayNumber, $date): bool
+    public function checkIfDisplayNumberOnSameDateExists($scopeId, string $displayNumber, \DateTime|false $date): bool
     {
         $processWithDisplayNumber = (new \BO\Zmsbackend\Process\Service\Process())->readProcessWithSameDayAndDisplayNumber(
             $scopeId,
@@ -1011,9 +1041,9 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     public function addValuesUpdateProcess(
         ProcessEntity $process,
         \DateTimeInterface $dateTime,
-        $parentProcess = 0,
+        int $parentProcess = 0,
         $previousStatus = null
-    ) {
+    ): void {
         $this->addValuesIPAdress($process);
         if (0 === $parentProcess) {
             $this->addValuesClientData($process);
@@ -1031,14 +1061,14 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValuesExternalUserId($process);
     }
 
-    public function addValuesIPAdress(ProcessEntity $process)
+    public function addValuesIPAdress(ProcessEntity $process): void
     {
         $data = array();
         $data['IPAdresse'] = $process->createIP;
         $this->addValues($data);
     }
 
-    public function addValuesFollowingProcessData($process, $parentProcess)
+    public function addValuesFollowingProcessData(ProcessEntity $process, $parentProcess): void
     {
         $data = array();
         if (0 === $parentProcess) {
@@ -1053,7 +1083,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
 
     public function addValuesAppointmentData(
         ProcessEntity $process
-    ) {
+    ): void {
         $data = array();
         $appointment = $process->getFirstAppointment();
         $datetime = $appointment->toDateTime();
@@ -1064,13 +1094,13 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
 
     public function addValuesScopeData(
         ProcessEntity $process
-    ) {
+    ): void {
         $data = array();
         $data['StandortID'] = $process->getScopeId();
         $this->addValues($data);
     }
 
-    public function addValuesStatusData(ProcessEntity $process, \DateTimeInterface $dateTime)
+    public function addValuesStatusData(ProcessEntity $process, \DateTimeInterface $dateTime): void
     {
         $data = array();
         $data['vorlaeufigeBuchung'] = ($process->status == 'reserved') ? 1 : 0;
@@ -1113,7 +1143,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValues($data);
     }
 
-    protected function addValuesClientData($process)
+    protected function addValuesClientData(ProcessEntity $process): void
     {
         $data = array();
         $client = $process->getFirstClient();
@@ -1139,13 +1169,13 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValues($data);
     }
 
-    public function addValueDisplayNumber($process)
+    public function addValueDisplayNumber(ProcessEntity $process): void
     {
         $data['displayNumber'] = $process->displayNumber;
         $this->addValues($data);
     }
 
-    protected function addProcessingTimeData($process, \DateTimeInterface $dateTime, $previousStatus = null)
+    protected function addProcessingTimeData(ProcessEntity $process, \DateTimeInterface $dateTime, $previousStatus = null): void
     {
         $data = array();
         $timeoutTime = null;
@@ -1225,7 +1255,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValues($data);
     }
 
-    protected function addValuesQueueData($process)
+    protected function addValuesQueueData(ProcessEntity $process): void
     {
         $data = array();
         $appointmentTime = $process->getFirstAppointment()->toDateTime()->format('H:i:s');
@@ -1252,7 +1282,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValues($data);
     }
 
-    protected function addValuesWaitingTimeData(ProcessEntity $process, $previousStatus = null)
+    protected function addValuesWaitingTimeData(ProcessEntity $process, $previousStatus = null): void
     {
         $data = array();
         $hasWaitingTimeAlready = (
@@ -1309,7 +1339,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
     }
 
 
-    protected function addValuesWayTimeData(ProcessEntity $process)
+    protected function addValuesWayTimeData(ProcessEntity $process): void
     {
         $data = array();
         if ($process->status == 'processing') {
@@ -1322,7 +1352,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         $this->addValues($data);
     }
 
-    protected function addValuesWasMissed($process)
+    protected function addValuesWasMissed(ProcessEntity $process): static
     {
         $data = [
             'wasMissed' => $process->wasMissed ? 1 : 0,
@@ -1332,7 +1362,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    protected function addValuesPriority($process)
+    protected function addValuesPriority(ProcessEntity $process): static
     {
         $data = [
             'priority' => $process->priority,
@@ -1342,7 +1372,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $this;
     }
 
-    protected function addValuesExternalUserId($process)
+    protected function addValuesExternalUserId(ProcessEntity $process): static
     {
         $data = [
             'external_user_id' => $process->externalUserId,
@@ -1397,13 +1427,18 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         return $data;
     }
 
-    /** @psalm-api */
-    public function removeDuplicates()
+    /**
+     * @psalm-api
+     */
+    public function removeDuplicates(): static
     {
         $this->query->groupBy('process.BuergerID');
         return $this;
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     protected function addRequiredJoins()
     {
@@ -1426,7 +1461,7 @@ class Process extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\
         }
     }
 
-    public function addConditionExternalUserId(string $externalUserId)
+    public function addConditionExternalUserId(string $externalUserId): static
     {
         $this->query->where('process.external_user_id', '=', $externalUserId);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusArchived.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusArchived.php
@@ -32,6 +32,10 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
             processing_time = :processingTime
     ';
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -66,19 +70,19 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
         ];
     }
 
-    public function addConditionArchiveId($archiveId)
+    public function addConditionArchiveId($archiveId): static
     {
         $this->query->where('process.BuergerarchivID', '=', $archiveId);
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->query->where('process.StandortID', '=', $scopeId);
         return $this;
     }
 
-    public function addConditionScopeIds($scopeIds)
+    public function addConditionScopeIds($scopeIds): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) use ($scopeIds) {
             foreach ($scopeIds as $scopeId) {
@@ -90,14 +94,16 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
     }
 
 
-    public function addConditionTime(\DateTimeInterface $now)
+    public function addConditionTime(\DateTimeInterface $now): static
     {
         $this->query->where('process.Datum', '=', $now->format('Y-m-d'));
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionTimes(array $dateTimes)
+    /**
+     * @psalm-api
+     */
+    public function addConditionTimes(array $dateTimes): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $condition) use ($dateTimes) {
             foreach ($dateTimes as $dateTime) {
@@ -108,19 +114,19 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
         return $this;
     }
 
-    public function addConditionIsMissed($missed)
+    public function addConditionIsMissed($missed): static
     {
         $this->query->where('process.nicht_erschienen', '=', $missed);
         return $this;
     }
 
-    public function addConditionWithAppointment($withAppointment)
+    public function addConditionWithAppointment($withAppointment): static
     {
         $this->query->where('process.mitTermin', '=', $withAppointment);
         return $this;
     }
 
-    public function addJoinStatisticFailed($dateTime, \BO\Zmsentities\Scope $scope)
+    public function addJoinStatisticFailed($dateTime, \BO\Zmsentities\Scope $scope): static
     {
         //use existing index with StandortID and Datum
         $this->leftJoin(
@@ -142,7 +148,7 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
         });
         return $this;
     }
-    public function addValuesNewArchive(\BO\Zmsentities\Process $process, \DateTimeInterface $now)
+    public function addValuesNewArchive(\BO\Zmsentities\Process $process, \DateTimeInterface $now): void
     {
         $processingTimeStr = $process->getProcessingTime();
         $bearbeitungszeit = null;
@@ -214,7 +220,7 @@ class ProcessStatusArchived extends \BO\Zmsbackend\Query\Base implements \BO\Zms
         return $services;
     }
 
-    public function addConditionOlderThanDate(\DateTimeInterface $dateTime)
+    public function addConditionOlderThanDate(\DateTimeInterface $dateTime): static
     {
         // Assuming 'Datum' is the column name that holds the date of the record
         // and you want to select records older than the specified $dateTime

--- a/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusFree.php
+++ b/zmsbackend/src/Zmsbackend/Process/Repository/ProcessStatusFree.php
@@ -2,9 +2,6 @@
 
 namespace BO\Zmsbackend\Process\Repository;
 
-/**
- *
- */
 class ProcessStatusFree extends \BO\Zmsbackend\Query\Base
 {
     /**
@@ -112,7 +109,7 @@ class ProcessStatusFree extends \BO\Zmsbackend\Query\Base
 
     const string GROUPBY_SELECT_PROCESSLIST_DAY = 'GROUP BY scope__id, appointments__0__date';
 
-    public static function buildDaysCondition($days)
+    public static function buildDaysCondition(array $days): string
     {
         $sql = 'AND (';
         $sqlPats = [];

--- a/zmsbackend/src/Zmsbackend/Process/Service/Process.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/Process.php
@@ -17,7 +17,11 @@ use BO\Zmsbackend\Helper\ProcessStatus;
  */
 class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\ResolveReferences
 {
-    public function readEntity($processId = null, $authKey = null, $resolveReferences = 2): ?Entity
+    /**
+     * @param \BO\Zmsbackend\Helper\NoAuth|null|string $authKey
+     * @param int|null|string $processId
+     */
+    public function readEntity(int|string|null $processId = null, string|\BO\Zmsbackend\Helper\NoAuth|null $authKey = null, int $resolveReferences = 2): ?Entity
     {
         if (null === $processId || null === $authKey) {
             return null;
@@ -35,7 +39,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $process;
     }
 
-    public function readById($processId, $resolveReferences = 1)
+    public function readById($processId, $resolveReferences = 1): Entity
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -44,8 +48,12 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $this->fetchOne($query, new Entity());
     }
 
+    /**
+     *
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
-    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
+    public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, int $resolveReferences)
     {
         if (0 <= $resolveReferences) {
             if ($entity->archiveId) {
@@ -62,8 +70,11 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
 
     /**
      * Update a process without changing appointment or scope
+     *
+     * @param null|string $previousStatus
+     *
      */
-    public function updateEntity(\BO\Zmsentities\Process $process, \DateTimeInterface $now, $resolveReferences = 0, $previousStatus = null, ?\BO\Zmsentities\Useraccount $useraccount = null)
+    public function updateEntity(\BO\Zmsentities\Process $process, \DateTimeInterface $now, int $resolveReferences = 0, string|null $previousStatus = null, ?\BO\Zmsentities\Useraccount $useraccount = null): Entity
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::UPDATE);
         $query->addConditionProcessId($process->getId());
@@ -85,7 +96,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $process;
     }
 
-    public function updateEntityDisplayNumber(Entity $process)
+    public function updateEntityDisplayNumber(Entity $process): Entity
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::UPDATE);
         $query->addConditionProcessId($process->getId());
@@ -143,7 +154,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $processEntity;
     }
 
-    public function redirectToScope($process, \BO\Zmsentities\Scope $scope, int $waitingNumber, ?\BO\Zmsentities\Useraccount $useraccount = null)
+    public function redirectToScope(Entity $process, \BO\Zmsentities\Scope $scope, int $waitingNumber, ?\BO\Zmsentities\Useraccount $useraccount = null): Entity
     {
         $datetime = \App::$now;
         $process->setStatus('confirmed');
@@ -162,7 +173,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $process;
     }
 
-    public function readSlotCount(\BO\Zmsentities\Process $process)
+    public function readSlotCount(\BO\Zmsentities\Process $process): Entity
     {
         $scope = new \BO\Zmsentities\Scope($process->scope);
         $requestRelationList = (new \BO\Zmsbackend\RequestRelation\Service\RequestRelation())
@@ -183,7 +194,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
     /**
      * write a new process with appointment and keep id and authkey from original process
      */
-    public function writeEntityWithNewAppointment(\BO\Zmsentities\Process $process, \BO\Zmsentities\Appointment $appointment, \DateTimeInterface $now, $slotType = 'public', $slotsRequired = 0, $resolveReferences = 0, $keepReserved = false)
+    public function writeEntityWithNewAppointment(\BO\Zmsentities\Process $process, \BO\Zmsentities\Appointment $appointment, \DateTimeInterface $now, $slotType = 'public', $slotsRequired = 0, $resolveReferences = 0, $keepReserved = false): Entity|null
     {
         // clone to new process with id = 0 and new appointment to reserve
         $processNew = clone $process;
@@ -215,7 +226,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
     /**
      * update following process with new credentials (also change process id if necessary)
      */
-    public function updateFollowingProcesses($processId, \BO\Zmsentities\Process $processData)
+    public function updateFollowingProcesses($processId, \BO\Zmsentities\Process $processData): void
     {
         $this->perform(\BO\Zmsbackend\Process\Repository\Process::QUERY_REASSIGN_PROCESS_CREDENTIALS, [
             'newProcessId' => $processData->getId(),
@@ -238,7 +249,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
     /**
      * update process requests with new credentials
      */
-    public function updateReassignedRequests($processId, $newProcessId)
+    public function updateReassignedRequests($processId, $newProcessId): void
     {
         $this->perform(\BO\Zmsbackend\Process\Repository\Process::QUERY_REASSIGN_PROCESS_REQUESTS, [
             'newProcessId' => $newProcessId,
@@ -250,7 +261,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
      * write a new process to DB
      *
      */
-    protected function writeNewProcess(\BO\Zmsentities\Process $process, \DateTimeInterface $dateTime, $parentProcess = 0, $childProcessCount = 0, $retry = true, $userAccount = null)
+    protected function writeNewProcess(\BO\Zmsentities\Process $process, \DateTimeInterface $dateTime, int $parentProcess = 0, int $childProcessCount = 0, bool $retry = true, \BO\Zmsentities\Useraccount|null $userAccount = null)
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::INSERT);
         $process->id = $this->readNewProcessId();
@@ -311,7 +322,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         ) : null;
     }
 
-    protected function readList($statement, $resolveReferences)
+    protected function readList($statement, $resolveReferences): Collection
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);
         $processList = new Collection();
@@ -392,11 +403,12 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
      * @param \DateTimeInterface $dateTime
      *
      * @return Collection
+     *
      */
     public function readProcessListByScopesAndTime(
         $scopeIds,
         \DateTimeInterface $dateTime,
-        $resolveReferences = 0,
+        int $resolveReferences = 0,
         $withEntities = []
     ) {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT, '', false, null, $withEntities);
@@ -455,8 +467,9 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
      * Read processList by scopeId and status
      *
      * @return Collection
+     *
      */
-    public function readProcessListByScopeAndStatus($scopeId, $status, $resolveReferences = 0, $limit = 1000, $offset = null)
+    public function readProcessListByScopeAndStatus(int $scopeId, string $status, int $resolveReferences = 0, $limit = 1000, $offset = null)
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -469,7 +482,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $this->readList($statement, $resolveReferences);
     }
 
-    public function readSearch(array $parameter, $resolveReferences = 0, $limit = 100, $offset = 0)
+    public function readSearch(array $parameter, $resolveReferences = 0, int $limit = 100, int $offset = 0)
     {
         $searchQuery = $this->extractSearchQuery($parameter);
         $query = $this->buildSearchQuery($parameter, $resolveReferences);
@@ -492,7 +505,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return (int) $this->fetchValue($query, $query->getParameters());
     }
 
-    protected function buildSearchQuery(array $parameter, $resolveReferences = 0, bool $withEntityMapping = true): \BO\Zmsbackend\Process\Repository\Process
+    protected function buildSearchQuery(array $parameter, int $resolveReferences = 0, bool $withEntityMapping = true): \BO\Zmsbackend\Process\Repository\Process
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -549,7 +562,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $queryString !== '' ? $queryString : null;
     }
 
-    protected function addSearchConditions(\BO\Zmsbackend\Process\Repository\Process $query, $parameter)
+    protected function addSearchConditions(\BO\Zmsbackend\Process\Repository\Process $query, array $parameter): \BO\Zmsbackend\Process\Repository\Process
     {
         if (isset($parameter['processId']) && $parameter['processId']) {
             $query->addConditionProcessId($parameter['processId']);
@@ -650,8 +663,9 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
      * Read processList by mail address and statuslist
      *
      * @return Collection
+     *
      */
-    public function readListByMailAndStatusList(string $mailAddress, array $statusList, $resolveReferences = 1, $limit = 300): Collection
+    public function readListByMailAndStatusList(string $mailAddress, array $statusList, int $resolveReferences = 1, int $limit = 300): Collection
     {
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -672,8 +686,9 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
      * @param \BO\Zmsentities\Process $process
      *
      * @return Entity|null
+     *
      */
-    public function updateProcessStatus(Entity $process, $status, \DateTimeInterface $dateTime, $resolveReferences = 0, $userAccount = null)
+    public function updateProcessStatus(Entity $process, string $status, \DateTimeInterface $dateTime, $resolveReferences = 0, $userAccount = null)
     {
         $process = (new ProcessStatus())
             ->writeUpdatedStatus($process, $status, $dateTime, $resolveReferences, $userAccount);
@@ -813,7 +828,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $status;
     }
 
-    protected function writeRequestsToDb(\BO\Zmsentities\Process $process)
+    protected function writeRequestsToDb(\BO\Zmsentities\Process $process): void
     {
         // Beware of resolveReferences=0 to not delete the existing requests, except for queued processes
         $hasRequests = ($process->requests && count($process->requests));
@@ -836,7 +851,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         }
     }
 
-    protected function deleteRequestsForProcessId($processId)
+    protected function deleteRequestsForProcessId($processId): bool
     {
         $status = false;
         if (0 < $processId) {
@@ -904,7 +919,7 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         return $this->readList($statement, $resolveReferences);
     }
 
-    public function readEmailReminderProcessListByInterval(\DateTimeInterface $now, \DateTimeInterface $lastRun, $defaultReminderInMinutes, $limit = 500, $offset = null, $resolveReferences = 0)
+    public function readEmailReminderProcessListByInterval(\DateTimeInterface $now, \DateTimeInterface $lastRun, $defaultReminderInMinutes, $limit = 500, $offset = null, int $resolveReferences = 0)
     {
         $selectQuery = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);
         $selectQuery

--- a/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusArchived.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusArchived.php
@@ -5,12 +5,12 @@ namespace BO\Zmsbackend\Process\Service;
 use BO\Zmsentities\Processarchived as Entity;
 use BO\Zmsentities\Collection\ProcessList as Collection;
 
-/**
- *
- */
 class ProcessStatusArchived extends Process
 {
-    public function readArchivedEntity($archiveId, $resolveReferences = 0)
+    /**
+     * @param false|string $archiveId
+     */
+    public function readArchivedEntity(string|false $archiveId, $resolveReferences = 0)
     {
         if (!$archiveId) {
             return null;
@@ -53,7 +53,11 @@ class ProcessStatusArchived extends Process
         return $this->readResolvedList($query, $resolveReferences);
     }
 
-    public function readListByScopesAndDates($scopeIds, $dateTimes, $resolveReferences = 0)
+    /**
+     * @param (\BO\Zmsentities\Helper\DateTime|false)[] $dateTimes
+     *
+     */
+    public function readListByScopesAndDates(array $scopeIds, array $dateTimes, $resolveReferences = 0)
     {
         $query = new \BO\Zmsbackend\Process\Repository\ProcessStatusArchivedToday(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -98,7 +102,7 @@ class ProcessStatusArchived extends Process
         return $this->readResolvedList($query, $resolveReferences);
     }
 
-    protected function readResolvedList($query, $resolveReferences)
+    protected function readResolvedList(\BO\Zmsbackend\Process\Repository\ProcessStatusArchived $query, $resolveReferences): Collection
     {
         $processList = new Collection();
         $resultList = $this->fetchList($query, new Entity());
@@ -186,7 +190,7 @@ class ProcessStatusArchived extends Process
     public function writeNewArchivedProcess(
         \BO\Zmsentities\Process $process,
         \DateTimeInterface $now,
-        $resolveReferences = 0,
+        int $resolveReferences = 0,
         bool $calculateStatistic = false
     ) {
         $query = new \BO\Zmsbackend\Process\Repository\ProcessStatusArchivedToday(\BO\Zmsbackend\Query\Base::INSERT);
@@ -211,7 +215,7 @@ class ProcessStatusArchived extends Process
         return $this->readArchivedEntity($archiveId, $resolveReferences);
     }
 
-    protected function writeXRequestsArchived($processId, $archiveId)
+    protected function writeXRequestsArchived($processId, $archiveId): void
     {
         $query = new \BO\Zmsbackend\Request\Repository\XRequest(\BO\Zmsbackend\Query\Base::UPDATE);
         $query->addConditionProcessId($processId);

--- a/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusFree.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusFree.php
@@ -10,11 +10,15 @@ use BO\Zmsentities\Collection\ProcessList as Collection;
  */
 class ProcessStatusFree extends Process
 {
+    /**
+     * @return (\BO\Zmsbackend\Day\Service\Day|\BO\Zmsentities\Calendar|array)[]
+     *
+     */
     private function prepareCalendarAndDays(
         \BO\Zmsentities\Calendar $calendar,
         \DateTimeInterface $now,
-        $slotsRequired = null
-    ) {
+        int|null $slotsRequired = null
+    ): array {
         $calendar = (new \BO\Zmsbackend\Calendar\Service\Calendar())->readResolvedEntity($calendar, $now, true);
         $dayquery = new \BO\Zmsbackend\Day\Service\Day();
         $dayquery->writeTemporaryScopeList($calendar, $slotsRequired);
@@ -99,9 +103,9 @@ class ProcessStatusFree extends Process
 
     private function getProcessDataHandle(
         array $days,
-        $slotType,
-        $slotsRequired,
-        $groupData,
+        string $slotType,
+        int|null $slotsRequired,
+        bool $groupData,
         bool $useAvailabilityQuery = false
     ) {
         $query = $useAvailabilityQuery
@@ -125,10 +129,10 @@ class ProcessStatusFree extends Process
     public function readFreeProcesses(
         \BO\Zmsentities\Calendar $calendar,
         \DateTimeInterface $now,
-        $slotType = 'public',
-        $slotsRequired = null,
-        $groupData = false
-    ) {
+        string $slotType = 'public',
+        int|null $slotsRequired = null,
+        bool $groupData = false
+    ): Collection {
         list($calendar, $dayquery, $days) = $this->prepareCalendarAndDays($calendar, $now, $slotsRequired);
         $processData = $this->getProcessDataHandle($days, $slotType, $slotsRequired, $groupData);
         $processList = new Collection();
@@ -352,7 +356,7 @@ class ProcessStatusFree extends Process
         ];
     }
 
-    public function readReservedProcesses($resolveReferences = 2)
+    public function readReservedProcesses($resolveReferences = 2): Collection
     {
         $processList = new Collection();
         $query = new \BO\Zmsbackend\Process\Repository\Process(\BO\Zmsbackend\Query\Base::SELECT);

--- a/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusQueued.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/ProcessStatusQueued.php
@@ -5,16 +5,13 @@ namespace BO\Zmsbackend\Process\Service;
 use BO\Zmsentities\Process as Entity;
 use BO\Zmsentities\Collection\ProcessList as Collection;
 
-/**
- *
- */
 class ProcessStatusQueued extends Process
 {
     public function writeNewFromTicketprinter(
         \BO\Zmsentities\Scope $scope,
         \DateTimeInterface $dateTime,
         array $requestIds = []
-    ) {
+    ): Entity {
         $process = Entity::createFromScope($scope, $dateTime);
         $process->setStatus('queued');
         $process->isTicketprinter = true;
@@ -28,7 +25,7 @@ class ProcessStatusQueued extends Process
         return $process;
     }
 
-    public function writeNewFromAdmin(Entity $process, \DateTimeInterface $dateTime)
+    public function writeNewFromAdmin(Entity $process, \DateTimeInterface $dateTime): Entity|null
     {
         $process->setStatus('queued');
         $process->getFirstAppointment()->date = $dateTime->modify('00:00:00')->getTimestamp();

--- a/zmsbackend/src/Zmsbackend/Provider/Repository/Provider.php
+++ b/zmsbackend/src/Zmsbackend/Provider/Repository/Provider.php
@@ -6,8 +6,13 @@ class Provider extends \BO\Zmsbackend\Query\Base
 {
     const string TABLE = 'provider';
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         $mapping = [
             'contact__city' => 'provider.contact__city',
@@ -30,7 +35,7 @@ class Provider extends \BO\Zmsbackend\Query\Base
         return $mapping;
     }
 
-    public function addConditionIsAssigned($isAssigned)
+    public function addConditionIsAssigned($isAssigned): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Query\Scope::TABLE, 'assignedscope'),
@@ -46,7 +51,7 @@ class Provider extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionProviderId($providerId)
+    public function addConditionProviderId($providerId): static
     {
         $this->query->where('provider.id', '=', $providerId);
         return $this;
@@ -59,7 +64,7 @@ class Provider extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionProviderSource($source)
+    public function addConditionProviderSource($source): static
     {
         $this->query->where('provider.source', '=', $source);
         return $this;
@@ -68,7 +73,7 @@ class Provider extends \BO\Zmsbackend\Query\Base
     /**
      * @todo find calls and implement "sourceName"-parameter to remove default value
      */
-    public function addConditionRequestCsv($requestIdCsv, $sourceName = 'dldb')
+    public function addConditionRequestCsv($requestIdCsv, $sourceName = 'dldb'): void
     {
         $requestIdList = explode(',', $requestIdCsv);
         $this->leftJoin(

--- a/zmsbackend/src/Zmsbackend/Provider/Service/Provider.php
+++ b/zmsbackend/src/Zmsbackend/Provider/Service/Provider.php
@@ -8,7 +8,7 @@ use BO\Zmsentities\Collection\ProviderList as Collection;
 
 class Provider extends \BO\Zmsbackend\Base
 {
-    public function readEntity($source, $providerId, $resolveReferences = 0, $disableCache = false)
+    public function readEntity($source, $providerId, int $resolveReferences = 0, bool $disableCache = false)
     {
         $cacheKey = "provider-$source-$providerId-$resolveReferences";
 
@@ -82,9 +82,8 @@ class Provider extends \BO\Zmsbackend\Base
 
     /**
      * @SuppressWarnings(Param)
-     *
      */
-    protected function readCollection($query)
+    protected function readCollection(\BO\Zmsbackend\Provider\Repository\Provider $query): Collection
     {
         $providerList = new Collection();
         $statement = $this->fetchStatement($query);
@@ -95,7 +94,11 @@ class Provider extends \BO\Zmsbackend\Base
         return $providerList;
     }
 
-    public function readListBySource($source, $resolveReferences = 0, $isAssigned = null, $requestIdCsv = null)
+    /**
+     * @param null|true $isAssigned
+     *
+     */
+    public function readListBySource($source, int $resolveReferences = 0, bool|null $isAssigned = null, $requestIdCsv = null)
     {
         $this->testSource($source);
         $query = new \BO\Zmsbackend\Provider\Repository\Provider(\BO\Zmsbackend\Query\Base::SELECT);
@@ -195,7 +198,7 @@ class Provider extends \BO\Zmsbackend\Base
         return $provider;
     }
 
-    public function writeDeleteEntity($providerId, $source)
+    public function writeDeleteEntity($providerId, $source): bool
     {
         $provider = $this->readEntity($source, $providerId);
         $query = new \BO\Zmsbackend\Provider\Repository\Provider(\BO\Zmsbackend\Query\Base::DELETE);
@@ -205,13 +208,16 @@ class Provider extends \BO\Zmsbackend\Base
         return $this->deleteItem($query);
     }
 
-    public function writeDeleteListBySource($source)
+    public function writeDeleteListBySource(string $source): bool
     {
         $query = new \BO\Zmsbackend\Provider\Repository\Provider(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionProviderSource($source);
         return $this->deleteItem($query);
     }
 
+    /**
+     * @return void
+     */
     protected function testSource($source)
     {
         if (! (new \BO\Zmsbackend\Source\Service\Source())->readEntity($source)) {
@@ -219,6 +225,9 @@ class Provider extends \BO\Zmsbackend\Base
         }
     }
 
+    /**
+     * @return void
+     */
     public function removeCache(Entity $provider)
     {
         if (!App::$cache || !isset($provider->id)) {

--- a/zmsbackend/src/Zmsbackend/Query/Base.php
+++ b/zmsbackend/src/Zmsbackend/Query/Base.php
@@ -176,12 +176,12 @@ abstract class Base
         return $this;
     }
 
-    public function setDistinctSelect()
+    public function setDistinctSelect(): void
     {
         $this->query->queryBaseStatement('SELECT DISTINCT');
     }
 
-    public function setResolveLevel($resolveLevel): static
+    public function setResolveLevel(int|null $resolveLevel): static
     {
         if ($resolveLevel !== null) {
             $this->resolveLevel = $resolveLevel;
@@ -255,6 +255,8 @@ abstract class Base
     /**
      * Add joins to table if required
      * Override this method if join are required for a select
+     *
+     * @return void
      */
     protected function addRequiredJoins()
     {
@@ -283,8 +285,10 @@ abstract class Base
         return $this;
     }
 
-    /** @psalm-api */
-    public function setWithEntities($withEntities = [])
+    /**
+     * @psalm-api
+     */
+    public function setWithEntities($withEntities = []): void
     {
         $this->withEntities = $withEntities;
     }
@@ -299,7 +303,7 @@ abstract class Base
         return [];
     }
 
-    protected function leftJoin($alias, $left = null, $operator = null, $right = null)
+    protected function leftJoin(Alias $alias, string|Expression|null $left = null, string|null $operator = null, string|null $right = null): QueryBuilder
     {
         $aliasId = $alias->getAliasIdentifier();
         if (!in_array($aliasId, $this->joinedAliasList)) {
@@ -311,7 +315,7 @@ abstract class Base
         return $this->query;
     }
 
-    protected function innerJoin($alias, $left = null, $operator = null, $right = null)
+    protected function innerJoin(Alias $alias, string|null $left = null, string|null $operator = null, string|null $right = null): QueryBuilder
     {
         $aliasId = $alias->getAliasIdentifier();
         if (!in_array($aliasId, $this->joinedAliasList)) {
@@ -343,6 +347,10 @@ abstract class Base
         return $this->query->params();
     }
 
+    /**
+     * @return array
+     *
+     */
     public function getReferenceMapping()
     {
         return [
@@ -354,7 +362,7 @@ abstract class Base
      *
      * @return \BO\Zmsbackend\Query\Builder\Expression
      */
-    protected static function expression($string)
+    protected static function expression(string $string)
     {
         return new Expression($string);
     }
@@ -374,12 +382,12 @@ abstract class Base
         return $this;
     }
 
-    protected function getPrefixed($prefix)
+    protected function getPrefixed($prefix): string
     {
         return $this->prefix . $prefix;
     }
 
-    protected function getPrefixedList($unprefixedList)
+    protected function getPrefixedList(array $unprefixedList): array
     {
         $prefixed = [];
         foreach ($unprefixedList as $key => $value) {
@@ -410,7 +418,7 @@ abstract class Base
     /**
      * Add values to a insert or update query
      */
-    public function addValues($values): static
+    public function addValues(array $values): static
     {
         $this->query->values($values);
         return $this;
@@ -428,8 +436,10 @@ abstract class Base
     /**
      * postProcess data including joined queries if necessary
      *
+     * @param (null|scalar)[] $data
+     *
      */
-    public function postProcessJoins($data)
+    public function postProcessJoins(array $data)
     {
         $data = $this->postProcess($data);
         foreach ($this->joinedQueryList as $query) {
@@ -438,7 +448,7 @@ abstract class Base
         return $data;
     }
 
-    public function shouldLoadEntity($name)
+    public function shouldLoadEntity(string $name): bool
     {
         if (empty($this->withEntities)) {
             return true;

--- a/zmsbackend/src/Zmsbackend/Query/Builder/Where.php
+++ b/zmsbackend/src/Zmsbackend/Query/Builder/Where.php
@@ -77,8 +77,12 @@ trait Where
         return $this;
     }
 
-    /** @psalm-api */
-    public function whereIn(string $field, array $values)
+    /**
+     * @psalm-api
+     *
+     * @return Update|array
+     */
+    public function whereIn(string $field, array $values): array|Update
     {
         if (empty($values)) {
             throw new \InvalidArgumentException('whereIn() requires a non-empty $values array.');

--- a/zmsbackend/src/Zmsbackend/Query/Builder/Where.php
+++ b/zmsbackend/src/Zmsbackend/Query/Builder/Where.php
@@ -79,10 +79,8 @@ trait Where
 
     /**
      * @psalm-api
-     *
-     * @return Update|array
      */
-    public function whereIn(string $field, array $values): array|Update
+    public function whereIn(string $field, array $values): static|array
     {
         if (empty($values)) {
             throw new \InvalidArgumentException('whereIn() requires a non-empty $values array.');

--- a/zmsbackend/src/Zmsbackend/Query/Scope.php
+++ b/zmsbackend/src/Zmsbackend/Query/Scope.php
@@ -16,7 +16,7 @@ class Scope extends Base implements MappingInterface
             scope.`BehoerdenID` = :department_id
     ';
 
-    public function getQueryLastWaitingNumber()
+    public function getQueryLastWaitingNumber(): string
     {
         return '
             SELECT letztewartenr
@@ -24,7 +24,7 @@ class Scope extends Base implements MappingInterface
             WHERE scope.`StandortID` = :scope_id LIMIT 1 FOR UPDATE';
     }
 
-    public function getQueryLastDisplayNumber()
+    public function getQueryLastDisplayNumber(): string
     {
         return '
             SELECT last_display_number
@@ -32,7 +32,7 @@ class Scope extends Base implements MappingInterface
             WHERE scope.`StandortID` = :scope_id LIMIT 1 FOR UPDATE';
     }
 
-    public function getQueryGivenNumbersInContingent()
+    public function getQueryGivenNumbersInContingent(): string
     {
         return '
             SELECT *
@@ -51,7 +51,7 @@ class Scope extends Base implements MappingInterface
         ';
     }
 
-    public function getQuerySimpleClusterMatch()
+    public function getQuerySimpleClusterMatch(): string
     {
         return '
             SELECT s.StandortID AS id, p.name AS contact__name, s.standortkuerzel AS shortName
@@ -64,7 +64,7 @@ class Scope extends Base implements MappingInterface
         ';
     }
 
-    public function getQuerySimpleDepartmentMatch()
+    public function getQuerySimpleDepartmentMatch(): string
     {
         return '
             SELECT s.StandortID AS id, p.name AS contact__name, s.standortkuerzel AS shortName
@@ -76,17 +76,17 @@ class Scope extends Base implements MappingInterface
         ';
     }
 
-    public function getQueryDepartmentIdByScopeId()
+    public function getQueryDepartmentIdByScopeId(): string
     {
         return 'SELECT BehoerdenID FROM standort WHERE StandortID = ?';
     }
 
-    public function getQueryClusterIdsByScopeId()
+    public function getQueryClusterIdsByScopeId(): string
     {
         return 'SELECT clusterID FROM clusterzuordnung WHERE standortID = ?';
     }
 
-    public function getQueryReadImageData()
+    public function getQueryReadImageData(): string
     {
         return '
             SELECT `imagecontent`, `imagename`
@@ -96,7 +96,7 @@ class Scope extends Base implements MappingInterface
         ';
     }
 
-    public function getQueryWriteImageData()
+    public function getQueryWriteImageData(): string
     {
         return '
             REPLACE INTO `imagedata`
@@ -106,7 +106,7 @@ class Scope extends Base implements MappingInterface
         ';
     }
 
-    public function getQueryDeleteImage()
+    public function getQueryDeleteImage(): string
     {
         return '
             DELETE FROM `imagedata`
@@ -130,6 +130,9 @@ class Scope extends Base implements MappingInterface
         return [];
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     protected function addRequiredJoins()
     {
@@ -161,6 +164,10 @@ class Scope extends Base implements MappingInterface
     }
 
     //Todo: now() Parameter to enable query cache
+    /**
+     * @return (Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -248,13 +255,13 @@ class Scope extends Base implements MappingInterface
         ], 'strlen');
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->query->where('scope.StandortID', '=', $scopeId);
         return $this;
     }
 
-    public function addConditionScopeIds(array $scopeIds)
+    public function addConditionScopeIds(array $scopeIds): static
     {
         $scopeIds = array_values(array_unique(array_map('intval', $scopeIds)));
         if (!$scopeIds) {
@@ -266,14 +273,16 @@ class Scope extends Base implements MappingInterface
         return $this;
     }
 
-    public function addConditionWithAdminEmail()
+    public function addConditionWithAdminEmail(): static
     {
         $this->query->where('scope.emailstandortadmin', '!=', '');
         return $this;
     }
 
-    /** @psalm-api */
-    public function addSelectWorkstationCount($dateTime)
+    /**
+     * @psalm-api
+     */
+    public function addSelectWorkstationCount($dateTime): void
     {
         $this->query->select(
             ['status__queue__workstationCount' => self::expression('
@@ -293,19 +302,19 @@ class Scope extends Base implements MappingInterface
         );
     }
 
-    public function addConditionProviderId($providerId)
+    public function addConditionProviderId($providerId): static
     {
         $this->query->where('scope.InfoDienstleisterID', '=', $providerId);
         return $this;
     }
 
-    public function addConditionDepartmentId($departmentId)
+    public function addConditionDepartmentId($departmentId): static
     {
         $this->query->where('scope.BehoerdenID', '=', $departmentId);
         return $this;
     }
 
-    public function addConditionClusterId($clusterId)
+    public function addConditionClusterId($clusterId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias('clusterzuordnung', 'cluster_scope'),
@@ -317,7 +326,11 @@ class Scope extends Base implements MappingInterface
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Scope $entity, $parentId = null)
+    /**
+     * @return (int|mixed|string)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Scope $entity, $parentId = null): array
     {
         $data = array();
         if ($parentId) {
@@ -393,7 +406,11 @@ class Scope extends Base implements MappingInterface
         return $data;
     }
 
-    public function setEmergencyEntityMapping(\BO\Zmsentities\Scope $entity)
+    /**
+     * @return (int|mixed)[]
+     *
+     */
+    public function setEmergencyEntityMapping(\BO\Zmsentities\Scope $entity): array
     {
         $data['notrufantwort'] = ($entity->toProperty()->status->emergency->acceptedByWorkstation->get(-1));
         $data['notrufausgeloest'] = intval($entity->toProperty()->status->emergency->activated->get(0));
@@ -401,7 +418,11 @@ class Scope extends Base implements MappingInterface
         return $data;
     }
 
-    public function setGhostWorkstationCountEntityMapping(\BO\Zmsentities\Scope $entity, \DateTimeInterface $dateTime)
+    /**
+     * @return (mixed|string)[]
+     *
+     */
+    public function setGhostWorkstationCountEntityMapping(\BO\Zmsentities\Scope $entity, \DateTimeInterface $dateTime): array
     {
         $data['virtuellesachbearbeiterzahl'] = $entity->getStatus('queue', 'ghostWorkstationCount');
         $data['datumvirtuellesachbearbeiterzahl'] = $dateTime->format('Y-m-d');
@@ -481,7 +502,7 @@ class Scope extends Base implements MappingInterface
         return $data;
     }
 
-    private function setIfEmpty(&$data, $checkKey, array $setKeys)
+    private function setIfEmpty(&$data, string $checkKey, array $setKeys): void
     {
         if (!$data[$this->getPrefixed($checkKey)]) {
             foreach ($setKeys as $key => $value) {

--- a/zmsbackend/src/Zmsbackend/Queue/Repository/Queue.php
+++ b/zmsbackend/src/Zmsbackend/Queue/Repository/Queue.php
@@ -11,6 +11,10 @@ class Queue extends \BO\Zmsbackend\Process\Repository\Process implements \BO\Zms
 {
     const string ALIAS = 'process';
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -84,6 +88,9 @@ class Queue extends \BO\Zmsbackend\Process\Repository\Process implements \BO\Zms
         ];
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function addConditionAssigned()
     {
@@ -120,6 +127,9 @@ class Queue extends \BO\Zmsbackend\Process\Repository\Process implements \BO\Zms
         return $data;
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     protected function addRequiredJoins()
     {

--- a/zmsbackend/src/Zmsbackend/Request/Api/RequestVariantList.php
+++ b/zmsbackend/src/Zmsbackend/Request/Api/RequestVariantList.php
@@ -6,6 +6,9 @@ use BO\Slim\Render;
 
 class RequestVariantList extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     #[\Override]
     public function readResponse($request, $response, array $args)
     {

--- a/zmsbackend/src/Zmsbackend/Request/Repository/Request.php
+++ b/zmsbackend/src/Zmsbackend/Request/Repository/Request.php
@@ -23,7 +23,11 @@ class Request extends \BO\Zmsbackend\Query\Base
         ORDER BY ba.`BuergeranliegenID` ASC
     ';
 
-    public function getEntityMapping()
+    /**
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         $mapping = [
             'id' => 'request.id',
@@ -40,7 +44,7 @@ class Request extends \BO\Zmsbackend\Query\Base
         return $mapping;
     }
 
-    public function addConditionRequestId($requestId)
+    public function addConditionRequestId($requestId): static
     {
         $this->query->where('id', '=', $requestId);
         return $this;
@@ -53,7 +57,7 @@ class Request extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionProcessId($processId)
+    public function addConditionProcessId($processId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias("buergeranliegen", 'buergeranliegen'),
@@ -95,7 +99,7 @@ class Request extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionArchiveId($archiveId)
+    public function addConditionArchiveId($archiveId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias("buergeranliegen", 'buergeranliegen'),
@@ -109,7 +113,7 @@ class Request extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionProvider($providerId, $source)
+    public function addConditionProvider($providerId, $source): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias("request_provider", 'xrequest'),
@@ -125,7 +129,7 @@ class Request extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    public function addConditionRequestSource($source)
+    public function addConditionRequestSource($source): static
     {
         $this->query->where('request.source', '=', $source);
         return $this;
@@ -140,7 +144,7 @@ class Request extends \BO\Zmsbackend\Query\Base
         return $data;
     }
 
-    public function addConditionIds($ids)
+    public function addConditionIds($ids): static
     {
         $this->query->where(function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($ids) {
             foreach ($ids as $id) {

--- a/zmsbackend/src/Zmsbackend/Request/Repository/XRequest.php
+++ b/zmsbackend/src/Zmsbackend/Request/Repository/XRequest.php
@@ -10,7 +10,7 @@ class XRequest extends \BO\Zmsbackend\Query\Base
      */
     const string TABLE = 'buergeranliegen';
 
-    public function addConditionProcessId($processId)
+    public function addConditionProcessId($processId): static
     {
         $this->query->where('BuergerID', '=', $processId);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Request/Service/Request.php
+++ b/zmsbackend/src/Zmsbackend/Request/Service/Request.php
@@ -13,7 +13,7 @@ use BO\Zmsentities\Collection\RequestList as Collection;
  */
 class Request extends \BO\Zmsbackend\Base
 {
-    public function readEntity($source, $requestId, $resolveReferences = 0, $disableCache = false)
+    public function readEntity(string $source, string $requestId, int $resolveReferences = 0, bool $disableCache = false)
     {
         $cacheKey = "request-$source-$requestId-$resolveReferences";
 
@@ -96,9 +96,8 @@ class Request extends \BO\Zmsbackend\Base
 
     /**
      * @SuppressWarnings(Param)
-     *
      */
-    protected function readCollection($query)
+    protected function readCollection(\BO\Zmsbackend\Request\Repository\Request $query): Collection
     {
         $requestList = new Collection();
         $statement = $this->fetchStatement($query);
@@ -217,7 +216,7 @@ class Request extends \BO\Zmsbackend\Base
         return $collection;
     }
 
-    public function readAllRequestsForProcessIds(array $processIds, $resolveReferences = 0): array
+    public function readAllRequestsForProcessIds(array $processIds, int $resolveReferences = 0): array
     {
         $processIds = array_values(array_unique(array_filter(
             array_map('intval', $processIds),
@@ -299,7 +298,7 @@ class Request extends \BO\Zmsbackend\Base
         return $ids;
     }
 
-    public function readListByProvider($source, $providerId, $resolveReferences = 0)
+    public function readListByProvider($source, $providerId, int $resolveReferences = 0)
     {
         $this->testSource($source);
         $query = new \BO\Zmsbackend\Request\Repository\Request(\BO\Zmsbackend\Query\Base::SELECT);
@@ -452,7 +451,7 @@ class Request extends \BO\Zmsbackend\Base
         return $requestList;
     }
 
-    public function readListByCluster(\BO\Zmsentities\Cluster $cluster, $resolveReferences = 0)
+    public function readListByCluster(\BO\Zmsentities\Cluster $cluster, $resolveReferences = 0): Collection
     {
         $intersectList = array();
         if ($cluster->scopes->count()) {
@@ -522,7 +521,7 @@ class Request extends \BO\Zmsbackend\Base
         return $this->readEntity($source, $request['id'], 0, true);
     }
 
-    public function writeDeleteEntity($requestId, $source)
+    public function writeDeleteEntity($requestId, $source): bool
     {
         $query = new \BO\Zmsbackend\Request\Repository\Request(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionRequestId($requestId);
@@ -531,13 +530,16 @@ class Request extends \BO\Zmsbackend\Base
         return $this->deleteItem($query);
     }
 
-    public function writeDeleteListBySource($source)
+    public function writeDeleteListBySource(string $source): bool
     {
         $query = new \BO\Zmsbackend\Request\Repository\Request(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionRequestSource($source);
         return $this->deleteItem($query);
     }
 
+    /**
+     * @return void
+     */
     protected function testSource($source)
     {
         if (! (new \BO\Zmsbackend\Source\Service\Source())->readEntity($source)) {
@@ -545,6 +547,9 @@ class Request extends \BO\Zmsbackend\Base
         }
     }
 
+    /**
+     * @return void
+     */
     public function removeCache(Entity $request)
     {
         if (!App::$cache) {

--- a/zmsbackend/src/Zmsbackend/Request/Service/Request.php
+++ b/zmsbackend/src/Zmsbackend/Request/Service/Request.php
@@ -13,7 +13,7 @@ use BO\Zmsentities\Collection\RequestList as Collection;
  */
 class Request extends \BO\Zmsbackend\Base
 {
-    public function readEntity(string $source, string $requestId, int $resolveReferences = 0, bool $disableCache = false)
+    public function readEntity(string $source, string $requestId, int|null $resolveReferences = 0, bool $disableCache = false)
     {
         $cacheKey = "request-$source-$requestId-$resolveReferences";
 

--- a/zmsbackend/src/Zmsbackend/RequestRelation/Repository/RequestRelation.php
+++ b/zmsbackend/src/Zmsbackend/RequestRelation/Repository/RequestRelation.php
@@ -8,6 +8,10 @@ class RequestRelation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbacken
 
     const string ALIAS = 'request_provider';
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -21,6 +25,10 @@ class RequestRelation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbacken
         ];
     }
 
+    /**
+     * @return \BO\Zmsbackend\Query\Builder\Expression[]
+     *
+     */
     #[\Override]
     public function getReferenceMapping()
     {
@@ -34,25 +42,25 @@ class RequestRelation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbacken
         ];
     }
 
-    public function addConditionRequestId($requestId)
+    public function addConditionRequestId($requestId): static
     {
         $this->query->where(self::TABLE . '.request__id', '=', $requestId);
         return $this;
     }
 
-    public function addConditionProviderId($providerId)
+    public function addConditionProviderId($providerId): static
     {
         $this->query->where(self::TABLE . '.provider__id', '=', $providerId);
         return $this;
     }
 
-    public function addConditionBookable()
+    public function addConditionBookable(): static
     {
         $this->query->where(self::TABLE . '.bookable', '=', 1);
         return $this;
     }
 
-    public function addConditionSource($sourceName)
+    public function addConditionSource($sourceName): static
     {
         $this->query->where(self::TABLE . '.source', '=', $sourceName);
         return $this;

--- a/zmsbackend/src/Zmsbackend/RequestRelation/Service/RequestRelation.php
+++ b/zmsbackend/src/Zmsbackend/RequestRelation/Service/RequestRelation.php
@@ -7,7 +7,7 @@ use BO\Zmsentities\Collection\RequestRelationList as Collection;
 
 class RequestRelation extends \BO\Zmsbackend\Base
 {
-    public function readEntity($requestId, $providerId, $resolveReferences = 0)
+    public function readEntity($requestId, $providerId, int $resolveReferences = 0): Entity
     {
         $query = new \BO\Zmsbackend\RequestRelation\Repository\RequestRelation(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -124,7 +124,7 @@ class RequestRelation extends \BO\Zmsbackend\Base
         return $this->readListBySource($source);
     }
 
-    protected function readList($statement)
+    protected function readList($statement): Collection
     {
         $collection = new Collection();
         while ($requestRelationData = $statement->fetch(\PDO::FETCH_ASSOC)) {
@@ -134,7 +134,7 @@ class RequestRelation extends \BO\Zmsbackend\Base
         return $collection;
     }
 
-    public function writeDeleteListBySource($source)
+    public function writeDeleteListBySource(string $source): bool
     {
         $query = new \BO\Zmsbackend\RequestRelation\Repository\RequestRelation(\BO\Zmsbackend\Query\Base::DELETE);
         $query->addConditionSource($source);

--- a/zmsbackend/src/Zmsbackend/RequestVariant/Repository/RequestVariant.php
+++ b/zmsbackend/src/Zmsbackend/RequestVariant/Repository/RequestVariant.php
@@ -7,6 +7,10 @@ class RequestVariant extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend
     const string TABLE = 'request_variant';
     const string ALIAS = 'request_variant';
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -16,7 +20,7 @@ class RequestVariant extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend
         ];
     }
 
-    public function orderByName()
+    public function orderByName(): static
     {
         $this->query->orderBy(self::TABLE . '.name', 'ASC');
         return $this;

--- a/zmsbackend/src/Zmsbackend/Role/Api/RoleAdd.php
+++ b/zmsbackend/src/Zmsbackend/Role/Api/RoleAdd.php
@@ -11,6 +11,9 @@ use BO\Mellon\Validator;
 
 class RoleAdd extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return ResponseInterface
+     */
     public function readResponse(
         RequestInterface $request,
         ResponseInterface $response,

--- a/zmsbackend/src/Zmsbackend/Role/Api/RoleDelete.php
+++ b/zmsbackend/src/Zmsbackend/Role/Api/RoleDelete.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class RoleDelete extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return ResponseInterface
+     */
     public function readResponse(
         RequestInterface $request,
         ResponseInterface $response,

--- a/zmsbackend/src/Zmsbackend/Role/Api/RoleGet.php
+++ b/zmsbackend/src/Zmsbackend/Role/Api/RoleGet.php
@@ -7,6 +7,9 @@ use BO\Zmsbackend\Role\Service\Role;
 
 class RoleGet extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse($request, $response, array $args)
     {
         (new \BO\Zmsbackend\Helper\User($request, 1))->checkPermissions('superuser');

--- a/zmsbackend/src/Zmsbackend/Role/Api/RoleListGet.php
+++ b/zmsbackend/src/Zmsbackend/Role/Api/RoleListGet.php
@@ -7,6 +7,9 @@ use BO\Zmsbackend\Role\Service\Role;
 
 class RoleListGet extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse($request, $response, array $args)
     {
         (new \BO\Zmsbackend\Helper\User($request, 1))->checkPermissions('useraccount');

--- a/zmsbackend/src/Zmsbackend/Role/Api/RoleUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Role/Api/RoleUpdate.php
@@ -9,6 +9,9 @@ use BO\Zmsentities\Role as RoleEntity;
 
 class RoleUpdate extends \BO\Zmsbackend\Api\BaseController
 {
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function readResponse(
         \Psr\Http\Message\RequestInterface $request,
         \Psr\Http\Message\ResponseInterface $response,

--- a/zmsbackend/src/Zmsbackend/Role/Repository/Role.php
+++ b/zmsbackend/src/Zmsbackend/Role/Repository/Role.php
@@ -9,6 +9,10 @@ class Role extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
      */
     const string TABLE = 'role';
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {

--- a/zmsbackend/src/Zmsbackend/Scope/Service/Scope.php
+++ b/zmsbackend/src/Zmsbackend/Scope/Service/Scope.php
@@ -17,7 +17,10 @@ class Scope extends \BO\Zmsbackend\Base
 {
     public static $cache = [ ];
 
-    public function readEntity($scopeId, $resolveReferences = 0, $disableCache = false): ?Entity
+    /**
+     * @param false|int|string $scopeId
+     */
+    public function readEntity(string|int|false $scopeId, int $resolveReferences = 0, bool $disableCache = false): ?Entity
     {
         $cacheKey = "scope-$scopeId-$resolveReferences";
 
@@ -92,10 +95,13 @@ class Scope extends \BO\Zmsbackend\Base
         return $ordered;
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(
         \BO\Zmsentities\Schema\Entity $entity,
-        $resolveReferences,
+        int $resolveReferences,
         $disableCache = false
     ) {
         if (0 < $resolveReferences) {
@@ -107,9 +113,9 @@ class Scope extends \BO\Zmsbackend\Base
 
     public function readByClusterId(
         $clusterId,
-        $resolveReferences = 0,
+        int $resolveReferences = 0,
         $disableCache = false
-    ) {
+    ): Collection {
         $cacheKey = "scopeReadByClusterId-$clusterId-$resolveReferences";
 
         if (!$disableCache && \App::$cache && \App::$cache->has($cacheKey)) {
@@ -166,7 +172,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $scopeList;
     }
 
-    public function readByProviderId($providerId, $resolveReferences = 0, $disableCache = false)
+    public function readByProviderId($providerId, int $resolveReferences = 0, $disableCache = false): Collection
     {
         $cacheKey = "scopeReadByProviderId-$providerId-$resolveReferences";
 
@@ -216,7 +222,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $scopeList;
     }
 
-    public function readByRequestId($requestId, $source, $resolveReferences = 0)
+    public function readByRequestId($requestId, $source, $resolveReferences = 0): Collection
     {
         $scopeList = new Collection();
         $providerList = (new \BO\Zmsbackend\Provider\Service\Provider())->readListBySource($source, 0, true, $requestId);
@@ -230,7 +236,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $scopeList->withUniqueScopes();
     }
 
-    public function readByDepartmentId($departmentId, $resolveReferences = 0, $disableCache = false)
+    public function readByDepartmentId(int $departmentId, int $resolveReferences = 0, $disableCache = false): Collection
     {
         $cacheKey = "scopeReadByDepartmentId-$departmentId-$resolveReferences";
 
@@ -297,6 +303,9 @@ class Scope extends \BO\Zmsbackend\Base
         return ($requestList->count()) ? $requestList->sortByCustomKey('id') : $requestList;
     }
 
+    /**
+     * @return void
+     */
     protected function testSource($source)
     {
         if (! (new \BO\Zmsbackend\Source\Service\Source())->readEntity($source)) {
@@ -304,7 +313,7 @@ class Scope extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function readCollection($query)
+    protected function readCollection(\BO\Zmsbackend\Request\Repository\Request $query): Collection
     {
         $requestList = new Collection();
         $statement = $this->fetchStatement($query);
@@ -315,7 +324,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $requestList;
     }
 
-    public function readList($resolveReferences = 0, $disableCache = false)
+    public function readList(int $resolveReferences = 0, $disableCache = false): Collection
     {
         $cacheKey = "scopeReadList-$resolveReferences";
 
@@ -349,7 +358,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $scopeList;
     }
 
-    public function readIsOpened($scopeId, $now)
+    public function readIsOpened($scopeId, \DateTimeInterface $now): bool
     {
         $isOpened = false;
         $availabilityList = (new \BO\Zmsbackend\Availability\Service\Availability())->readOpeningHoursListByDate($scopeId, $now, 2);
@@ -359,7 +368,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $isOpened;
     }
 
-    public function readIsEnabled($scopeId, $now)
+    public function readIsEnabled(string $scopeId, \DateTimeInterface $now): bool
     {
         $query = new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -373,7 +382,7 @@ class Scope extends \BO\Zmsbackend\Base
         );
     }
 
-    public function readWaitingNumberUpdated($scopeId, $dateTime, $respectContingent = true)
+    public function readWaitingNumberUpdated($scopeId, \DateTimeInterface $dateTime, bool $respectContingent = true)
     {
         if (! $this->readIsGivenNumberInContingent($scopeId) && $respectContingent) {
             throw new \BO\Zmsbackend\Scope\Exception\GivenNumberCountExceeded();
@@ -398,7 +407,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $scope->getStatus('queue', 'lastDisplayNumber');
     }
 
-    public function readIsGivenNumberInContingent($scopeId)
+    public function readIsGivenNumberInContingent($scopeId): bool
     {
         $isInContingent = $this->getReader()
             ->fetchValue((new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::SELECT))
@@ -406,7 +415,7 @@ class Scope extends \BO\Zmsbackend\Base
         return ($isInContingent) ? true : false;
     }
 
-    public function readQueueList($scopeIds, $dateTime, $resolveReferences = 0, $withEntities = [])
+    public function readQueueList(array $scopeIds, $dateTime, int $resolveReferences = 0, $withEntities = []): \BO\Zmsentities\Collection\QueueList
     {
         if ($resolveReferences > 0) {
             $queueList = (new \BO\Zmsbackend\Process\Service\Process())
@@ -425,7 +434,11 @@ class Scope extends \BO\Zmsbackend\Base
         return $queueList->withSortedArrival();
     }
 
-    public function readWithWorkstationCount($scopeId, $dateTime, $resolveReferences = 0, $withEntities = [])
+    /**
+     * @param string[] $withEntities
+     *
+     */
+    public function readWithWorkstationCount(string $scopeId, \DateTimeInterface $dateTime, int $resolveReferences = 0, array $withEntities = [])
     {
         $query = new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::SELECT, '', false, null, $withEntities);
         $query
@@ -438,7 +451,11 @@ class Scope extends \BO\Zmsbackend\Base
         return ($scope->hasId()) ? $scope : null;
     }
 
-    public function readQueueListWithWaitingTime($scope, $dateTime, $resolveReferences = 0, $withEntities = [])
+    /**
+     * @param string[] $withEntities
+     *
+     */
+    public function readQueueListWithWaitingTime(\BO\Zmsentities\Useraccount\AccessInterface $scope, \DateTimeInterface|false $dateTime, int $resolveReferences = 0, array $withEntities = [])
     {
         $timeAverage = (int) $scope->getPreference('queue', 'processingTimeAverage');
         if ($timeAverage <= 0) {
@@ -453,7 +470,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $queueList->withEstimatedWaitingTime($timeAverage, $workstationCount, $dateTime);
     }
 
-    public function readScopesQueueListWithWaitingTime(Collection $scopes, $dateTime, $resolveReferences = 0, $withEntities = [])
+    public function readScopesQueueListWithWaitingTime(Collection $scopes, \DateTimeInterface $dateTime, $resolveReferences = 0, $withEntities = [])
     {
         $timeSum = 0;
         $workstationCount = 0;
@@ -473,7 +490,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $queueList->withEstimatedWaitingTime($timeAverage, $workstationCount, $dateTime);
     }
 
-    public function readListWithScopeAdminEmail($resolveReferences = 0)
+    public function readListWithScopeAdminEmail(int $resolveReferences = 0): Collection
     {
         $scopeList = new Collection();
         $query = new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::SELECT);
@@ -493,7 +510,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $scopeList;
     }
 
-    public function writeEntity(\BO\Zmsentities\Scope $entity, $parentId)
+    public function writeEntity(\BO\Zmsentities\Scope $entity, $parentId): Entity|null
     {
         self::$cache = [];
         $query = new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::INSERT);
@@ -509,7 +526,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $this->readEntity($lastInsertId);
     }
 
-    public function updateEntity($scopeId, \BO\Zmsentities\Scope $entity, $resolveReferences = 0)
+    public function updateEntity($scopeId, \BO\Zmsentities\Scope $entity, $resolveReferences = 0): Entity|null
     {
         self::$cache = [];
 
@@ -527,7 +544,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $this->readEntity($scopeId, $resolveReferences, true);
     }
 
-    public function replacePreferences(\BO\Zmsentities\Scope $entity)
+    public function replacePreferences(\BO\Zmsentities\Scope $entity): void
     {
         if (isset($entity['preferences'])) {
             $preferenceQuery = new \BO\Zmsbackend\Preferences\Service\Preferences();
@@ -541,7 +558,7 @@ class Scope extends \BO\Zmsbackend\Base
         }
     }
 
-    public function updateGhostWorkstationCount(\BO\Zmsentities\Scope $entity, \DateTimeInterface $dateTime)
+    public function updateGhostWorkstationCount(\BO\Zmsentities\Scope $entity, \DateTimeInterface $dateTime): Entity
     {
         $departmentId = $this->readDepartmentIdByScopeId($entity->id);
 
@@ -556,7 +573,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function updateEmergency($scopeId, \BO\Zmsentities\Scope $entity)
+    public function updateEmergency($scopeId, \BO\Zmsentities\Scope $entity): Entity|null
     {
         self::$cache = [];
         $departmentId = $this->readDepartmentIdByScopeId($scopeId);
@@ -572,7 +589,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $this->readEntity($scopeId, 0, true);
     }
 
-    public function writeImageData($scopeId, \BO\Zmsentities\Mimepart $entity)
+    public function writeImageData($scopeId, \BO\Zmsentities\Mimepart $entity): \BO\Zmsentities\Mimepart
     {
         if ($entity->mime && $entity->content) {
             $this->deleteImage($scopeId);
@@ -593,7 +610,7 @@ class Scope extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readImageData($scopeId)
+    public function readImageData($scopeId): \BO\Zmsentities\Mimepart
     {
         $imageName = 's_' . $scopeId . '_bild';
         $imageData = new \BO\Zmsentities\Mimepart();
@@ -616,7 +633,7 @@ class Scope extends \BO\Zmsbackend\Base
         ));
     }
 
-    public function deleteEntity($scopeId)
+    public function deleteEntity($scopeId): Entity|null
     {
         $processListCount = (new \BO\Zmsbackend\Process\Service\Process())->readProcessListCountByScope($scopeId);
         if (0 < $processListCount) {
@@ -636,7 +653,7 @@ class Scope extends \BO\Zmsbackend\Base
         return ($this->deleteItem($query)) ? $entity : null;
     }
 
-    public function deletePreferences(\BO\Zmsentities\Scope $entity)
+    public function deletePreferences(\BO\Zmsentities\Scope $entity): void
     {
         $preferenceQuery = new \BO\Zmsbackend\Preferences\Service\Preferences();
         $entityName = 'scope';
@@ -648,20 +665,23 @@ class Scope extends \BO\Zmsbackend\Base
         }
     }
 
-    public function readDepartmentIdByScopeId($scopeId)
+    public function readDepartmentIdByScopeId(int $scopeId)
     {
         $query = new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::SELECT);
         return $this->getReader()->fetchValue($query->getQueryDepartmentIdByScopeId(), [$scopeId]);
     }
 
-    public function readClusterIdsByScopeId($scopeId)
+    public function readClusterIdsByScopeId($scopeId): array
     {
         $query = new \BO\Zmsbackend\Query\Scope(\BO\Zmsbackend\Query\Base::SELECT);
         $result = $this->getReader()->fetchAll($query->getQueryClusterIdsByScopeId(), [$scopeId]);
         return array_column($result, 'clusterID');
     }
 
-    public function removeCacheByContext($scope, $departmentId = null)
+    /**
+     * @return void
+     */
+    public function removeCacheByContext(Entity $scope, $departmentId = null)
     {
         if (!\App::$cache) {
             return;
@@ -734,8 +754,10 @@ class Scope extends \BO\Zmsbackend\Base
         }
     }
 
-    /** @psalm-api */
-    public function removeCache($scope)
+    /**
+     * @psalm-api
+     */
+    public function removeCache($scope): void
     {
         $departmentId = isset($scope->id) ? $this->readDepartmentIdByScopeId($scope->id) : null;
         $this->removeCacheByContext($scope, $departmentId);

--- a/zmsbackend/src/Zmsbackend/Session/Api/SessionUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Session/Api/SessionUpdate.php
@@ -42,7 +42,10 @@ class SessionUpdate extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testMatching($session)
+    /**
+     * @return void
+     */
+    protected function testMatching(\BO\Zmsentities\Session $session)
     {
         if (false === \BO\Zmsbackend\Helper\Matching::isProviderExisting($session)) {
             throw new \BO\Zmsbackend\Matching\Exception\ProviderNotFound();

--- a/zmsbackend/src/Zmsbackend/Session/Repository/Session.php
+++ b/zmsbackend/src/Zmsbackend/Session/Repository/Session.php
@@ -31,8 +31,13 @@ class Session extends \BO\Zmsbackend\Query\Base
             sessionname=?
     ';
 
-    /** @psalm-api */
-    public function getEntityMapping()
+    /**
+     * @psalm-api
+     *
+     * @return string[]
+     *
+     */
+    public function getEntityMapping(): array
     {
         return [
             'id' => 'session.sessionid',
@@ -41,19 +46,19 @@ class Session extends \BO\Zmsbackend\Query\Base
         ];
     }
 
-    public function addConditionSessionId($sessionId)
+    public function addConditionSessionId($sessionId): static
     {
         $this->query->where('session.sessionid', '=', $sessionId);
         return $this;
     }
 
-    public function addConditionSessionName($sessionName)
+    public function addConditionSessionName(string $sessionName): static
     {
         $this->query->where('session.sessionname', '=', $sessionName);
         return $this;
     }
 
-    public function addConditionSessionDeleteInterval($deleteInSeconds)
+    public function addConditionSessionDeleteInterval(int $deleteInSeconds): static
     {
         $this->query->where(
             self::expression(

--- a/zmsbackend/src/Zmsbackend/Session/Service/Session.php
+++ b/zmsbackend/src/Zmsbackend/Session/Service/Session.php
@@ -25,7 +25,7 @@ class Session extends \BO\Zmsbackend\Base
         return $session;
     }
 
-    public function updateEntity($session)
+    public function updateEntity(Entity $session): Entity
     {
         $query = \BO\Zmsbackend\Session\Repository\Session::QUERY_WRITE;
         $this->perform($query, array(
@@ -37,7 +37,7 @@ class Session extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function deleteEntity($sessionName, $sessionId)
+    public function deleteEntity($sessionName, $sessionId): bool
     {
         $query = \BO\Zmsbackend\Session\Repository\Session::QUERY_DELETE;
         $result = $this->perform($query, array(

--- a/zmsbackend/src/Zmsbackend/Slot/Repository/Slot.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Repository/Slot.php
@@ -247,6 +247,10 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
     ';
 
 
+    /**
+     * @return array
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -254,11 +258,15 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
         ];
     }
 
+    /**
+     * @return (mixed|string)[]
+     *
+     */
     public function reverseEntityMapping(
         \BO\Zmsentities\Slot $slot,
         \BO\Zmsentities\Availability $availability,
         \DateTimeInterface $date
-    ) {
+    ): array {
         $data = array();
         $data['scopeID'] = $availability->scope->id;
         $data['availabilityID'] = $availability->id;
@@ -274,7 +282,7 @@ class Slot extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\Map
         return $data;
     }
 
-    public function addConditionSlotId($slotID)
+    public function addConditionSlotId($slotID): static
     {
         $this->query->where('slot.slotID', '=', $slotID);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Slot/Repository/SlotList.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Repository/SlotList.php
@@ -190,14 +190,21 @@ class SlotList extends \BO\Zmsbackend\Query\Base
         }
     }
 
-    /** @psalm-api */
-    public static function getQuery()
+    /**
+     * @psalm-api
+     */
+    public static function getQuery(): string
     {
         return self::QUERY;
     }
 
-    /** @psalm-api */
-    public static function getParametersMonth($scopeId, \DateTimeInterface $monthDateTime, \DateTimeInterface $now)
+    /**
+     * @psalm-api
+     *
+     * @return (mixed|string)[]
+     *
+     */
+    public static function getParametersMonth($scopeId, \DateTimeInterface $monthDateTime, \DateTimeInterface $now): array
     {
         $now = DateTime::create($now);
         $monthDateTime = DateTime::create($monthDateTime);
@@ -215,8 +222,13 @@ class SlotList extends \BO\Zmsbackend\Query\Base
         return $parameters;
     }
 
-    /** @psalm-api */
-    public static function getParametersDay($scopeId, \DateTimeInterface $dateTime, \DateTimeInterface $now)
+    /**
+     * @psalm-api
+     *
+     * @return (mixed|string)[]
+     *
+     */
+    public static function getParametersDay($scopeId, \DateTimeInterface $dateTime, \DateTimeInterface $now): array
     {
         $now = DateTime::create($now);
         $dateTime = DateTime::create($dateTime);
@@ -240,7 +252,7 @@ class SlotList extends \BO\Zmsbackend\Query\Base
      * we use the scope data to add missing values
      * and try to use availability data in query result
      */
-    public function setSlotData(array $slotData)
+    public function setSlotData(array $slotData): static
     {
         $this->slotData = $slotData;
         if (null === $this->availability) {
@@ -261,10 +273,10 @@ class SlotList extends \BO\Zmsbackend\Query\Base
 
     /**
      * add data from a mysql result set
-     * @see self::QUERY
      *
+     * @see self::QUERY
      */
-    public function addQueryData(array $slotData)
+    public function addQueryData(array $slotData): static
     {
         if (isset($slotData['slotnr'])) {
             $slotnumber = $slotData['slotnr'];
@@ -295,7 +307,7 @@ class SlotList extends \BO\Zmsbackend\Query\Base
         return $this;
     }
 
-    protected function getCalculatedSlot(Slot $slot, $slotData)
+    protected function getCalculatedSlot(Slot $slot, array $slotData): Slot
     {
         $slot->public += $slotData['freeAppointments__public'] -
             $slotData['availability__workstationCount__public'];
@@ -306,14 +318,16 @@ class SlotList extends \BO\Zmsbackend\Query\Base
         return $slot;
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     */
     public function addToCalendar(
         \BO\Zmsentities\Calendar $calendar,
         \DateTimeInterface $now,
         $freeProcessesDate,
         $slotType = 'public',
         $slotsRequired = 1
-    ) {
+    ): \BO\Zmsentities\Calendar {
         $nowDate = $now->format('Y-m-d');
         foreach ($this->slots as $date => $slotList) {
             if ($nowDate == $date) {
@@ -335,7 +349,7 @@ class SlotList extends \BO\Zmsbackend\Query\Base
         $date,
         $slotType = 'public',
         $slotsRequired = 1
-    ) {
+    ): void {
         if (null !== $freeProcessesDate && $date == $freeProcessesDate->format('Y-m-d')) {
             $freeProcesses = $this->getFreeProcesses($calendar, $freeProcessesDate, $slotType, $slotsRequired);
             foreach ($freeProcesses as $process) {
@@ -370,7 +384,7 @@ class SlotList extends \BO\Zmsbackend\Query\Base
     /**
      * Create slots based on availability
      */
-    public function createSlots(\DateTimeInterface $startDate, \DateTimeInterface $stopDate, \DateTimeInterface $now)
+    public function createSlots(\DateTimeInterface $startDate, \DateTimeInterface $stopDate, \DateTimeInterface $now): void
     {
         $startDate = ($startDate < $now) ? $now->modify('00:00:00') : $startDate;
         $stopDate = $stopDate->modify('00:00:00');
@@ -385,8 +399,10 @@ class SlotList extends \BO\Zmsbackend\Query\Base
         } while ($time->getTimestamp() <= $stopDate->getTimestamp());
     }
 
-    /** @psalm-api */
-    public function isSameAvailability(array $slotData)
+    /**
+     * @psalm-api
+     */
+    public function isSameAvailability(array $slotData): bool
     {
         return $this->slotData['availability__id'] == $slotData['availability__id'];
     }

--- a/zmsbackend/src/Zmsbackend/Slot/Service/Slot.php
+++ b/zmsbackend/src/Zmsbackend/Slot/Service/Slot.php
@@ -28,9 +28,9 @@ class Slot extends \BO\Zmsbackend\Base
      */
     public function readByAppointment(
         \BO\Zmsentities\Appointment $appointment,
-        $overwriteSlotsCount = null,
-        $extendSlotList = false,
-        $lockSlots = false
+        int|null $overwriteSlotsCount = null,
+        bool $extendSlotList = false,
+        bool $lockSlots = false
     ) {
         $appointment = clone $appointment;
         $availability = (new \BO\Zmsbackend\Availability\Service\Availability())->readByAppointment($appointment);
@@ -113,6 +113,9 @@ class Slot extends \BO\Zmsbackend\Base
         $this->fetchAll($sql, $params);
     }
 
+    /**
+     * @return null|true
+     */
     public function hasScopeRelevantChanges(
         \BO\Zmsentities\Scope $scope,
         \DateTimeInterface $slotLastChange = null
@@ -145,7 +148,7 @@ class Slot extends \BO\Zmsbackend\Base
         \DateTimeInterface $now,
         \DateTimeInterface $slotLastChange = null,
         int $oldestSlotVersion = 1
-    ) {
+    ): bool {
         $proposedChange = new \BO\Zmsbackend\Helper\AvailabilitySnapShot($availability, $now);
         $formerChange = new \BO\Zmsbackend\Helper\AvailabilitySnapShot($availability, $slotLastChange);
 
@@ -297,7 +300,7 @@ class Slot extends \BO\Zmsbackend\Base
         return $status || (isset($cancelledSlots) && $cancelledSlots > 0);
     }
 
-    public function writeByScope(\BO\Zmsentities\Scope $scope, \DateTimeInterface $now)
+    public function writeByScope(\BO\Zmsentities\Scope $scope, \DateTimeInterface $now): \BO\Zmsentities\Collection\AvailabilityList
     {
         $slotLastChange = $this->readLastChangedTimeByScope($scope);
         $availabilityList = (new \BO\Zmsbackend\Availability\Service\Availability())
@@ -350,7 +353,7 @@ class Slot extends \BO\Zmsbackend\Base
         return $status;
     }
 
-    protected function writeAncestorIDs($slotID, array $ancestors)
+    protected function writeAncestorIDs($slotID, array $ancestors): void
     {
         $this->perform(\BO\Zmsbackend\Slot\Repository\Slot::QUERY_DELETE_ANCESTOR, [
             'slotID' => $slotID,
@@ -368,7 +371,7 @@ class Slot extends \BO\Zmsbackend\Base
         }
     }
 
-    public function readLastChangedTime()
+    public function readLastChangedTime(): \DateTimeImmutable
     {
         $last = $this->fetchRow(
             \BO\Zmsbackend\Slot\Repository\Slot::QUERY_LAST_CHANGED
@@ -379,7 +382,7 @@ class Slot extends \BO\Zmsbackend\Base
         return new \DateTimeImmutable($last['dateString'] . \BO\Zmsbackend\Connection\Select::$connectionTimezone);
     }
 
-    public function readLastChangedTimeByScope(ScopeEntity $scope)
+    public function readLastChangedTimeByScope(ScopeEntity $scope): \DateTimeImmutable
     {
         $last = $this->fetchRow(
             \BO\Zmsbackend\Slot\Repository\Slot::QUERY_LAST_CHANGED_SCOPE,
@@ -393,7 +396,7 @@ class Slot extends \BO\Zmsbackend\Base
         return new \DateTimeImmutable($last['dateString'] . \BO\Zmsbackend\Connection\Select::$connectionTimezone);
     }
 
-    public function readLastChangedTimeByAvailability(AvailabilityEntity $availabiliy)
+    public function readLastChangedTimeByAvailability(AvailabilityEntity $availabiliy): \DateTimeImmutable
     {
         $last = $this->fetchRow(
             \BO\Zmsbackend\Slot\Repository\Slot::QUERY_LAST_CHANGED_AVAILABILITY,
@@ -407,7 +410,7 @@ class Slot extends \BO\Zmsbackend\Base
         return new \DateTimeImmutable($last['dateString'] . \BO\Zmsbackend\Connection\Select::$connectionTimezone);
     }
 
-    public function updateSlotProcessMapping($scopeID = null)
+    public function updateSlotProcessMapping($scopeID = null): int
     {
         if ($scopeID) {
             $processIdList = $this->fetchAll(
@@ -425,7 +428,7 @@ class Slot extends \BO\Zmsbackend\Base
         return count($processIdList);
     }
 
-    public function deleteSlotProcessOnSlot($scopeID = null)
+    public function deleteSlotProcessOnSlot($scopeID = null): void
     {
         if ($scopeID) {
             $this->perform(
@@ -438,7 +441,7 @@ class Slot extends \BO\Zmsbackend\Base
         }
     }
 
-    public function deleteSlotProcessOnProcess($scopeID = null)
+    public function deleteSlotProcessOnProcess($scopeID = null): int
     {
         if ($scopeID) {
             $processIdList = $this->fetchAll(
@@ -456,7 +459,7 @@ class Slot extends \BO\Zmsbackend\Base
         return count($processIdList);
     }
 
-    public function writeSlotProcessMappingFor($processId)
+    public function writeSlotProcessMappingFor($processId): static
     {
         $this->perform(\BO\Zmsbackend\Slot\Repository\Slot::QUERY_INSERT_SLOT_PROCESS_ID, [
             'processId' => $processId,
@@ -464,7 +467,7 @@ class Slot extends \BO\Zmsbackend\Base
         return $this;
     }
 
-    public function deleteSlotProcessMappingFor($processId)
+    public function deleteSlotProcessMappingFor($processId): static
     {
         $this->perform(\BO\Zmsbackend\Slot\Repository\Slot::QUERY_DELETE_SLOT_PROCESS_ID, [
             'processId' => $processId,
@@ -472,7 +475,7 @@ class Slot extends \BO\Zmsbackend\Base
         return $this;
     }
 
-    public function writeCanceledByTimeAndScope(\DateTimeInterface $dateTime, \BO\Zmsentities\Scope $scope)
+    public function writeCanceledByTimeAndScope(\DateTimeInterface $dateTime, \BO\Zmsentities\Scope $scope): bool
     {
         $status = $this->perform(\BO\Zmsbackend\Slot\Repository\Slot::QUERY_UPDATE_SLOT_MISSING_AVAILABILITY_BY_SCOPE, [
             'dateString' => $dateTime->format('Y-m-d'),
@@ -488,7 +491,7 @@ class Slot extends \BO\Zmsbackend\Base
         ]) && $status;
     }
 
-    public function writeCanceledByTime(\DateTimeInterface $dateTime)
+    public function writeCanceledByTime(\DateTimeInterface $dateTime): bool
     {
         $status = $this->perform(\BO\Zmsbackend\Slot\Repository\Slot::QUERY_UPDATE_SLOT_MISSING_AVAILABILITY, [
             'dateString' => $dateTime->format('Y-m-d'),
@@ -501,7 +504,7 @@ class Slot extends \BO\Zmsbackend\Base
         ]) && $status;
     }
 
-    public function deleteSlotsOlderThan(\DateTimeInterface $dateTime)
+    public function deleteSlotsOlderThan(\DateTimeInterface $dateTime): bool
     {
         $status = $this->perform(\BO\Zmsbackend\Slot\Repository\Slot::QUERY_DELETE_SLOT_OLD, [
             'year' => $dateTime->format('Y'),
@@ -528,7 +531,7 @@ class Slot extends \BO\Zmsbackend\Base
         return $list;
     }
 
-    public function writeOptimizedSlotTables()
+    public function writeOptimizedSlotTables(): bool
     {
         $queries = [
             \BO\Zmsbackend\Slot\Repository\Slot::QUERY_OPTIMIZE_SLOT,
@@ -551,7 +554,7 @@ class Slot extends \BO\Zmsbackend\Base
         return $status;
     }
 
-    private function getLastGeneratedSlotDate(AvailabilityEntity $availability)
+    private function getLastGeneratedSlotDate(AvailabilityEntity $availability): \DateTimeImmutable|null
     {
         $last = $this->fetchRow(
             \BO\Zmsbackend\Slot\Repository\Slot::QUERY_LAST_IN_AVAILABILITY,

--- a/zmsbackend/src/Zmsbackend/Source/Api/SourceUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Source/Api/SourceUpdate.php
@@ -39,7 +39,10 @@ class SourceUpdate extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testEntity($entity, $input)
+    /**
+     * @return void
+     */
+    protected function testEntity(Entity $entity, $input)
     {
         try {
             $entity->testValid('de_DE', 1);

--- a/zmsbackend/src/Zmsbackend/Source/Repository/Source.php
+++ b/zmsbackend/src/Zmsbackend/Source/Repository/Source.php
@@ -9,6 +9,10 @@ class Source extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
      */
     const string TABLE = 'source';
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -22,7 +26,7 @@ class Source extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Query\M
         ];
     }
 
-    public function addConditionSource($source)
+    public function addConditionSource($source): static
     {
         $this->query->where('source.source', '=', $source);
         return $this;

--- a/zmsbackend/src/Zmsbackend/Source/Service/Source.php
+++ b/zmsbackend/src/Zmsbackend/Source/Service/Source.php
@@ -22,7 +22,7 @@ class Source extends \BO\Zmsbackend\Base
      *
      * @return \BO\Zmsentities\Source
      */
-    public function readEntity($sourceName, $resolveReferences = 0, $disableCache = false)
+    public function readEntity($sourceName, $resolveReferences = 0, bool $disableCache = false)
     {
         $cacheKey = "source-$sourceName-$resolveReferences";
 
@@ -133,9 +133,8 @@ class Source extends \BO\Zmsbackend\Base
 
     /**
      * delete provider and request relations of source
-     *
      */
-    public function writeInsertRelations(\BO\Zmsentities\Source $entity)
+    public function writeInsertRelations(\BO\Zmsentities\Source $entity): void
     {
         (new \BO\Zmsbackend\Provider\Service\Provider())->writeListBySource($entity);
         (new \BO\Zmsbackend\Request\Service\Request())->writeListBySource($entity);
@@ -161,15 +160,17 @@ class Source extends \BO\Zmsbackend\Base
 
     /**
      * delete provider and request relations of source
-     *
      */
-    public function writeDeleteRelations($sourceName)
+    public function writeDeleteRelations($sourceName): void
     {
         (new \BO\Zmsbackend\Provider\Service\Provider())->writeDeleteListBySource($sourceName);
         (new \BO\Zmsbackend\Request\Service\Request())->writeDeleteListBySource($sourceName);
         (new \BO\Zmsbackend\RequestRelation\Service\RequestRelation())->writeDeleteListBySource($sourceName);
     }
 
+    /**
+     * @return void
+     */
     public function removeCache($sourceName)
     {
         if (!App::$cache) {

--- a/zmsbackend/src/Zmsbackend/Source/Zmsdldb.php
+++ b/zmsbackend/src/Zmsbackend/Source/Zmsdldb.php
@@ -11,20 +11,29 @@ class Zmsdldb extends \BO\Zmsbackend\Base
     public static $repository = null;
     public static $verbose = false;
 
-    /** @psalm-api */
-    public static function getFixturesImportPath()
+    /**
+     * @psalm-api
+     *
+     * @return false|string
+     */
+    public static function getFixturesImportPath(): string|false
     {
         $dir = dirname(__FILE__);
         $importPath = realpath($dir . '/../../../tests/Zmsbackend/Service/fixtures/');
         return $importPath;
     }
 
-    /** @psalm-api */
-    public static function setImportPath($path)
+    /**
+     * @psalm-api
+     */
+    public static function setImportPath($path): void
     {
         self::$importPath = $path;
     }
 
+    /**
+     * @return void
+     */
     public function startImport($verbose = true, $updateAvailability = true)
     {
         if (!static::$importPath) {
@@ -49,7 +58,7 @@ class Zmsdldb extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function writeRequestList()
+    protected function writeRequestList(): void
     {
         $startTime = microtime(true);
         $requestQuery = (new \BO\Zmsbackend\Request\Service\Request());
@@ -83,7 +92,7 @@ class Zmsdldb extends \BO\Zmsbackend\Base
         return $providers;
     }
 
-    protected function updateAvailability($providers)
+    protected function updateAvailability($providers): void
     {
         foreach ($providers as $provider) {
             $providerData = $provider->data;
@@ -106,7 +115,7 @@ class Zmsdldb extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function writeRequestRelationList()
+    protected function writeRequestRelationList(): void
     {
         $startTime = microtime(true);
         (new \BO\Zmsbackend\RequestRelation\Service\RequestRelation())->writeDeleteListBySource('dldb');
@@ -117,7 +126,7 @@ class Zmsdldb extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function writeLastUpdate()
+    protected function writeLastUpdate(): void
     {
         $startTime = microtime(true);
         (new \BO\Zmsbackend\Config\Service\Config())->replaceProperty('sources_dldb_last', date('c'));

--- a/zmsbackend/src/Zmsbackend/Status/Api/Healthcheck.php
+++ b/zmsbackend/src/Zmsbackend/Status/Api/Healthcheck.php
@@ -15,6 +15,8 @@ class Healthcheck extends \BO\Zmsbackend\Api\BaseController
 {
     /**
      * @SuppressWarnings(UnusedFormalParameter)
+     *
+     * @return \Psr\Http\Message\ResponseInterface
      */
     #[\Override]
     public function readResponse(

--- a/zmsbackend/src/Zmsbackend/Status/Service/Status.php
+++ b/zmsbackend/src/Zmsbackend/Status/Service/Status.php
@@ -11,7 +11,7 @@ class Status extends \BO\Zmsbackend\Base
      *
      * @return \BO\Zmsentities\Status
      */
-    public function readEntity(\DateTimeImmutable $now, $includeProcessStats = true)
+    public function readEntity(\DateTimeImmutable $now, bool $includeProcessStats = true)
     {
         $entity = new Entity();
         $configVariables = $this->readConfigVariables();
@@ -113,7 +113,7 @@ class Status extends \BO\Zmsbackend\Base
      *
      * @return string
      */
-    public function getConfigProblems($configVariables)
+    public function getConfigProblems(array $configVariables)
     {
         $problems = [];
         if ($configVariables['tmp_table_size'] < 32000000) {

--- a/zmsbackend/src/Zmsbackend/Ticketprinter/Repository/Ticketprinter.php
+++ b/zmsbackend/src/Zmsbackend/Ticketprinter/Repository/Ticketprinter.php
@@ -16,7 +16,7 @@ class Ticketprinter extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\
      */
     protected $resolveLevel = 0;
 
-    public function getOrganisationIdByHash()
+    public function getOrganisationIdByHash(): string
     {
         return '
             SELECT organisationsid
@@ -24,6 +24,10 @@ class Ticketprinter extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\
             WHERE ticketprinter.`cookiecode` = :hash';
     }
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -36,31 +40,35 @@ class Ticketprinter extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\
         ];
     }
 
-    public function addConditionTicketprinterId($ticketprinterId)
+    public function addConditionTicketprinterId(int|string $ticketprinterId): static
     {
         $this->query->where('ticketprinter.kioskid', '=', $ticketprinterId);
         return $this;
     }
 
-    public function addConditionOrganisationId($organisationId)
+    public function addConditionOrganisationId(int $organisationId): static
     {
         $this->query->where('ticketprinter.organisationsid', '=', $organisationId);
         return $this;
     }
 
-    public function addConditionHash($hash)
+    public function addConditionHash(string $hash): static
     {
         $this->query->where('ticketprinter.cookiecode', '=', $hash);
         return $this;
     }
 
-    public function addConditionDeleteInterval($expirationDate)
+    public function addConditionDeleteInterval($expirationDate): static
     {
         $this->query->where('ticketprinter.timestamp', '<=', $expirationDate->getTimestamp());
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Ticketprinter $entity, $organisationId)
+    /**
+     * @return (int|mixed)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Ticketprinter $entity, int $organisationId): array
     {
         $data = array();
         $data['organisationsid'] = $organisationId;

--- a/zmsbackend/src/Zmsbackend/Ticketprinter/Service/Ticketprinter.php
+++ b/zmsbackend/src/Zmsbackend/Ticketprinter/Service/Ticketprinter.php
@@ -111,6 +111,9 @@ class Ticketprinter extends \BO\Zmsbackend\Base
         return $ticketprinter;
     }
 
+    /**
+     * @return void
+     */
     protected function readExceptions(Entity $ticketprinter)
     {
         $query = new \BO\Zmsbackend\Scope\Service\Scope();
@@ -120,7 +123,7 @@ class Ticketprinter extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function readWithContactData(Entity $entity)
+    protected function readWithContactData(Entity $entity): Entity
     {
         $contact = new \BO\Zmsentities\Contact();
 
@@ -142,7 +145,7 @@ class Ticketprinter extends \BO\Zmsbackend\Base
         return $entity;
     }
 
-    public function readSingleScopeFromButtonList(Entity $ticketprinter)
+    public function readSingleScopeFromButtonList(Entity $ticketprinter): \BO\Zmsentities\Scope|null
     {
         $scope = null;
         if (1 == $ticketprinter->getScopeList()->count()) {
@@ -241,7 +244,7 @@ class Ticketprinter extends \BO\Zmsbackend\Base
         return $this->deleteItem($query);
     }
 
-    public function readExpiredTicketprinterList($expirationDate)
+    public function readExpiredTicketprinterList($expirationDate): Collection
     {
         $selectQuery = new \BO\Zmsbackend\Ticketprinter\Repository\Ticketprinter(\BO\Zmsbackend\Query\Base::SELECT);
         $selectQuery

--- a/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountAdd.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountAdd.php
@@ -41,7 +41,10 @@ class UseraccountAdd extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testEntity($entity, $input)
+    /**
+     * @return void
+     */
+    protected function testEntity(\BO\Zmsentities\Useraccount $entity, $input)
     {
         if (0 == count($input)) {
             throw new \BO\Zmsbackend\Useraccount\Exception\UseraccountInvalidInput();

--- a/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountUpdate.php
@@ -51,7 +51,10 @@ class UseraccountUpdate extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function testEntity($entity, $input, $args)
+    /**
+     * @return void
+     */
+    protected function testEntity(\BO\Zmsentities\Useraccount $entity, $input, array $args)
     {
         if (0 == count($input)) {
             throw new \BO\Zmsbackend\Useraccount\Exception\UseraccountInvalidInput();

--- a/zmsbackend/src/Zmsbackend/Useraccount/Repository/Useraccount.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Repository/Useraccount.php
@@ -106,7 +106,7 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
      * Build an SQL expression that checks whether the current useraccount has
      * a permission via user_role -> role_permission -> permission.
      */
-    protected function permissionExists(string $permissionName)
+    protected function permissionExists(string $permissionName): \BO\Zmsbackend\Query\Builder\Expression
     {
         if (!in_array($permissionName, self::VALID_PERMISSION_NAMES, true)) {
             throw new \InvalidArgumentException("Invalid permission name: $permissionName");
@@ -124,6 +124,10 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         );
     }
 
+    /**
+     * @return (\BO\Zmsbackend\Query\Builder\Expression|mixed|string)[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -170,25 +174,25 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         ];
     }
 
-    public function addConditionLoginName($loginName)
+    public function addConditionLoginName($loginName): static
     {
         $this->query->where('useraccount.Name', '=', $loginName);
         return $this;
     }
 
-    public function addConditionUserId($userId)
+    public function addConditionUserId($userId): static
     {
         $this->query->where('useraccount.NutzerID', '=', $userId);
         return $this;
     }
 
-    public function addConditionPassword($password)
+    public function addConditionPassword($password): static
     {
         $this->query->where('useraccount.Passworthash', '=', $password);
         return $this;
     }
 
-    public function addConditionXauthKey($xAuthKey)
+    public function addConditionXauthKey(string $xAuthKey): static
     {
         $this->query->where('useraccount.SessionID', '=', $xAuthKey);
         $this->query->where('useraccount.SessionExpiry', '>', date('Y-m-d H:i:s', time() - App::SESSION_DURATION));
@@ -218,7 +222,7 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $this;
     }
 
-    public function addConditionSearch($queryString, $orWhere = false)
+    public function addConditionSearch($queryString, bool $orWhere = false): static
     {
         $condition = function (\BO\Zmsbackend\Query\Builder\ConditionBuilder $query) use ($queryString) {
             $queryString = trim($queryString);
@@ -233,7 +237,11 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Useraccount $entity)
+    /**
+     * @return (int|mixed)[]
+     *
+     */
+    public function reverseEntityMapping(\BO\Zmsentities\Useraccount $entity): array
     {
         $data = array();
         $data['Name'] = $entity->id;
@@ -279,7 +287,7 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $data;
     }
 
-    public function addConditionDepartmentIds(array $departmentIds)
+    public function addConditionDepartmentIds(array $departmentIds): static
     {
         $this->setDistinctSelect();
         $this->innerJoin(
@@ -292,7 +300,7 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $this;
     }
 
-    public function addConditionDepartmentIdsAndSearch(array $departmentIds, $queryString = null, $orWhere = false): self
+    public function addConditionDepartmentIdsAndSearch(array $departmentIds, $queryString = null, bool $orWhere = false): self
     {
         $this->addConditionDepartmentIds($departmentIds);
 
@@ -334,8 +342,10 @@ class Useraccount extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
 
     /**
      * @SuppressWarnings(UnusedFormalParameter)
+     *
+     * @param false $isWorkstationSuperuser
      */
-    public function addConditionWorkstationAccess($workstationUserId, array $workstationDepartmentIds, $isWorkstationSuperuser = false): self
+    public function addConditionWorkstationAccess($workstationUserId, array $workstationDepartmentIds, bool $isWorkstationSuperuser = false): self
     {
         // Superusers can access all useraccounts, no filtering needed
         if ($isWorkstationSuperuser) {

--- a/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
@@ -234,13 +234,16 @@ class Useraccount extends \BO\Zmsbackend\Base
     /**
      * Sanitize cache key by replacing reserved characters
      * Reserved characters: {}()/\@:
+     *
+     * @return string|string[]
+     *
      */
-    protected function sanitizeCacheKey($key)
+    protected function sanitizeCacheKey(string $key): array|string
     {
         return str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '_', $key);
     }
 
-    public function readIsUserExisting($loginName, $password = false)
+    public function readIsUserExisting($loginName, $password = false): bool
     {
         $query = new \BO\Zmsbackend\Useraccount\Repository\Useraccount(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addEntityMapping()
@@ -253,7 +256,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return ($useraccount->hasId()) ? true : false;
     }
 
-    public function readEntity($loginname, $resolveReferences = 1, $disableCache = false)
+    public function readEntity($loginname, int $resolveReferences = 1, bool $disableCache = false)
     {
         $version = $this->getUseraccountCacheVersion();
         $cacheKey = $this->sanitizeCacheKey("useraccount-v{$version}-$loginname-$resolveReferences");
@@ -298,6 +301,9 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $useraccount;
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
     {
@@ -376,7 +382,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    protected function readListStatement($statement, $resolveReferences)
+    protected function readListStatement($statement, $resolveReferences): Collection
     {
         $query = new \BO\Zmsbackend\Useraccount\Repository\Useraccount(\BO\Zmsbackend\Query\Base::SELECT);
         $collection = new Collection();
@@ -395,7 +401,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $collection;
     }
 
-    public function readAssignedDepartmentList($useraccount, $resolveReferences = 0)
+    public function readAssignedDepartmentList(\BO\Zmsentities\Schema\Entity $useraccount, $resolveReferences = 0)
     {
         if ($useraccount->isSuperUser()) {
             $query = \BO\Zmsbackend\Useraccount\Repository\Useraccount::QUERY_READ_SUPERUSER_DEPARTMENTS;
@@ -407,7 +413,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $this->buildDepartmentList($departmentData, $resolveReferences);
     }
 
-    protected function readAssignedDepartmentListsForAll(Collection $useraccounts, $resolveReferences = 0)
+    protected function readAssignedDepartmentListsForAll(Collection $useraccounts, $resolveReferences = 0): array
     {
         if (count($useraccounts) === 0) {
             return [];
@@ -427,7 +433,11 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    protected function separateSuperusersFromRegularUsers(Collection $useraccounts)
+    /**
+     * @return array[]
+     *
+     */
+    protected function separateSuperusersFromRegularUsers(Collection $useraccounts): array
     {
         $superusers = [];
         $regularUsers = [];
@@ -441,7 +451,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return [$superusers, $regularUsers];
     }
 
-    protected function loadSuperuserDepartments(array $superusers, $resolveReferences = 0)
+    protected function loadSuperuserDepartments(array $superusers, $resolveReferences = 0): array
     {
         // Load all departments once - all superusers have access to all departments
             $query = \BO\Zmsbackend\Useraccount\Repository\Useraccount::QUERY_READ_SUPERUSER_DEPARTMENTS;
@@ -466,7 +476,11 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $this->buildDepartmentListsForUsers($regularUsers, $assignmentsByUser, $resolveReferences);
     }
 
-    protected function groupAssignmentsByUser(array $allAssignments)
+    /**
+     * @return array[]
+     *
+     */
+    protected function groupAssignmentsByUser(array $allAssignments): array
     {
         $assignmentsByUser = [];
         foreach ($allAssignments as $assignment) {
@@ -479,7 +493,11 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $assignmentsByUser;
     }
 
-    protected function buildDepartmentListsForUsers(array $useraccountNames, array $assignmentsByUser, $resolveReferences = 0)
+    /**
+     * @return \BO\Zmsentities\Collection\DepartmentList[]
+     *
+     */
+    protected function buildDepartmentListsForUsers(array $useraccountNames, array $assignmentsByUser, $resolveReferences = 0): array
     {
         // Collect ALL unique department IDs from all useraccounts
         $allDepartmentIds = [];
@@ -523,7 +541,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    protected function buildDepartmentList(array $items, $resolveReferences = 0)
+    protected function buildDepartmentList(array $items, $resolveReferences = 0): \BO\Zmsentities\Collection\DepartmentList
     {
         $departmentList = new \BO\Zmsentities\Collection\DepartmentList();
 
@@ -548,7 +566,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $departmentList;
     }
 
-    public function readEntityByAuthKey($xAuthKey, $resolveReferences = 0)
+    public function readEntityByAuthKey(array $xAuthKey, $resolveReferences = 0)
     {
         $hashedAuthKey = hash('sha256', $xAuthKey);
         $query = new \BO\Zmsbackend\Useraccount\Repository\Useraccount(\BO\Zmsbackend\Query\Base::SELECT);
@@ -757,7 +775,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $this->readEntity($entity->getId(), $resolveReferences, true);
     }
 
-    public function deleteEntity($loginName)
+    public function deleteEntity($loginName): bool
     {
         // Read entity before deletion to get cache info
         $entity = $this->readEntity($loginName, 0, true);
@@ -775,7 +793,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    protected function updateAssignedDepartments($entity)
+    protected function updateAssignedDepartments(Entity $entity): void
     {
         $loginName = $entity->id;
         if (!$entity->isSuperUser()) {
@@ -807,7 +825,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $this->perform($query, [$userId]);
     }
 
-    protected function buildSearchCacheKey($prefix, $resolveReferences, $workstation, $queryString, array $departmentIds = [])
+    protected function buildSearchCacheKey(string $prefix, $resolveReferences, $workstation, $queryString, array $departmentIds = []): string
     {
         $version = $this->getUseraccountCacheVersion();
         $workstationKey = '';
@@ -818,7 +836,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return "{$prefix}-v{$version}{$departmentKey}-$resolveReferences$workstationKey-query-" . md5($queryString);
     }
 
-    protected function getCachedResult($cacheKey, $disableCache, $logMessage, array $logContext = [])
+    protected function getCachedResult($cacheKey, $disableCache, string $logMessage, array $logContext = [])
     {
         $result = null;
         if (!$disableCache && App::$cache && App::$cache->has($cacheKey)) {
@@ -832,7 +850,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    protected function setCachedResult($cacheKey, $result, array $departmentIds, $logMessage, array $logContext = [])
+    protected function setCachedResult($cacheKey, $result, array $departmentIds, string $logMessage, array $logContext = []): void
     {
         if (App::$cache) {
             App::$cache->set($cacheKey, $result);
@@ -845,7 +863,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         }
     }
 
-    protected function executeSearchQuery(array $parameter, $resolveReferences, $workstation)
+    protected function executeSearchQuery(array $parameter, $resolveReferences, $workstation): Collection
     {
         $query = new \BO\Zmsbackend\Useraccount\Repository\Useraccount(\BO\Zmsbackend\Query\Base::SELECT);
         $query
@@ -886,7 +904,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $collection;
     }
 
-    protected function executeSearchByDepartmentIdsQuery(array $departmentIds, array $parameter, $resolveReferences, $workstation)
+    protected function executeSearchByDepartmentIdsQuery(array $departmentIds, array $parameter, $resolveReferences, $workstation): Collection
     {
         $query = new \BO\Zmsbackend\Useraccount\Repository\Useraccount(\BO\Zmsbackend\Query\Base::SELECT);
         $query->addResolvedReferences($resolveReferences)
@@ -929,8 +947,9 @@ class Useraccount extends \BO\Zmsbackend\Base
 
     /**
      * @SuppressWarnings(NPathComplexity)
+     *
      */
-    public function readSearch(array $parameter, $resolveReferences = 0, $workstation = null, $disableCache = false)
+    public function readSearch(array $parameter, int $resolveReferences = 0, $workstation = null, $disableCache = false)
     {
         $queryString = isset($parameter['query']) ? $parameter['query'] : '';
         $cacheKey = $this->buildSearchCacheKey('useraccountReadSearch', $resolveReferences, $workstation, $queryString);
@@ -952,8 +971,9 @@ class Useraccount extends \BO\Zmsbackend\Base
 
     /**
      * @SuppressWarnings(NPathComplexity)
+     *
      */
-    public function readSearchByDepartmentIds(array $departmentIds, array $parameter, $resolveReferences = 0, $workstation = null, $disableCache = false)
+    public function readSearchByDepartmentIds(array $departmentIds, array $parameter, int $resolveReferences = 0, $workstation = null, $disableCache = false)
     {
         sort($departmentIds);
         $queryString = isset($parameter['query']) ? $parameter['query'] : '';
@@ -976,7 +996,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    public function readListRole($roleName, $resolveReferences = 0, $workstation = null)
+    public function readListRole($roleName, int $resolveReferences = 0, $workstation = null)
     {
         $version = $this->getUseraccountCacheVersion();
         $workstationKey = '';
@@ -1037,8 +1057,11 @@ class Useraccount extends \BO\Zmsbackend\Base
 
     /**
      * @SuppressWarnings(NPathComplexity)
+     *
+     * @param false $disableCache
+     *
      */
-    public function readListByRoleAndDepartmentIds($roleName, array $departmentIds, $resolveReferences = 0, $disableCache = false, $workstation = null)
+    public function readListByRoleAndDepartmentIds($roleName, array $departmentIds, int $resolveReferences = 0, bool $disableCache = false, $workstation = null)
     {
         sort($departmentIds);
         $version = $this->getUseraccountCacheVersion();
@@ -1103,7 +1126,10 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $result;
     }
 
-    public function removeCache($useraccount, array $previousDepartmentIds = [], ?string $oldLoginName = null)
+    /**
+     * @return void
+     */
+    public function removeCache(Entity $useraccount, array $previousDepartmentIds = [], ?string $oldLoginName = null)
     {
         if (!App::$cache) {
             return;

--- a/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
@@ -566,7 +566,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         return $departmentList;
     }
 
-    public function readEntityByAuthKey(array $xAuthKey, $resolveReferences = 0)
+    public function readEntityByAuthKey(string $xAuthKey, $resolveReferences = 0)
     {
         $hashedAuthKey = hash('sha256', $xAuthKey);
         $query = new \BO\Zmsbackend\Useraccount\Repository\Useraccount(\BO\Zmsbackend\Query\Base::SELECT);

--- a/zmsbackend/src/Zmsbackend/Warehouse/Service/Warehouse.php
+++ b/zmsbackend/src/Zmsbackend/Warehouse/Service/Warehouse.php
@@ -85,7 +85,7 @@ class Warehouse extends \BO\Zmsbackend\Base
         ],
     ];
 
-    public function readSubjectsList()
+    public function readSubjectsList(): Exchange
     {
         $entity = (new Exchange())->withLessData();
         $entity->addDictionaryEntry('subject', 'string', 'subject name');

--- a/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationLogin.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationLogin.php
@@ -46,7 +46,7 @@ class WorkstationLogin extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    public static function getLoggedInWorkstation($request, $entity, $resolveReferences)
+    public static function getLoggedInWorkstation(\Psr\Http\Message\RequestInterface $request, \BO\Zmsentities\Useraccount $entity, $resolveReferences)
     {
         \BO\Zmsbackend\Helper\UserAuth::testUseraccountExists($entity->getId());
         $useraccount = \BO\Zmsbackend\Helper\UserAuth::getVerifiedUseraccount($entity);
@@ -75,6 +75,9 @@ class WorkstationLogin extends \BO\Zmsbackend\Api\BaseController
         return $workstation;
     }
 
+    /**
+     * @return void
+     */
     public static function testLoginHash($workstation)
     {
         $useraccount = $workstation->getUseraccount();

--- a/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationOAuth.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationOAuth.php
@@ -49,7 +49,7 @@ class WorkstationOAuth extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function getLoggedInWorkstationByOidc($request, $entity, $resolveReferences)
+    protected function getLoggedInWorkstationByOidc(\Psr\Http\Message\RequestInterface $request, string $entity, $resolveReferences)
     {
         \BO\Zmsbackend\Helper\UserAuth::testUseraccountExists($entity->getId());
 

--- a/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationOAuth.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationOAuth.php
@@ -49,7 +49,7 @@ class WorkstationOAuth extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function getLoggedInWorkstationByOidc(\Psr\Http\Message\RequestInterface $request, string $entity, $resolveReferences)
+    protected function getLoggedInWorkstationByOidc(\Psr\Http\Message\RequestInterface $request, UseraccountEntity $entity, $resolveReferences)
     {
         \BO\Zmsbackend\Helper\UserAuth::testUseraccountExists($entity->getId());
 

--- a/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationProcess.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationProcess.php
@@ -90,7 +90,10 @@ class WorkstationProcess extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    protected function validateProcessCurrentDate($process)
+    /**
+     * @return void
+     */
+    protected function validateProcessCurrentDate(\BO\Zmsentities\Process|null $process)
     {
         if (!$process || !$process->hasId() || !$process->isWithAppointment()) {
             return;
@@ -118,7 +121,10 @@ class WorkstationProcess extends \BO\Zmsbackend\Api\BaseController
         }
     }
 
-    protected function testProcessData($entity)
+    /**
+     * @return void
+     */
+    protected function testProcessData(\BO\Zmsentities\Process $entity)
     {
         $authCheck = (new Query())->readAuthKeyByProcessId($entity->id);
         if (! $authCheck) {
@@ -129,7 +135,10 @@ class WorkstationProcess extends \BO\Zmsbackend\Api\BaseController
         \BO\Zmsbackend\Helper\Matching::testCurrentScopeHasRequest($entity);
     }
 
-    protected function testProcess($process, $workstation, $allowClusterWideCall)
+    /**
+     * @return void
+     */
+    protected function testProcess(\BO\Zmsentities\Process $process, $workstation, $allowClusterWideCall)
     {
         if ('called' == $process->status || 'processing' == $process->status) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessAlreadyCalled();

--- a/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationProcessGet.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Api/WorkstationProcessGet.php
@@ -47,7 +47,10 @@ class WorkstationProcessGet extends \BO\Zmsbackend\Api\BaseController
         return $response;
     }
 
-    protected function validateProcessStatus($process)
+    /**
+     * @return void
+     */
+    protected function validateProcessStatus(\BO\Zmsentities\Process $process)
     {
         $blockedStatuses = ['reserved', 'preconfirmed', 'deleted', 'called', 'processing'];
 

--- a/zmsbackend/src/Zmsbackend/Workstation/Repository/Workstation.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Repository/Workstation.php
@@ -88,17 +88,24 @@ class Workstation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
             `Passworthash` = ?
     ';
 
+    /**
+     * @return void
+     */
     #[\Override]
     protected function addRequiredJoins()
     {
     }
 
-    public function getLockWorkstationId()
+    public function getLockWorkstationId(): string
     {
         return 'SELECT * FROM `' . self::getTablename() . '` A
             WHERE A.`NutzerID` = :workstationId FOR UPDATE';
     }
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getEntityMapping()
     {
@@ -128,7 +135,7 @@ class Workstation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $joins;
     }
 
-    public function addJoinScope()
+    public function addJoinScope(): \BO\Zmsbackend\Query\Scope
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Query\Scope::TABLE, 'scope'),
@@ -141,7 +148,7 @@ class Workstation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
     }
 
 
-    public function addJoinUseraccount()
+    public function addJoinUseraccount(): \BO\Zmsbackend\Useraccount\Repository\Useraccount
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Useraccount\Repository\Useraccount::TABLE, 'useraccount'),
@@ -153,46 +160,52 @@ class Workstation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $joinQuery;
     }
 
-    public function addConditionLoginName($loginName)
+    public function addConditionLoginName($loginName): static
     {
         $this->query->where('workstation.Name', '=', $loginName);
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionWorkstationName($workstationName)
+    /**
+     * @psalm-api
+     */
+    public function addConditionWorkstationName($workstationName): static
     {
         $this->query->where('workstation.Arbeitsplatznr', '=', $workstationName);
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionWorkstationIsNotCounter()
+    /**
+     * @psalm-api
+     */
+    public function addConditionWorkstationIsNotCounter(): static
     {
         $this->query->where('workstation.Arbeitsplatznr', '>', 0);
         return $this;
     }
 
-    public function addConditionWorkstationId($workstationId)
+    public function addConditionWorkstationId($workstationId): static
     {
         $this->query->where('workstation.NutzerID', '=', $workstationId);
         return $this;
     }
 
-    public function addConditionScopeId($scopeId)
+    public function addConditionScopeId($scopeId): static
     {
         $this->query->where('workstation.StandortID', '=', $scopeId);
         return $this;
     }
 
-    /** @psalm-api */
-    public function addConditionTime($now)
+    /**
+     * @psalm-api
+     */
+    public function addConditionTime($now): static
     {
         $this->query->where('workstation.Datum', '=', $now->format('Y-m-d'));
         return $this;
     }
 
-    public function addConditionDepartmentId($departmentId)
+    public function addConditionDepartmentId($departmentId): static
     {
         $this->leftJoin(
             new \BO\Zmsbackend\Query\Alias(\BO\Zmsbackend\Useraccount\Repository\Useraccount::TABLE_ASSIGNMENT, 'workstation_department'),
@@ -204,7 +217,7 @@ class Workstation extends \BO\Zmsbackend\Query\Base implements \BO\Zmsbackend\Qu
         return $this;
     }
 
-    public function reverseEntityMapping(\BO\Zmsentities\Workstation $entity)
+    public function reverseEntityMapping(\BO\Zmsentities\Workstation $entity): array
     {
         $data = array();
         if ((isset($entity['hint']) && '' == $entity['hint']) || ! isset($entity['hint'])) {

--- a/zmsbackend/src/Zmsbackend/Workstation/Service/Workstation.php
+++ b/zmsbackend/src/Zmsbackend/Workstation/Service/Workstation.php
@@ -29,6 +29,9 @@ class Workstation extends \BO\Zmsbackend\Base
         return $this->readResolvedReferences($workstation, $resolveReferences);
     }
 
+    /**
+     * @return \BO\Zmsentities\Schema\Entity
+     */
     #[\Override]
     public function readResolvedReferences(\BO\Zmsentities\Schema\Entity $entity, $resolveReferences)
     {
@@ -61,7 +64,7 @@ class Workstation extends \BO\Zmsbackend\Base
         return ($loggedInWorkstation['hash']) ? $loggedInWorkstation['hash'] : null;
     }
 
-    public function readLoggedInListByScope($scopeId, \DateTimeInterface $dateTime, $resolveReferences = 0)
+    public function readLoggedInListByScope($scopeId, \DateTimeInterface $dateTime, $resolveReferences = 0): Collection
     {
         $workstationList = new \BO\Zmsentities\Collection\WorkstationList();
         $query = new \BO\Zmsbackend\Workstation\Repository\Workstation(\BO\Zmsbackend\Query\Base::SELECT);
@@ -83,7 +86,7 @@ class Workstation extends \BO\Zmsbackend\Base
         return $workstationList;
     }
 
-    public function readLoggedInListByCluster($clusterId, \DateTimeInterface $dateTime, $resolveReferences = 0)
+    public function readLoggedInListByCluster($clusterId, \DateTimeInterface $dateTime, $resolveReferences = 0): Collection
     {
         $workstationList = new \BO\Zmsentities\Collection\WorkstationList();
         $cluster = (new \BO\Zmsbackend\Cluster\Service\Cluster())->readEntity($clusterId, $resolveReferences);
@@ -111,7 +114,7 @@ class Workstation extends \BO\Zmsbackend\Base
         return $workstation;
     }
 
-    public function readCollectionByDepartmentId($departmentId, $resolveReferences = 0)
+    public function readCollectionByDepartmentId($departmentId, $resolveReferences = 0): Collection
     {
         $collection = new Collection();
         $query = new \BO\Zmsbackend\Workstation\Repository\Workstation(\BO\Zmsbackend\Query\Base::SELECT);

--- a/zmscalldisplay/src/Zmscalldisplay/BaseController.php
+++ b/zmscalldisplay/src/Zmscalldisplay/BaseController.php
@@ -28,7 +28,7 @@ abstract class BaseController extends \BO\Slim\Controller
         return $this->readResponse($request, $noCacheResponse, $args);
     }
 
-    protected function buildQuery(string $target, RequestInterface $request)
+    protected function buildQuery(string $target, RequestInterface $request): string
     {
         $queryArr  = [];
         $allParams = array_merge(static::$hashParameter[$target], ['template']);

--- a/zmscalldisplay/src/Zmscalldisplay/Helper/Calldisplay.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Helper/Calldisplay.php
@@ -26,7 +26,7 @@ class Calldisplay
         $this->entity = static::createInstance($request);
     }
 
-    public static function getRequestedQueueStatus($request)
+    public static function getRequestedQueueStatus(\Psr\Http\Message\RequestInterface $request)
     {
         /** @var Validator $validator */
         $validator = $request->getAttribute('validator');
@@ -35,7 +35,7 @@ class Calldisplay
         return is_string($status) ? explode(',', $status) : static::DEFAULT_STATUS;
     }
 
-    public function getEntity($resolveEntity = true)
+    public function getEntity(bool $resolveEntity = true)
     {
         if (!$this->isEntityResolved && $resolveEntity) {
             $callDisplay = \App::$http->readPostResult('/calldisplay/', $this->entity);

--- a/zmscalldisplay/src/Zmscalldisplay/Helper/EntryFromOldRoute.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Helper/EntryFromOldRoute.php
@@ -21,8 +21,10 @@ class EntryFromOldRoute
 
     /**
      * @param Request $request
+     *
+     * @return null|string
      */
-    protected static function getScopes($request)
+    protected static function getScopes($request): string|null
     {
         $scopes = [ ];
         $validator = $request->getAttribute('validator');

--- a/zmscalldisplay/src/Zmscalldisplay/Helper/TemplateFinder.php
+++ b/zmscalldisplay/src/Zmscalldisplay/Helper/TemplateFinder.php
@@ -39,7 +39,7 @@ class TemplateFinder
         return $this->template;
     }
 
-    public function setCustomizedTemplate($calldisplay)
+    public function setCustomizedTemplate($calldisplay): static
     {
         $template = null;
         if ($this->defaultTemplate == 'defaultplatz') {
@@ -77,7 +77,7 @@ class TemplateFinder
         return $template;
     }
 
-    protected function getExistingTemplate(Entity $entity)
+    protected function getExistingTemplate(Entity $entity): string|null
     {
         $path = $this->subPath . '/calldisplay_' . $entity->getEntityName() . '_' . $entity->getId() . '.twig';
         if ($entity->hasId() && $this->isTemplateReadable($path)) {
@@ -87,12 +87,12 @@ class TemplateFinder
         return null;
     }
 
-    protected function isTemplateReadable($path)
+    protected function isTemplateReadable(string $path): bool
     {
         return is_readable($this->getTemplatePath() . $path);
     }
 
-    public function getTemplatePath()
+    public function getTemplatePath(): string
     {
         return realpath(__DIR__) . '/../../../templates';
     }

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Collections/OfficeList.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Collections/OfficeList.php
@@ -29,6 +29,9 @@ class OfficeList extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Collections/OfficeServiceAndRelationList.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Collections/OfficeServiceAndRelationList.php
@@ -34,6 +34,9 @@ class OfficeServiceAndRelationList extends Entity implements JsonSerializable
         ];
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Collections/OfficeServiceRelationList.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Collections/OfficeServiceRelationList.php
@@ -30,6 +30,9 @@ class OfficeServiceRelationList extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Collections/ServiceList.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Collections/ServiceList.php
@@ -29,6 +29,9 @@ class ServiceList extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Collections/ThinnedScopeList.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Collections/ThinnedScopeList.php
@@ -29,6 +29,9 @@ class ThinnedScopeList extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Combinable.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Combinable.php
@@ -24,6 +24,9 @@ class Combinable extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Office.php
@@ -66,6 +66,9 @@ class Office extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/OfficeServiceRelation.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/OfficeServiceRelation.php
@@ -28,6 +28,9 @@ class OfficeServiceRelation extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/Service.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/Service.php
@@ -42,6 +42,9 @@ class Service extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedProcess.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedProcess.php
@@ -107,6 +107,9 @@ class ThinnedProcess extends Entity implements JsonSerializable
         return $this->icsContent;
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedProvider.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedProvider.php
@@ -30,6 +30,9 @@ class ThinnedProvider extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedScope.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Models/ThinnedScope.php
@@ -62,6 +62,9 @@ class ThinnedScope extends Entity implements JsonSerializable
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Captcha/CaptchaService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Captcha/CaptchaService.php
@@ -35,6 +35,9 @@ class CaptchaService extends Entity implements CaptchaInterface
         $this->ensureValid();
     }
 
+    /**
+     * @return void
+     */
     private function ensureValid()
     {
         if (!$this->testValid()) {

--- a/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
+++ b/zmscitizenapi/src/Zmscitizenapi/Services/Core/ZmsApiFacadeService.php
@@ -37,7 +37,10 @@ class ZmsApiFacadeService
     private const string CACHE_KEY_OFFICES_AND_SERVICES = 'processed_offices_and_services';
     private const string CACHE_KEY_SERVICES_BY_OFFICE_PREFIX = 'processed_services_by_office_';
 
-    private static function setMappedCache(string $cacheKey, mixed $data): void
+    /**
+     * @param OfficeList|OfficeServiceAndRelationList|ServiceList|ThinnedScopeList $data
+     */
+    private static function setMappedCache(string $cacheKey, OfficeList|ThinnedScopeList|ServiceList|OfficeServiceAndRelationList $data): void
     {
         if (\App::$cache) {
             \App::$cache->set($cacheKey, $data, \App::$SOURCE_CACHE_TTL);

--- a/zmsclient/src/Zmsclient/Auth.php
+++ b/zmsclient/src/Zmsclient/Auth.php
@@ -12,11 +12,9 @@ class Auth
     private static $cookieName = 'X-AuthKey';
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
-     *
      */
-    public static function setKey($authKey, $expires = 0)
+    public static function setKey($authKey, $expires = 0): void
     {
         $_COOKIE[self::getCookieName()] = $authKey; // for access in the same process
         if (!headers_sent()) {
@@ -35,11 +33,11 @@ class Auth
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
      *
+     * @return null|string
      */
-    public static function getKey()
+    public static function getKey(): string|null
     {
         if (array_key_exists(self::getCookieName(), $_COOKIE)) {
             return $_COOKIE[self::getCookieName()];
@@ -48,11 +46,9 @@ class Auth
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
-     *
      */
-    public static function removeKey()
+    public static function removeKey(): void
     {
         if (array_key_exists(self::getCookieName(), $_COOKIE)) {
             $oldKey = $_COOKIE[self::getCookieName()];
@@ -76,17 +72,15 @@ class Auth
         return self::$cookieName;
     }
 
-    protected static function getOidcName()
+    protected static function getOidcName(): string
     {
         return 'OIDC';
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
-     *
      */
-    public static function setOidcProvider($provider)
+    public static function setOidcProvider($provider): void
     {
         $_COOKIE[self::getOidcName()] = $provider; // for access in the same process
         if (!headers_sent()) {
@@ -95,11 +89,11 @@ class Auth
     }
 
      /**
-     *
      * @SuppressWarnings(Superglobals)
      *
+     * @return false|string
      */
-    public static function getOidcProvider()
+    public static function getOidcProvider(): string|false
     {
         if (array_key_exists(self::getOidcName(), $_COOKIE)) {
             return $_COOKIE[self::getOidcName()];
@@ -108,11 +102,9 @@ class Auth
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
-     *
      */
-    public static function removeOidcProvider()
+    public static function removeOidcProvider(): void
     {
         if (array_key_exists(self::getOidcName(), $_COOKIE)) {
             unset($_COOKIE[self::getOidcName()]);

--- a/zmsclient/src/Zmsclient/GraphQL/GraphQLInterpreter.php
+++ b/zmsclient/src/Zmsclient/GraphQL/GraphQLInterpreter.php
@@ -12,7 +12,7 @@ class GraphQLInterpreter implements \JsonSerializable
         $this->gqlString = $gqlString;
     }
 
-    protected function getGraphInterpretation()
+    protected function getGraphInterpretation(): GraphQLNode
     {
         if (!preg_match_all('#\w+|[{}]#', $this->gqlString, $parts)) {
             throw new GraphQLException("No content for graph");

--- a/zmsclient/src/Zmsclient/GraphQL/GraphQLNode.php
+++ b/zmsclient/src/Zmsclient/GraphQL/GraphQLNode.php
@@ -8,12 +8,15 @@ class GraphQLNode extends GraphQLElement
 
     public $parent;
 
-    public function addElement($propertyName): self
+    public function addElement(string $propertyName): self
     {
         $this->propertyList[] = new GraphQLElement($propertyName);
         return $this;
     }
 
+    /**
+     * @return false|key-of<TArray>
+     */
     protected function getLastKey()
     {
         $keys = array_keys($this->propertyList);

--- a/zmsclient/src/Zmsclient/Http.php
+++ b/zmsclient/src/Zmsclient/Http.php
@@ -80,13 +80,13 @@ class Http
         $this->client = $client;
     }
 
-    public function setUserInfo($user, $pass)
+    public function setUserInfo(string $user, string|false|null $pass): static
     {
         $this->uri = $this->uri->withUserInfo($user, $pass);
         return $this;
     }
 
-    public function getUserInfo()
+    public function getUserInfo(): string
     {
         return $this->uri->getUserInfo();
     }
@@ -144,13 +144,13 @@ class Http
         return $request;
     }
 
-    public function setApiKey($apikeyString)
+    public function setApiKey($apikeyString): static
     {
         $this->apikeyString = $apikeyString;
         return $this;
     }
 
-    public function setWorkflowKey($apikeyString)
+    public function setWorkflowKey($apikeyString): static
     {
         $this->workflowkeyString = $apikeyString;
         return $this;
@@ -161,10 +161,11 @@ class Http
      *
      * @param string $relativeUrl
      * @param array|null $getParameters (optional)
+     * @param null|string $xToken
      *
      * @return Result
      */
-    public function readGetResult($relativeUrl, array $getParameters = null, $xToken = null)
+    public function readGetResult($relativeUrl, array $getParameters = null, string|null $xToken = null)
     {
         $uri = $this->uri->withPath($this->http_baseurl . $relativeUrl);
         if (null !== $getParameters) {
@@ -181,8 +182,11 @@ class Http
 
     /**
      * Creates a POST-Http-Request and fetches the response
+     *
+     * @param \BO\Zmsentities\Session|\BO\Zmsentities\Useraccount $entity
+     *
      */
-    public function readPostResult($relativeUrl, $entity, array $getParameters = null)
+    public function readPostResult(string $relativeUrl, \BO\Zmsentities\Useraccount|\BO\Zmsentities\Session $entity, array $getParameters = null)
     {
         $uri = $this->uri->withPath($this->http_baseurl . $relativeUrl);
         if (null !== $getParameters) {

--- a/zmsclient/src/Zmsclient/Http.php
+++ b/zmsclient/src/Zmsclient/Http.php
@@ -183,10 +183,9 @@ class Http
     /**
      * Creates a POST-Http-Request and fetches the response
      *
-     * @param \BO\Zmsentities\Session|\BO\Zmsentities\Useraccount $entity
-     *
+     * @param \BO\Zmsentities\Schema\Entity $entity
      */
-    public function readPostResult(string $relativeUrl, \BO\Zmsentities\Useraccount|\BO\Zmsentities\Session $entity, array $getParameters = null)
+    public function readPostResult(string $relativeUrl, \BO\Zmsentities\Schema\Entity $entity, array $getParameters = null)
     {
         $uri = $this->uri->withPath($this->http_baseurl . $relativeUrl);
         if (null !== $getParameters) {

--- a/zmsclient/src/Zmsclient/Http.php
+++ b/zmsclient/src/Zmsclient/Http.php
@@ -144,7 +144,7 @@ class Http
         return $request;
     }
 
-    public function setApiKey($apikeyString): static
+    public function setApiKey($apikeyString)
     {
         $this->apikeyString = $apikeyString;
         return $this;
@@ -183,9 +183,9 @@ class Http
     /**
      * Creates a POST-Http-Request and fetches the response
      *
-     * @param \BO\Zmsentities\Schema\Entity $entity
+     * @param mixed $entity JSON-encodable payload (entity or collection)
      */
-    public function readPostResult(string $relativeUrl, \BO\Zmsentities\Schema\Entity $entity, array $getParameters = null)
+    public function readPostResult(string $relativeUrl, $entity, array $getParameters = null)
     {
         $uri = $this->uri->withPath($this->http_baseurl . $relativeUrl);
         if (null !== $getParameters) {

--- a/zmsclient/src/Zmsclient/PhpUnit/Base.php
+++ b/zmsclient/src/Zmsclient/PhpUnit/Base.php
@@ -117,8 +117,10 @@ abstract class Base extends \BO\Slim\PhpUnit\Base
         return $this->apiCalls;
     }
 
-    /** @psalm-api */
-    protected function getGraphQL($parameters)
+    /**
+     * @psalm-api
+     */
+    protected function getGraphQL($parameters): GraphQLInterpreter|null
     {
         if (isset($parameters['gql'])) {
             $gqlString = $parameters['gql'];
@@ -130,7 +132,7 @@ abstract class Base extends \BO\Slim\PhpUnit\Base
         return null;
     }
 
-    public function setApiCalls($apiCalls)
+    public function setApiCalls($apiCalls): void
     {
         $this->apiCalls = $apiCalls;
         \App::$http = $this->getApiMockup();

--- a/zmsclient/src/Zmsclient/Psr7/Client.php
+++ b/zmsclient/src/Zmsclient/Psr7/Client.php
@@ -43,7 +43,7 @@ class Client
      * @return \Http\Client\Curl\Client
      * @throws ClientCreationException
      */
-    public static function getCurlClient($curlOptions): ClientInterface
+    public static function getCurlClient(array $curlOptions): ClientInterface
     {
         $curlOptions = $curlOptions + static::$curlopt;
         if (!isset($curlOptions[CURLOPT_USERAGENT])) {
@@ -64,8 +64,10 @@ class Client
         return $client;
     }
 
-    /** @psalm-api */
-    public function send(RequestInterface $request)
+    /**
+     * @psalm-api
+     */
+    public function send(RequestInterface $request): ResponseInterface
     {
         return static::readResponse($request);
     }

--- a/zmsclient/src/Zmsclient/Result.php
+++ b/zmsclient/src/Zmsclient/Result.php
@@ -69,7 +69,10 @@ class Result
      *
      * @param Valid $body
      * @param ResponseInterface $response
+     *
      * @throws Exception
+     *
+     * @return void
      */
     protected function testMeta($body, ResponseInterface $response)
     {

--- a/zmsclient/src/Zmsclient/Status.php
+++ b/zmsclient/src/Zmsclient/Status.php
@@ -12,9 +12,10 @@ class Status
 {
     /**
      * throws exception on critical status variables
+     *
      * @SuppressWarnings(Complexity)
      */
-    public static function testStatus(ResponseInterface $response, $status)
+    public static function testStatus(ResponseInterface $response, $status): ResponseInterface
     {
         $result = '';
         if ($status instanceof \Closure) {
@@ -82,7 +83,7 @@ class Status
         return $response;
     }
 
-    public static function getDldbUpdateStats($status)
+    public static function getDldbUpdateStats($status): string
     {
         $result = '';
         if (isset($status['sources'])) {

--- a/zmsclient/src/Zmsclient/Ticketprinter.php
+++ b/zmsclient/src/Zmsclient/Ticketprinter.php
@@ -12,10 +12,11 @@ class Ticketprinter
 
     /**
      * @SuppressWarnings(Superglobals)
+     *
      * @param string $hash
      * @param \BO\Zmsclient\Psr7\Request $request
      */
-    public static function setHash($hash, $request)
+    public static function setHash($hash, $request): void
     {
         $_COOKIE[self::HASH_COOKIE_NAME] = $hash;
         if (!headers_sent()) {
@@ -31,11 +32,11 @@ class Ticketprinter
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
      *
+     * @return false|string
      */
-    public static function getHash()
+    public static function getHash(): string|false
     {
         if (array_key_exists(self::HASH_COOKIE_NAME, $_COOKIE)) {
             return $_COOKIE[self::HASH_COOKIE_NAME];
@@ -44,12 +45,11 @@ class Ticketprinter
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
-     * @getBasePath() see https://www.slimframework.com/docs/v3/objects/request.html#the-request-method
      *
+     * @getBasePath () see https://www.slimframework.com/docs/v3/objects/request.html#the-request-method
      */
-    public static function setHomeUrl($url, $request)
+    public static function setHomeUrl($url, $request): void
     {
         $_COOKIE[self::HOME_URL_COOKIE_NAME] = $url;
         if (!headers_sent()) {
@@ -66,11 +66,11 @@ class Ticketprinter
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
      *
+     * @return false|string
      */
-    public static function getHomeUrl()
+    public static function getHomeUrl(): string|false
     {
         if (array_key_exists(self::HOME_URL_COOKIE_NAME, $_COOKIE)) {
             return $_COOKIE[self::HOME_URL_COOKIE_NAME];

--- a/zmsclient/src/Zmsclient/TwigExtension.php
+++ b/zmsclient/src/Zmsclient/TwigExtension.php
@@ -28,7 +28,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         $this->container = $container;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'bozmsclientExtension';
     }
@@ -42,7 +42,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         );
     }
 
-    public function dumpHttpLog()
+    public function dumpHttpLog(): string
     {
         $output = '<h2>HTTP API-Log</h2>'
             . ' <p>For debugging: This log contains HTTP calls. <strong>DISABLE FOR PRODUCTION!</strong></p>';
@@ -58,7 +58,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $output;
     }
 
-    protected function parseBody($body, $allowEmpty = false)
+    protected function parseBody(\Psr\Http\Message\StreamInterface $body, bool $allowEmpty = false)
     {
         $content = Validator::value((string)$body)->isJson();
         if ($content->hasFailed() && !$allowEmpty) {
@@ -72,7 +72,11 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $output;
     }
 
-    protected function parseHeaders(\Psr\Http\Message\MessageInterface $message)
+    /**
+     * @return string[]
+     *
+     */
+    protected function parseHeaders(\Psr\Http\Message\MessageInterface $message): array
     {
         $headers = [];
         foreach ($message->getHeaders() as $name => $header) {
@@ -81,7 +85,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $headers;
     }
 
-    protected function formatRequest(\Psr\Http\Message\RequestInterface $request)
+    protected function formatRequest(\Psr\Http\Message\RequestInterface $request): array
     {
         $output = [];
         $output['header'] = $this->parseHeaders($request);
@@ -89,7 +93,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $output;
     }
 
-    protected function formatResponse(\Psr\Http\Message\ResponseInterface $response)
+    protected function formatResponse(\Psr\Http\Message\ResponseInterface $response): array
     {
         $output = [];
         $output['header'] = $this->parseHeaders($response);

--- a/zmsclient/src/Zmsclient/WorkstationRequests.php
+++ b/zmsclient/src/Zmsclient/WorkstationRequests.php
@@ -84,8 +84,10 @@ class WorkstationRequests
     }
 
 
-    /** @psalm-api */
-    public function readNextProcess($excludedIds)
+    /**
+     * @psalm-api
+     */
+    public function readNextProcess($excludedIds): \BO\Zmsentities\Schema\Entity|false|null
     {
         $exclude = is_array($excludedIds) ? implode(',', $excludedIds) : $excludedIds;
         if ($this->workstation->isClusterEnabled()) {

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -48,8 +48,10 @@ class AbstractAccess
         'Topic' => null
     ];
 
-    /** @psalm-api */
-    public function addAccessInstanceLocale($locale = 'de')
+    /**
+     * @psalm-api
+     */
+    public function addAccessInstanceLocale($locale = 'de'): void
     {
         if (!isset($this->accessInstance[$locale])) {
             $this->accessInstance[$locale] = static::$accessInstanceTypes;
@@ -118,10 +120,10 @@ class AbstractAccess
     }
 
     /**
-     *
      * @return string InstanceName
+     *
      */
-    protected function getInstanceOnName($name, $position = 0)
+    protected function getInstanceOnName($name, int $position = 0)
     {
         foreach (array_keys($this->getInstanceCompatibilities()) as $instanceName) {
             if ($position === strpos($name, $instanceName)) {
@@ -131,7 +133,7 @@ class AbstractAccess
         return null;
     }
 
-    protected function from($instanceName, $locale = 'de')
+    protected function from(string $instanceName, $locale = 'de'): File\Base
     {
         if (array_key_exists($instanceName, $this->accessInstance[$locale])) {
             $instance = $this->accessInstance[$locale][$instanceName];

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -20,7 +20,7 @@ class Authorities extends Base
         }
     }
 
-    public function addLocation(\BO\Zmsdldb\Entity\Location $location)
+    public function addLocation(\BO\Zmsdldb\Entity\Location $location): static
     {
         if (
             $location->offsetExists('authority')
@@ -41,7 +41,7 @@ class Authorities extends Base
         return $this;
     }
 
-    public function addAuthority($authority_id, $name)
+    public function addAuthority($authority_id, $name): static
     {
         if (! $this->hasAuthority($authority_id)) {
             $authority = \BO\Zmsdldb\Entity\Authority::create($name);
@@ -55,8 +55,10 @@ class Authorities extends Base
         return $this->offsetExists($authority_id);
     }
 
-    /** @psalm-api */
-    public function readByExtendedService($service)
+    /**
+     * @psalm-api
+     */
+    public function readByExtendedService($service): static
     {
         foreach ($service['authorities'] as $authority) {
             if (! $this->hasAuthority($authority['id'])) {
@@ -168,7 +170,7 @@ class Authorities extends Base
         return $this;
     }
 
-    public function removeEmptyAuthorities()
+    public function removeEmptyAuthorities(): self
     {
         $authoritylist = new self();
         foreach ($this as $key => $authority) {
@@ -179,7 +181,7 @@ class Authorities extends Base
         return $authoritylist;
     }
 
-    public function removeLocations()
+    public function removeLocations(): static
     {
         $authoritylist = clone $this;
         foreach ($authoritylist as $authority) {
@@ -213,8 +215,13 @@ class Authorities extends Base
         return $authoritylist;
     }
 
-    /** @psalm-api */
-    public function getAuthorityIds()
+    /**
+     * @psalm-api
+     *
+     * @return (int|mixed|string)[]
+     *
+     */
+    public function getAuthorityIds(): array
     {
         $ids = [];
 

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -14,7 +14,7 @@ use BO\Zmsdldb\Helper\Sorter;
  */
 class Base extends \ArrayObject
 {
-    public function sortByName()
+    public function sortByName(): static
     {
         $itemList = clone $this;
         $itemList->uasort(function ($a, $b) {
@@ -23,8 +23,10 @@ class Base extends \ArrayObject
         return $itemList;
     }
 
-    /** @psalm-api */
-    public function sortWithCollator($field = 'name', $locale = 'de')
+    /**
+     * @psalm-api
+     */
+    public function sortWithCollator($field = 'name', $locale = 'de'): static
     {
         $collator = collator_create($locale);
         $collator->setStrength(\Collator::QUATERNARY);

--- a/zmsdldb/src/Zmsdldb/Collection/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Locations.php
@@ -49,7 +49,7 @@ class Locations extends Base
      * @param String $serviceCsv only check for this serviceCsv
      * @param Bool $external allow external links, default false
      */
-    public function getLocationsWithAppointmentsFor($serviceCsv = null, $external = false)
+    public function getLocationsWithAppointmentsFor($serviceCsv = null, $external = false): self
     {
         $list = new self();
         foreach ($this as $location) {
@@ -60,7 +60,7 @@ class Locations extends Base
         return $list;
     }
 
-    public function getIds()
+    public function getIds(): array
     {
         $idList = array();
         foreach ($this as $location) {
@@ -69,8 +69,10 @@ class Locations extends Base
         return $idList;
     }
 
-    /** @psalm-api */
-    public function getNames()
+    /**
+     * @psalm-api
+     */
+    public function getNames(): array
     {
         $nameList = array();
         foreach ($this as $location) {
@@ -79,12 +81,12 @@ class Locations extends Base
         return $nameList;
     }
 
-    public function getCSV()
+    public function getCSV(): string
     {
         return implode(',', $this->getIds());
     }
 
-    public function getLocationListByOfficePath($officepath)
+    public function getLocationListByOfficePath(string $officepath): self
     {
         $locationList = new self();
         foreach ($this as $location_id => $location) {

--- a/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
+++ b/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
@@ -11,8 +11,10 @@ use BO\Zmsdldb\Entity\SearchResult as Entity;
 
 class SearchResults extends Base
 {
-    /** @psalm-api */
-    public function getNames()
+    /**
+     * @psalm-api
+     */
+    public function getNames(): array
     {
         $nameList = array();
         foreach ($this as $item) {
@@ -21,8 +23,10 @@ class SearchResults extends Base
         return $nameList;
     }
 
-    /** @psalm-api */
-    public function toSearchResultData()
+    /**
+     * @psalm-api
+     */
+    public function toSearchResultData(): self
     {
         $list = new self();
         foreach ($this as $results) {
@@ -37,8 +41,12 @@ class SearchResults extends Base
         return $list;
     }
 
-    /** @psalm-api */
-    public function addSearchResultsData($data)
+    /**
+     * @psalm-api
+     *
+     * @return null|static
+     */
+    public function addSearchResultsData($data): static|null
     {
         if ($data) {
             $this[] = $data;
@@ -47,8 +55,10 @@ class SearchResults extends Base
         return null;
     }
 
-    /** @psalm-api */
-    public function sortByType(array $order)
+    /**
+     * @psalm-api
+     */
+    public function sortByType(array $order): self
     {
         $list = new self();
         foreach ($order as $type) {

--- a/zmsdldb/src/Zmsdldb/Collection/Services.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Services.php
@@ -9,7 +9,7 @@ namespace BO\Zmsdldb\Collection;
 
 class Services extends Base
 {
-    public function containsLocation($locationCsv = null)
+    public function containsLocation($locationCsv = null): self
     {
         $list = new self();
         foreach ($this as $service) {
@@ -20,7 +20,7 @@ class Services extends Base
         return $list;
     }
 
-    public function getIds()
+    public function getIds(): array
     {
         $idList = array();
         foreach ($this as $service) {
@@ -29,8 +29,10 @@ class Services extends Base
         return $idList;
     }
 
-    /** @psalm-api */
-    public function getNames()
+    /**
+     * @psalm-api
+     */
+    public function getNames(): array
     {
         $nameList = array();
         foreach ($this as $service) {
@@ -39,14 +41,20 @@ class Services extends Base
         return $nameList;
     }
 
-    /** @psalm-api */
-    public function getCSV()
+    /**
+     * @psalm-api
+     */
+    public function getCSV(): string
     {
         return implode(',', $this->getIds());
     }
 
-    /** @psalm-api */
-    public function isLocale($locale)
+    /**
+     * @psalm-api
+     *
+     * @return null|self
+     */
+    public function isLocale($locale): self|null
     {
         $list = new self();
         foreach ($this as $service) {

--- a/zmsdldb/src/Zmsdldb/Collection/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Topics.php
@@ -9,8 +9,10 @@ namespace BO\Zmsdldb\Collection;
 
 class Topics extends Base
 {
-    /** @psalm-api */
-    public function getNames()
+    /**
+     * @psalm-api
+     */
+    public function getNames(): array
     {
         $nameList = array();
         foreach ($this as $topic) {

--- a/zmsdldb/src/Zmsdldb/Elastic/Helper.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Helper.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Elastic;
 
 class Helper
 {
-    public static function boolFilteredQuery()
+    public static function boolFilteredQuery(): \Elastica\Query\Filtered
     {
         $boolQuery = new \Elastica\Query\BoolQuery();
         $boolFilter = new \Elastica\Filter\BoolFilter();
@@ -14,7 +14,7 @@ class Helper
         return $query;
     }
 
-    public static function localeFilter($locale)
+    public static function localeFilter(string $locale): \Elastica\Filter\Term
     {
         $localeFilter = new \Elastica\Filter\Term(array(
             'meta.locale' => $locale
@@ -22,7 +22,7 @@ class Helper
         return $localeFilter;
     }
 
-    public static function idsFilter($ids)
+    public static function idsFilter(string $ids): \Elastica\Filter\Ids
     {
         $filter = new \Elastica\Filter\Ids();
         $filter->setIds($ids);

--- a/zmsdldb/src/Zmsdldb/Elastic/Link.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Link.php
@@ -11,10 +11,11 @@ use BO\Zmsdldb\Entity\Link as Entity;
 use BO\Zmsdldb\Collection\Links as Collection;
 use BO\Zmsdldb\File\Link as Base;
 
-/**
- */
 class Link extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     public function readSearchResultList($query)
     {

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -245,7 +245,11 @@ class Location extends Base
 
     /**
      * @todo Refactoring required, functions in this class should return entities, not JSON data
+     *
      * @psalm-api
+     *
+     * @return ((string|string[])[]|bool|mixed|string)[][]
+     *
      */
     public function fetchGeoJson($category = null, $getAll = false)
     {
@@ -279,7 +283,11 @@ class Location extends Base
         return $geoJson;
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     *
+     * @return Collection
+     */
     public function fetchLocationsForCompilation($authoritys = [], $locations = [])
     {
         $limit = 1000;

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -184,8 +184,10 @@ class Service extends Base
         return $serviceList;
     }
 
-    /** @psalm-api */
-    public function fetchServicesForCompilation($authoritys = [], $locations = [], $services = [])
+    /**
+     * @psalm-api
+     */
+    public function fetchServicesForCompilation($authoritys = [], $locations = [], $services = []): Collection
     {
         $limit = 1000;
 

--- a/zmsdldb/src/Zmsdldb/ElasticAccess.php
+++ b/zmsdldb/src/Zmsdldb/ElasticAccess.php
@@ -40,7 +40,7 @@ class ElasticAccess extends FileAccess
         }
     }
 
-    public function connectElasticSearch($index, $host = 'localhost', $port = '9200', $transport = 'Http')
+    public function connectElasticSearch($index, $host = 'localhost', $port = '9200', $transport = 'Http'): void
     {
         $this->connection = new \Elastica\Client(array(
                 'host' => $host,

--- a/zmsdldb/src/Zmsdldb/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Authority.php
@@ -19,7 +19,7 @@ class Authority extends Base
         }
     }
 
-    public static function create($name)
+    public static function create($name): self
     {
         $data = array(
             'name' => $name,
@@ -127,12 +127,12 @@ class Authority extends Base
         return false;
     }
 
-    public function clearLocations()
+    public function clearLocations(): void
     {
         $this['locations'] = new \BO\Zmsdldb\Collection\Locations();
     }
 
-    public function addLocation(\BO\Zmsdldb\Entity\Location $location)
+    public function addLocation(\BO\Zmsdldb\Entity\Location $location): void
     {
         $this['locations'][$location['id']] = $location;
     }

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -46,7 +46,7 @@ class Base extends \ArrayObject
         return $this['path'];
     }
 
-    public static function hasValidOffset($item, $index)
+    public static function hasValidOffset($item, string $index): bool
     {
         return (
             (is_object($item) && $item->offsetExists($index)) ||
@@ -81,7 +81,7 @@ class Base extends \ArrayObject
         return $this['type'];
     }
 
-    protected static function subcount($countable)
+    protected static function subcount($countable): int|null
     {
         if (is_array($countable) || $countable instanceof \Countable) {
             return count($countable);
@@ -114,7 +114,10 @@ class Base extends \ArrayObject
         }
     }
 
-    public static function doubleUnterlineToArray(&$array, $key, $value)
+    /**
+     * @param static $array
+     */
+    public static function doubleUnterlineToArray(&$array, string $key, $value)
     {
         if (is_null($key)) {
             return $array = $value;

--- a/zmsdldb/src/Zmsdldb/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Location.php
@@ -33,7 +33,7 @@ class Location extends Base
     /**
      * @return Bool
      */
-    public function isLocale($locale)
+    public function isLocale(string $locale)
     {
         $location = $this->getArrayCopy();
         return $location['meta']['locale'] == $locale;

--- a/zmsdldb/src/Zmsdldb/Entity/SearchResult.php
+++ b/zmsdldb/src/Zmsdldb/Entity/SearchResult.php
@@ -13,7 +13,7 @@ namespace BO\Zmsdldb\Entity;
   */
 class SearchResult extends Base
 {
-    public static function create($item)
+    public static function create($item): self
     {
         $type = explode('\\', get_class($item));
         $data = array(

--- a/zmsdldb/src/Zmsdldb/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Service.php
@@ -35,8 +35,10 @@ class Service extends Base
         return count($locationcompare) == count($locationsfound);
     }
 
-    /** @psalm-api */
-    public function hasLocation($location_csv)
+    /**
+     * @psalm-api
+     */
+    public function hasLocation($location_csv): bool
     {
         $service = $this->getArrayCopy();
         $locationcompare = explode(',', $location_csv);
@@ -48,8 +50,10 @@ class Service extends Base
         return false;
     }
 
-    /** @psalm-api */
-    public function hasAppointments($external = false)
+    /**
+     * @psalm-api
+     */
+    public function hasAppointments($external = false): bool
     {
         foreach ($this['locations'] as $location) {
             if (isset($location['appointment']['allowed'])) {
@@ -75,14 +79,16 @@ class Service extends Base
     /**
      * @return Bool
      */
-    public function isLocale($locale)
+    public function isLocale(string $locale)
     {
         $service = $this->getArrayCopy();
         return $service['meta']['locale'] == $locale;
     }
 
-    /** @psalm-api */
-    public function getLocations()
+    /**
+     * @psalm-api
+     */
+    public function getLocations(): array
     {
         $locations = [];
         foreach ($this['locations'] as $location) {

--- a/zmsdldb/src/Zmsdldb/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Topic.php
@@ -12,7 +12,7 @@ namespace BO\Zmsdldb\Entity;
  */
 class Topic extends Base
 {
-    public function getServiceIds()
+    public function getServiceIds(): array
     {
         $serviceIds = array();
         foreach ($this['relation']['services'] as $service) {
@@ -21,14 +21,18 @@ class Topic extends Base
         return $serviceIds;
     }
 
-    /** @psalm-api */
-    public function isLinked()
+    /**
+     * @psalm-api
+     */
+    public function isLinked(): bool
     {
         return ($this['relation']['navi'] || static::subcount($this['relation']['navi']));
     }
 
-    /** @psalm-api */
-    public function getServiceLocationLinkList()
+    /**
+     * @psalm-api
+     */
+    public function getServiceLocationLinkList(): \BO\Zmsdldb\Collection\Base
     {
         $list = new \BO\Zmsdldb\Collection\Base();
         $items = array(

--- a/zmsdldb/src/Zmsdldb/File/Authority.php
+++ b/zmsdldb/src/Zmsdldb/File/Authority.php
@@ -15,6 +15,9 @@ use BO\Zmsdldb\Collection\Authorities as Collection;
  */
 class Authority extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -99,6 +99,9 @@ abstract class Base
         }
     }
 
+    /**
+     * @return void
+     */
     public function loadData()
     {
         try {
@@ -109,6 +112,9 @@ abstract class Base
         }
     }
 
+    /**
+     * @return \BO\Zmsdldb\Collection\Base
+     */
     public function getItemList()
     {
         if (null === $this->itemList) {
@@ -117,13 +123,16 @@ abstract class Base
         return $this->itemList;
     }
 
-    protected function setItemList($list)
+    protected function setItemList($list): static
     {
         $this->itemList = $list;
         return $this;
     }
 
-    public function fetchId($itemId)
+    /**
+     * @return \BO\Zmsdldb\Entity\Base|false
+     */
+    public function fetchId(string $itemId)
     {
         $itemList = $this->getItemList();
 
@@ -134,12 +143,12 @@ abstract class Base
         return $itemList[$itemId];
     }
 
-    public function setAccessInstance(\BO\Zmsdldb\AbstractAccess $accessInstance)
+    public function setAccessInstance(\BO\Zmsdldb\AbstractAccess $accessInstance): void
     {
         $this->accessInstance = $accessInstance;
     }
 
-    public function access()
+    public function access(): \BO\Zmsdldb\AbstractAccess
     {
         return $this->accessInstance;
     }

--- a/zmsdldb/src/Zmsdldb/File/Borough.php
+++ b/zmsdldb/src/Zmsdldb/File/Borough.php
@@ -16,6 +16,9 @@ use BO\Zmsdldb\Collection\Boroughs as Collection;
   */
 class Borough extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {

--- a/zmsdldb/src/Zmsdldb/File/Link.php
+++ b/zmsdldb/src/Zmsdldb/File/Link.php
@@ -15,6 +15,9 @@ use BO\Zmsdldb\Collection\Links as Collection;
  */
 class Link extends Base
 {
+    /**
+     * @return void
+     */
     #[\Override]
     public function loadData()
     {
@@ -24,6 +27,9 @@ class Link extends Base
         $this->setItemList($this->parseData($data));
     }
 
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {
@@ -61,7 +67,11 @@ class Link extends Base
         return false;
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     *
+     * @return Collection
+     */
     public function readSearchResultList($query)
     {
         $list = $this->getItemList();

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -15,6 +15,9 @@ use BO\Zmsdldb\Collection\Locations as Collection;
  */
 class Location extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {

--- a/zmsdldb/src/Zmsdldb/File/Office.php
+++ b/zmsdldb/src/Zmsdldb/File/Office.php
@@ -16,6 +16,9 @@ use BO\Zmsdldb\Collection\Offices as Collection;
   */
 class Office extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -15,6 +15,9 @@ use BO\Zmsdldb\Collection\Services as Collection;
  */
 class Service extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {
@@ -50,10 +53,11 @@ class Service extends Base
     }
 
     /**
-     *
      * @return Collection
+     *
+     * @param false|string $location_csv
      */
-    public function fetchList($location_csv = false)
+    public function fetchList(string|false $location_csv = false)
     {
         #echo '<pre>' . print_r($this,1) . '</pre>';exit;
         $servicelist = $this->getItemList();
@@ -118,7 +122,7 @@ class Service extends Base
      *
      * @return Collection
      */
-    public function fetchFromCsv($service_csv)
+    public function fetchFromCsv(string $service_csv)
     {
         $servicelist = new Collection();
         foreach (explode(',', $service_csv) as $service_id) {

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -16,6 +16,9 @@ use BO\Zmsdldb\Entity\Setting as Entity;
   */
 class Setting extends Base
 {
+    /**
+     * @return Settings
+     */
     #[\Override]
     protected function parseData($data)
     {

--- a/zmsdldb/src/Zmsdldb/File/Topic.php
+++ b/zmsdldb/src/Zmsdldb/File/Topic.php
@@ -15,6 +15,9 @@ use BO\Zmsdldb\Collection\Topics as Collection;
  */
 class Topic extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     protected function parseData($data)
     {

--- a/zmsdldb/src/Zmsdldb/FileAccess.php
+++ b/zmsdldb/src/Zmsdldb/FileAccess.php
@@ -45,8 +45,9 @@ class FileAccess extends AbstractAccess
      * Parameters for json files are deprecated, try using loadFromPath() instead
      *
      * @return self
+     *
      */
-    public function loadFromPath($path)
+    public function loadFromPath(string $path)
     {
         if (!is_dir($path)) {
             throw new Exception("Could not read directory $path");
@@ -63,41 +64,51 @@ class FileAccess extends AbstractAccess
         return $this;
     }
 
-    /** @psalm-api */
-    public function loadLocationsFromPathByLocale($path, $locale)
+    /**
+     * @psalm-api
+     */
+    public function loadLocationsFromPathByLocale($path, $locale): void
     {
         $this->loadLocations($path . DIRECTORY_SEPARATOR . 'locations_' . $locale . '.json', $locale);
     }
 
-    /** @psalm-api */
-    public function loadServicesFromPathByLocale($path, $locale)
+    /**
+     * @psalm-api
+     */
+    public function loadServicesFromPathByLocale($path, $locale): void
     {
         $this->loadServices($path . DIRECTORY_SEPARATOR . 'services_' . $locale . '.json', $locale);
     }
 
-    /** @psalm-api */
-    public function loadTopicsFromPathByLocale($path, $locale)
+    /**
+     * @psalm-api
+     */
+    public function loadTopicsFromPathByLocale($path, $locale): void
     {
         $this->loadTopics($path . DIRECTORY_SEPARATOR . 'topic_' . $locale . '.json', $locale);
     }
 
-    /** @psalm-api */
-    public function loadAuthoritiesFromPathByLocale($path, $locale)
+    /**
+     * @psalm-api
+     */
+    public function loadAuthoritiesFromPathByLocale($path, $locale): void
     {
         $this->loadAuthorities($path . DIRECTORY_SEPARATOR . 'authority_' . $locale . '.json', $locale);
     }
 
-    /** @psalm-api */
-    public function loadSettingsFromPath($path)
+    /**
+     * @psalm-api
+     */
+    public function loadSettingsFromPath($path): void
     {
         $this->loadSettings($path . DIRECTORY_SEPARATOR . 'settings.json');
     }
 
     /**
-     *
      * @return self
+     *
      */
-    public function loadLocations($locationJson, $locale = 'de')
+    public function loadLocations(string $locationJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Location'] = new File\Location($locationJson, $locale);
         $this->accessInstance[$locale]['Location']->setAccessInstance($this);
@@ -105,10 +116,10 @@ class FileAccess extends AbstractAccess
     }
 
     /**
-     *
      * @return self
+     *
      */
-    public function loadServices($serviceJson, $locale = 'de')
+    public function loadServices(string $serviceJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Service'] = new File\Service($serviceJson, $locale);
         $this->accessInstance[$locale]['Service']->setAccessInstance($this);
@@ -116,10 +127,10 @@ class FileAccess extends AbstractAccess
     }
 
     /**
-     *
      * @return self
+     *
      */
-    public function loadTopics($topicJson, $locale = 'de')
+    public function loadTopics(string $topicJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Topic'] = new File\Topic($topicJson, $locale);
         $this->accessInstance[$locale]['Topic']->setAccessInstance($this);
@@ -132,7 +143,7 @@ class FileAccess extends AbstractAccess
      *
      * @return self
      */
-    public function loadSettings($settingsJson)
+    public function loadSettings(string $settingsJson)
     {
         $this->accessInstance['de']['Setting'] = new File\Setting($settingsJson);
         $this->accessInstance['de']['Setting']->setAccessInstance($this);
@@ -144,10 +155,10 @@ class FileAccess extends AbstractAccess
     }
 
     /**
-     *
      * @return self
+     *
      */
-    public function loadAuthorities($authorityJson, $locale = 'de')
+    public function loadAuthorities(string $authorityJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Authority'] = new File\Authority($authorityJson, $locale);
         $this->accessInstance[$locale]['Authority']->setAccessInstance($this);

--- a/zmsdldb/src/Zmsdldb/Helper/DateTime.php
+++ b/zmsdldb/src/Zmsdldb/Helper/DateTime.php
@@ -4,12 +4,15 @@ namespace BO\Zmsdldb\Helper;
 
 class DateTime extends \DateTimeImmutable
 {
+    /**
+     * @return false|string
+     */
     public static function getFormatedDates(
-        $timestamp,
-        $pattern = 'MMMM',
+        \DateTimeImmutable $timestamp,
+        string $pattern = 'MMMM',
         $locale = 'de_DE',
         $timezone = 'Europe/Berlin'
-    ) {
+    ): string|false {
         $dateFormatter = new \IntlDateFormatter(
             $locale,
             \IntlDateFormatter::MEDIUM,

--- a/zmsdldb/src/Zmsdldb/Helper/Sorter.php
+++ b/zmsdldb/src/Zmsdldb/Helper/Sorter.php
@@ -10,7 +10,7 @@ class Sorter
     /**
      * @todo check against ISO definition
      */
-    public static function toSortableString($string)
+    public static function toSortableString($string): string
     {
         $string = strtr($string, array(
             'Ä' => 'Ae',

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -45,8 +45,10 @@ abstract class Base implements Options
         $this->options = $options;
     }
 
-    /** @psalm-api */
-    public function setLocaleList(array $localeList = ['de', 'en'])
+    /**
+     * @psalm-api
+     */
+    public function setLocaleList(array $localeList = ['de', 'en']): void
     {
         $this->localeList = $localeList;
     }
@@ -111,7 +113,11 @@ abstract class Base implements Options
         }
     }
 
-    /** @psalm-api */
+    /**
+     * @psalm-api
+     *
+     * @return void
+     */
     public function clearDatabase()
     {
         try {
@@ -221,10 +227,16 @@ abstract class Base implements Options
         }
     }
 
+    /**
+     * @return void
+     */
     public function preImport()
     {
     }
 
+    /**
+     * @return void
+     */
     public function postImport()
     {
     }

--- a/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
@@ -11,7 +11,7 @@ trait OptionsTrait
         return $this->options & $optionFlag;
     }
 
-    protected function setOptions(int $options = 0)
+    protected function setOptions(int $options = 0): void
     {
         $this->options = $options;
     }

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -19,26 +19,32 @@ class Timer
         }
     }
 
-    public function start()
+    public function start(): void
     {
         $this->start = Timer::getMicroTime();
     }
 
-    /** @psalm-api */
-    public function stop()
+    /**
+     * @psalm-api
+     */
+    public function stop(): void
     {
         $this->stop = Timer::getMicroTime();
     }
 
-    /** @psalm-api */
-    public function pause()
+    /**
+     * @psalm-api
+     */
+    public function pause(): void
     {
         $this->pause = Timer::getMicroTime();
         $this->elapsed += ($this->pause - $this->start);
     }
 
-    /** @psalm-api */
-    public function resume()
+    /**
+     * @psalm-api
+     */
+    public function resume(): void
     {
         $this->start = Timer::getMicroTime();
     }
@@ -57,13 +63,13 @@ class Timer
         return $this->timeToString();
     }
 
-    protected static function getMicroTime()
+    protected static function getMicroTime(): float
     {
         list($usec, $sec) = explode(' ', microtime());
         return ((float) $usec + (float) $sec);
     }
 
-    protected function timeToString()
+    protected function timeToString(): string
     {
         $seconds = ($this->stop - $this->start) + $this->elapsed;
         $seconds = Timer::roundMicroTime($seconds);
@@ -73,7 +79,7 @@ class Timer
         return $hours . "h:" . $minutes . "m:" . $seconds . "s";
     }
 
-    protected static function roundMicroTime($microTime)
+    protected static function roundMicroTime($microTime): float
     {
         return round($microTime, 4, PHP_ROUND_HALF_UP);
     }

--- a/zmsdldb/src/Zmsdldb/MySQL/Authority.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Authority.php
@@ -13,8 +13,6 @@ use BO\Zmsdldb\Elastic\Authority as Base;
 use BO\Zmsdldb\Entity\Authority as AuthorityEntity;
 use BO\Zmsdldb\Entity\Location as LocationEntity;
 
-/**
- */
 /** @psalm-api */
 class Authority extends Base
 {
@@ -24,7 +22,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(array $servicelist = []): Collection
+    public function fetchList($servicelist = []): Collection
     {
         try {
             $authorityList = new Collection();
@@ -147,7 +145,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function readListByOfficePath(string $officepath): Collection
+    public function readListByOfficePath($officepath): Collection
     {
         $authorityList = new Collection();
 

--- a/zmsdldb/src/Zmsdldb/MySQL/Link.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Link.php
@@ -10,13 +10,11 @@ namespace BO\Zmsdldb\MySQL;
 use BO\Zmsdldb\MySQL\Collection\Links as Collection;
 use BO\Zmsdldb\Elastic\Link as Base;
 
-/**
- */
 /** @psalm-api */
 class Link extends Base
 {
     #[\Override]
-    public function readSearchResultList(string $query): Collection
+    public function readSearchResultList($query): Collection
     {
         try {
             #$query = '+' . implode(' +', explode(' ', $query));

--- a/zmsdldb/src/Zmsdldb/MySQL/Location.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Location.php
@@ -41,7 +41,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchList(string|false $service_csv = false, bool $mixLanguages = false): Collection
+    public function fetchList($service_csv = false, $mixLanguages = false): Collection
     {
         # COALESCE(l2.data_json, l.data_json) AS data_json
         # IF(l2.id, l2.data_json, l.data_json) AS data_json
@@ -94,7 +94,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchListByOffice(string $office, bool $mixLanguages = false): Collection
+    public function fetchListByOffice($office, $mixLanguages = false): Collection
     {
         try {
             $sqlArgs = [$this->locale];
@@ -141,7 +141,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchFromCsv(string $location_csv, bool $mixLanguages = false): Collection
+    public function fetchFromCsv($location_csv, $mixLanguages = false): Collection
     {
         try {
             $sqlArgs = [$this->locale];
@@ -183,7 +183,7 @@ class Location extends Base
     }
 
     #[\Override]
-    protected function fetchGeoJsonLocations(?string $category, bool $getAll): Collection
+    protected function fetchGeoJsonLocations($category, $getAll): Collection
     {
         try {
             $sqlArgs = [$this->locale, $this->locale, $this->locale];
@@ -242,7 +242,7 @@ class Location extends Base
      * @todo Refactoring required, functions in this class should return entities, not JSON data
      */
     #[\Override]
-    public function fetchGeoJson(?string $category = null, bool $getAll = false): array
+    public function fetchGeoJson($category = null, $getAll = false): array
     {
         $locationList = $this->fetchGeoJsonLocations($category, $getAll);
         $geoJson = [];
@@ -273,7 +273,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function readSearchResultList(string $query, ?string $service_csv = null): Collection
+    public function readSearchResultList($query, $service_csv = null): Collection
     {
         try {
             #$query = '+' . implode(' +', explode(' ', $query));
@@ -313,7 +313,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchLocationsForCompilation(array $authoritys = [], array $locations = []): Collection
+    public function fetchLocationsForCompilation($authoritys = [], $locations = []): Collection
     {
         try {
             $sqlArgs = [$this->locale];

--- a/zmsdldb/src/Zmsdldb/MySQL/Setting.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Setting.php
@@ -16,7 +16,7 @@ use BO\Zmsdldb\File\Setting as Base;
 class Setting extends Base
 {
     #[\Override]
-    public function fetchName(string $name): ?string
+    public function fetchName($name): ?string
     {
         try {
             $sql = 'SELECT value FROM setting WHERE name = ?';

--- a/zmsdldb/src/Zmsdldb/MySQL/Topic.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Topic.php
@@ -11,9 +11,6 @@ use BO\Zmsdldb\MySQL\Entity\Topic as Entity;
 use BO\Zmsdldb\MySQL\Collection\Topics as Collection;
 use BO\Zmsdldb\Elastic\Topic as Base;
 
-/**
-  *
-  */
 /** @psalm-api */
 class Topic extends Base
 {
@@ -46,7 +43,7 @@ class Topic extends Base
      * @return Entity|false
      */
     #[\Override]
-    public function fetchPath(string $topic_path): Entity|false
+    public function fetchPath($topic_path): Entity|false
     {
         try {
             $sqlArgs = [$this->locale, $topic_path];
@@ -92,7 +89,7 @@ class Topic extends Base
     }
 
     #[\Override]
-    public function readSearchResultList(string $querystring): Collection
+    public function readSearchResultList($querystring): Collection
     {
         try {
             #$querystring = '+' . implode(' +', explode(' ', $querystring));

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -70,6 +70,9 @@ abstract class PDOAccess extends AbstractAccess
         }
     }
 
+    /**
+     * @return void
+     */
     protected function postConnect()
     {
     }
@@ -113,8 +116,7 @@ abstract class PDOAccess extends AbstractAccess
     /**
      * parameters see https://www.php.net/manual/de/pdo.exec.php
      */
-
-    public function exec(...$args)
+    public function exec(string ...$args)
     {
         try {
             return $this->pdo->exec(...$args);
@@ -126,8 +128,7 @@ abstract class PDOAccess extends AbstractAccess
     /**
      * parameters see https://www.php.net/manual/de/pdo.prepare.php
      */
-
-    public function prepare(...$args)
+    public function prepare(string ...$args)
     {
         try {
             return $this->pdo->prepare(...$args);

--- a/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
+++ b/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
@@ -30,7 +30,12 @@ class Coordinates
         return $coordinates->getLatLon($plz);
     }
 
-    public function loadData($file = null)
+    /**
+     * @param null|string $file
+     *
+     * @return void
+     */
+    public function loadData(string|null $file = null)
     {
         if (null === $file) {
             $file = __DIR__ . DIRECTORY_SEPARATOR . 'plz_geodb.json';

--- a/zmsdldb/src/Zmsdldb/SQLiteAccess.php
+++ b/zmsdldb/src/Zmsdldb/SQLiteAccess.php
@@ -7,9 +7,6 @@
 
 namespace BO\Zmsdldb;
 
-/**
- *
- */
 class SQLiteAccess extends PDOAccess
 {
     const string DEFAULT_DATABASE_NAME = 'dldb_frontend_dev';
@@ -33,6 +30,9 @@ class SQLiteAccess extends PDOAccess
         }
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     protected function postConnect()
     {

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -679,6 +679,8 @@ class Munich
 
     /**
      * Calculate greatest common divisor for slot times
+     *
+     * @param never $a
      */
     protected function getSlotTime($a, $b): int
     {

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -23,7 +23,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         $this->container = $container;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'dldb';
     }
@@ -60,12 +60,16 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         );
     }
 
-    public function dump($item)
+    public function dump($item): string
     {
         return '<pre>' . print_r($item, 1) . '</pre>';
     }
 
-    public function currentRoute($lang = null)
+    /**
+     * @return (array|mixed|string)[]
+     *
+     */
+    public function currentRoute($lang = null): array
     {
         if ($this->container->has('currentRoute')) {
             $routeParams = $this->container->get('currentRouteParams');
@@ -92,7 +96,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
     }
 
 
-    public function getD115Enabeld()
+    public function getD115Enabeld(): bool
     {
         $settingsRepository = \App::$repository->fromSetting();
         $active = (bool)($settingsRepository->fetchName('d115.active') ?? true);
@@ -117,7 +121,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $text;
     }
 
-    public function getBobbiChatButtonEnabeld()
+    public function getBobbiChatButtonEnabeld(): bool
     {
         $settingsRepository = \App::$repository->fromSetting();
         $buttonEnabled = (bool)($settingsRepository->fetchName('frontend.bobbi.chatbutton.enabled') ?? false);
@@ -125,17 +129,17 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $buttonEnabled;
     }
 
-    public function getOSMAccessToken()
+    public function getOSMAccessToken(): string
     {
         return \App::OSM_ACCESS_TOKEN;
     }
 
-    public function getOSMOptions()
+    public function getOSMOptions(): string
     {
         return 'gestureHandling: ' . \App::OSM_GESTURE_HANDLING;
     }
 
-    public function formatPhoneNumber($phoneNumber)
+    public function formatPhoneNumber($phoneNumber): string|null
     {
         preg_match_all('/(^\+)?[\d]+/', $phoneNumber, $matches);
         $number = implode($matches[0]);
@@ -143,7 +147,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $phonenumber;
     }
 
-    public function convertOpeningTimes($name)
+    public function convertOpeningTimes($name): string
     {
         $days = array(
             'monday' => 'Montag',
@@ -158,19 +162,26 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $days[$name];
     }
 
-    public function dateToTS($datetime)
+    /**
+     * @return false|int
+     */
+    public function dateToTS($datetime): int|false
     {
         $timestamp = ($datetime === (int)$datetime) ? $datetime : strtotime($datetime);
         return $timestamp;
     }
 
-    public function tsToDate($timestamp)
+    public function tsToDate($timestamp): string
     {
         $date =  date('Y-m-d', $timestamp);
         return $date;
     }
 
-    public function formatDateTime($dateString)
+    /**
+     * @return (false|float|int|mixed|string)[]
+     *
+     */
+    public function formatDateTime($dateString): array
     {
         $dateTime = new \DateTimeImmutable($dateString, new \DateTimezone('Europe/Berlin'));
         $formatDate['date']     = Helper\DateTime::getFormatedDates($dateTime, "EE, dd. MMMM yyyy");
@@ -192,7 +203,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $formatDate;
     }
 
-    public function kindOfPayment($code)
+    public function kindOfPayment($code): string
     {
         $result = '';
         if ($code == 0) {
@@ -209,7 +220,11 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $result;
     }
 
-    public function azPrefixList($list, $property)
+    /**
+     * @return (array|mixed)[][]
+     *
+     */
+    public function azPrefixList($list, $property): array
     {
         $azList = array();
         foreach ((array)$list as $item) {
@@ -229,7 +244,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $azList;
     }
 
-    protected static function sortFirstChar($string)
+    protected static function sortFirstChar($string): string
     {
         $firstChar = mb_substr($string, 0, 1);
         $firstChar = mb_strtoupper($firstChar);
@@ -237,7 +252,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $firstChar;
     }
 
-    protected static function sortByName($left, $right)
+    protected static function sortByName($left, $right): int
     {
         return strcmp(
             self::toSortableString(strtolower($left['name'])),
@@ -245,7 +260,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         );
     }
 
-    protected static function toSortableString($string)
+    protected static function toSortableString(string $string): string
     {
         $string = strtr($string, array(
             'Ä' => 'Ae',
@@ -260,7 +275,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $string;
     }
 
-    public function csvProperty($list, $property)
+    public function csvProperty($list, $property): string
     {
         $propertylist = array();
         foreach ($list as $item) {
@@ -271,7 +286,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return implode(',', array_unique($propertylist));
     }
 
-    public function csvAppointmentLocations($list, $service_id = '')
+    public function csvAppointmentLocations($list, $service_id = ''): string
     {
         $propertylist = array();
         foreach ($list as $item) {

--- a/zmsentities/src/Zmsentities/Apiclient.php
+++ b/zmsentities/src/Zmsentities/Apiclient.php
@@ -8,6 +8,10 @@ class Apiclient extends Schema\Entity
 
     public static $schema = "apiclient.json";
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {

--- a/zmsentities/src/Zmsentities/Apikey.php
+++ b/zmsentities/src/Zmsentities/Apikey.php
@@ -8,6 +8,10 @@ class Apikey extends Schema\Entity
 
     public static $schema = "apikey.json";
 
+    /**
+     * @return Apiclient[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -16,7 +20,7 @@ class Apikey extends Schema\Entity
         ];
     }
 
-    public function setApiClient(Apiclient $apiClient)
+    public function setApiClient(Apiclient $apiClient): void
     {
         $this['apiclient'] = $apiClient;
     }
@@ -26,14 +30,18 @@ class Apikey extends Schema\Entity
         return $this['apiclient'];
     }
 
-    public function getQuotaPositionByRoute($route)
+    /**
+     * @return false|int
+     *
+     */
+    public function getQuotaPositionByRoute($route): int|false
     {
         return (isset($this->quota) && is_array($this->quota)) ?
             array_search($route, array_column($this->quota, 'route'))
             : false;
     }
 
-    public function addQuota($route, $period)
+    public function addQuota($route, $period): static
     {
         $this->quota[] = [
             'route' => $route,
@@ -43,7 +51,7 @@ class Apikey extends Schema\Entity
         return $this;
     }
 
-    public function updateQuota($position)
+    public function updateQuota($position): static
     {
         $this->quota[$position]['requests']++;
         return $this;

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -10,6 +10,10 @@ class Appointment extends Schema\Entity
 
     public static $schema = "appointment.json";
 
+    /**
+     * @return (Availability|Scope|int)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -30,13 +34,13 @@ class Appointment extends Schema\Entity
         );
     }
 
-    public function toTime($lang = 'de')
+    public function toTime($lang = 'de'): string
     {
         $suffix = ($lang == 'en') ? ' o\'clock' : ' Uhr';
         return date('H:i', $this->date) . $suffix;
     }
 
-    public function hasTime()
+    public function hasTime(): bool
     {
         if ($this->date == 0) {
             return false;
@@ -47,40 +51,39 @@ class Appointment extends Schema\Entity
 
     /**
      * Modify time for appointment
-     *
      */
-    public function setTime($timeString)
+    public function setTime($timeString): static
     {
         $dateTime = $this->toDateTime();
         $this->date = $dateTime->modify($timeString)->getTimestamp();
         return $this;
     }
 
-    public function setDateTime(\DateTimeInterface $dateTime)
+    public function setDateTime(\DateTimeInterface $dateTime): static
     {
         $this->date = $dateTime->getTimestamp();
         return $this;
     }
 
-    public function addDate($date)
+    public function addDate(int $date): static
     {
         $this->date = $date;
         return $this;
     }
 
-    public function addScope($scopeId)
+    public function addScope($scopeId): static
     {
         $this->getScope()->id = $scopeId;
         return $this;
     }
 
-    public function getScope()
+    public function getScope(): Scope
     {
         $this->scope = ($this->toProperty()->scope->isAvailable()) ? new Scope($this['scope']) : new Scope();
         return $this->scope;
     }
 
-    public function addSlotCount($slotCount = null)
+    public function addSlotCount(int|null $slotCount = null): static
     {
         if ($slotCount) {
             $this->slotCount = $slotCount;
@@ -96,7 +99,7 @@ class Appointment extends Schema\Entity
         return $this->slotCount;
     }
 
-    public function getAvailability()
+    public function getAvailability(): Availability
     {
         $data = array();
         if (Property::__keyExists('availability', $this)) {
@@ -105,7 +108,7 @@ class Appointment extends Schema\Entity
         return new Availability($data);
     }
 
-    public function toDateTime($timezone = 'Europe/Berlin')
+    public function toDateTime($timezone = 'Europe/Berlin'): \DateTimeImmutable
     {
         $date = (new \DateTimeImmutable())->setTimestamp($this->date);
         //$date = \DateTimeImmutable::createFromFormat("U", $this->date);
@@ -136,7 +139,7 @@ class Appointment extends Schema\Entity
         return $time->modify('+' . ($slotTimeInMinutes * $this->slotCount) . ' minutes');
     }
 
-    public function setDateByString($dateString, $format = 'Y-m-d H:i')
+    public function setDateByString(string $dateString, $format = 'Y-m-d H:i'): static
     {
         $appointmentDateTime = \DateTimeImmutable::createFromFormat($format, $dateString);
         if ($appointmentDateTime) {
@@ -151,9 +154,8 @@ class Appointment extends Schema\Entity
 
     /**
      * Does two appointments match, the matching appointment might have a lower slot count
-     *
      */
-    public function isMatching(self $appointment)
+    public function isMatching(self $appointment): bool
     {
         if (
             $appointment['scope']['id'] == $this['scope']['id']

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -45,6 +45,9 @@ class Availability extends Schema\Entity
 
     /**
      * Set Default values
+     *
+     * @return (((int|string)[]|int|string)[]|int|string|true)[]
+     *
      */
     #[\Override]
     public function getDefaults()
@@ -107,7 +110,7 @@ class Availability extends Schema\Entity
         return true;
     }
 
-    public function hasBookableDates(\DateTimeInterface $now)
+    public function hasBookableDates(\DateTimeInterface $now): bool
     {
         if ($this->workstationCount['intern'] <= 0) {
             return false;
@@ -183,7 +186,7 @@ class Availability extends Schema\Entity
         return (!$this->isOpenedOnDate($dateTime, $type) || !$this->hasTime($dateTime)) ? false : true;
     }
 
-    public function hasWeekDay(\DateTimeInterface $dateTime)
+    public function hasWeekDay(\DateTimeInterface $dateTime): bool
     {
         $weekDayName = self::$weekdayNameList[$dateTime->format('w')];
         if (!$this['weekday'][$weekDayName]) {
@@ -193,7 +196,7 @@ class Availability extends Schema\Entity
         return true;
     }
 
-    public function hasAppointment(Appointment $appointment)
+    public function hasAppointment(Appointment $appointment): bool
     {
         $dateTime = $appointment->toDateTime();
         $isOpenedStart = $this->isOpened($dateTime, false);
@@ -721,9 +724,8 @@ class Availability extends Schema\Entity
 
     /**
      * Check of a different availability has the same opening configuration
-     *
      */
-    public function isMatchOf(Availability $availability)
+    public function isMatchOf(Availability $availability): bool
     {
         return ($this->type != $availability->type
             || $this->startTime != $availability->startTime
@@ -742,7 +744,7 @@ class Availability extends Schema\Entity
         ) ? false : true;
     }
 
-    public function hasSharedWeekdayWith(Availability $availability)
+    public function hasSharedWeekdayWith(Availability $availability): bool
     {
         return ($this->type == $availability->type
             && (bool)$this->weekday['monday'] != (bool)$availability->weekday['monday']
@@ -941,7 +943,7 @@ class Availability extends Schema\Entity
         return $availability;
     }
 
-    public function withScope(\BO\Zmsentities\Scope $scope)
+    public function withScope(\BO\Zmsentities\Scope $scope): static
     {
         $availability = clone $this;
         $availability->scope = $scope;
@@ -1001,6 +1003,7 @@ class Availability extends Schema\Entity
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData(array $keepArray = [])

--- a/zmsentities/src/Zmsentities/Calendar.php
+++ b/zmsentities/src/Zmsentities/Calendar.php
@@ -14,6 +14,10 @@ class Calendar extends Schema\Entity
 
     public static $schema = "calendar.json";
 
+    /**
+     * @return (Collection\DayList|Day|array|null)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -28,7 +32,7 @@ class Calendar extends Schema\Entity
         ];
     }
 
-    public function addDates($date, \DateTimeInterface $now, $timeZone)
+    public function addDates($date, \DateTimeInterface $now, $timeZone): static
     {
         $validDate = \BO\Mellon\Validator::value($date)->isDate();
         $date = (! $validDate->hasFailed()) ? $validDate->getValue() : $now->format('U');
@@ -210,7 +214,7 @@ class Calendar extends Schema\Entity
         return $this->getDayList()->getDayByDateTime($datetime);
     }
 
-    public function getDateTimeFromDate($date)
+    public function getDateTimeFromDate(array $date)
     {
         $day = (isset($date['day'])) ? $date['day'] : 1;
         $date = Helper\DateTime::createFromFormat('Y-m-d', $date['year'] . '-' . $date['month'] . '-' . $day);
@@ -219,9 +223,8 @@ class Calendar extends Schema\Entity
 
     /**
      * Simple quick check, if first and last day are defined
-     *
      */
-    public function hasFirstAndLastDay()
+    public function hasFirstAndLastDay(): bool
     {
         if (!$this->toProperty()->firstDay->day->get()) {
             return false;
@@ -268,7 +271,7 @@ class Calendar extends Schema\Entity
         return $dateTime->modify('23:59:59');
     }
 
-    public function setLastDayTime($date)
+    public function setLastDayTime($date): static
     {
         $day = new Day();
         $day->setDateTime($date);
@@ -276,7 +279,7 @@ class Calendar extends Schema\Entity
         return $this;
     }
 
-    public function setFirstDayTime($date)
+    public function setFirstDayTime($date): static
     {
         $day = new Day();
         $day->setDateTime($date);
@@ -287,10 +290,8 @@ class Calendar extends Schema\Entity
     /**
      * Returns a list of contained month given by firstDay and lastDay
      * The return value is a month entity object for the first day of the month
-     *
-     * @return [\DateTime]
      */
-    public function getMonthList()
+    public function getMonthList(): Collection\MonthList
     {
         $firstDay = $this->getFirstDay()->modify('first day of this month')->modify('00:00:00');
         $lastDay = $this->getLastDay()->modify('last day of this month')->modify('23:59:59');
@@ -311,6 +312,7 @@ class Calendar extends Schema\Entity
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData()
@@ -338,7 +340,7 @@ class Calendar extends Schema\Entity
         return $entity;
     }
 
-    public function withFilledEmptyDays()
+    public function withFilledEmptyDays(): static
     {
         $entity = clone $this;
 

--- a/zmsentities/src/Zmsentities/Calldisplay.php
+++ b/zmsentities/src/Zmsentities/Calldisplay.php
@@ -18,6 +18,10 @@ class Calldisplay extends Schema\Entity
 
     public static $schema = "calldisplay.json";
 
+    /**
+     * @return (Collection\ClusterList|Collection\ScopeList|Organisation|int)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -29,7 +33,7 @@ class Calldisplay extends Schema\Entity
         ];
     }
 
-    public function withResolvedCollections($input)
+    public function withResolvedCollections($input): static
     {
         $input =  (is_object($input)) ? $input->getArrayCopy() : $input;
         if (Property::__keyExists('scopelist', $input)) {
@@ -41,17 +45,17 @@ class Calldisplay extends Schema\Entity
         return $this;
     }
 
-    public function hasScopeList()
+    public function hasScopeList(): bool
     {
         return (0 < $this->getScopeList()->count());
     }
 
-    public function hasClusterList()
+    public function hasClusterList(): bool
     {
         return (0 < $this->getClusterList()->count());
     }
 
-    public function setServerTime($timestamp)
+    public function setServerTime($timestamp): static
     {
         $this->serverTime = $timestamp;
         return $this;
@@ -73,7 +77,7 @@ class Calldisplay extends Schema\Entity
         return $scopeList;
     }
 
-    public function getScopeList()
+    public function getScopeList(): Collection\ScopeList
     {
         if (!$this->scopes instanceof Collection\ScopeList) {
             $scopeList = new Collection\ScopeList();
@@ -85,7 +89,7 @@ class Calldisplay extends Schema\Entity
         return $this->scopes;
     }
 
-    public function getClusterList()
+    public function getClusterList(): Collection\ClusterList
     {
         if (!$this->clusters instanceof Collection\ClusterList) {
             $clusterList = new Collection\ClusterList();
@@ -97,7 +101,7 @@ class Calldisplay extends Schema\Entity
         return $this->clusters;
     }
 
-    public function getImageName()
+    public function getImageName(): string
     {
         $name = '';
         if (1 == $this->getScopeList()->count()) {
@@ -108,7 +112,7 @@ class Calldisplay extends Schema\Entity
         return $name;
     }
 
-    public function withOutClusterDuplicates()
+    public function withOutClusterDuplicates(): self
     {
         $calldisplay = new self($this);
         if ($calldisplay->hasClusterList() && $calldisplay->hasScopeList()) {
@@ -133,7 +137,7 @@ class Calldisplay extends Schema\Entity
         return $calldisplay;
     }
 
-    protected function getScopeListFromCsv($scopeIds = '')
+    protected function getScopeListFromCsv($scopeIds = ''): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         $scopeIds = explode(',', $scopeIds);
@@ -146,7 +150,7 @@ class Calldisplay extends Schema\Entity
         return $scopeList;
     }
 
-    protected function getClusterListFromCsv($clusterIds = '')
+    protected function getClusterListFromCsv($clusterIds = ''): Collection\ClusterList
     {
         $clusterList = new Collection\ClusterList();
         $clusterIds = explode(',', $clusterIds);

--- a/zmsentities/src/Zmsentities/Client.php
+++ b/zmsentities/src/Zmsentities/Client.php
@@ -6,6 +6,10 @@ class Client extends Schema\Entity
 {
     public static $schema = "client.json";
 
+    /**
+     * @return (false|int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -18,17 +22,17 @@ class Client extends Schema\Entity
         ];
     }
 
-    public function hasFamilyName()
+    public function hasFamilyName(): bool
     {
         return ($this->toProperty()->familyName->get()) ? true : false;
     }
 
-    public function hasEmail()
+    public function hasEmail(): bool
     {
         return ($this->toProperty()->email->get()) ? true : false;
     }
 
-    public function hasTelephone()
+    public function hasTelephone(): bool
     {
         return ($this->toProperty()->telephone->get()) ? true : false;
     }
@@ -38,7 +42,7 @@ class Client extends Schema\Entity
         return $this->toProperty()->emailSendCount->get();
     }
 
-    public function hasSurveyAccepted()
+    public function hasSurveyAccepted(): bool
     {
         return (1 == $this->toProperty()->surveyAccepted->get()) ? true : false;
     }

--- a/zmsentities/src/Zmsentities/Closure.php
+++ b/zmsentities/src/Zmsentities/Closure.php
@@ -8,6 +8,10 @@ class Closure extends Schema\Entity
 
     public static $schema = "closure.json";
 
+    /**
+     * @return int[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -17,7 +21,7 @@ class Closure extends Schema\Entity
         ];
     }
 
-    public function setTimestampFromDateformat($fromFormat = 'd.m.Y')
+    public function setTimestampFromDateformat($fromFormat = 'd.m.Y'): static
     {
         $dateTime = \DateTimeImmutable::createFromFormat($fromFormat, $this->date, new \DateTimeZone('UTC'));
         if ($dateTime) {
@@ -26,7 +30,7 @@ class Closure extends Schema\Entity
         return $this;
     }
 
-    public function getDateTime()
+    public function getDateTime(): Helper\DateTime
     {
         return (new \BO\Zmsentities\Helper\DateTime($this->year . '-' . $this->month . '-' . $this->day));
     }
@@ -44,7 +48,7 @@ class Closure extends Schema\Entity
         return ($dateTime->getTimestamp() < $this->lastChange);
     }
 
-    public function isAffectingAvailability(Availability $availabiliy, \DateTimeInterface $now)
+    public function isAffectingAvailability(Availability $availabiliy, \DateTimeInterface $now): bool
     {
         return $availabiliy->isBookable($this->getDateTime(), $now);
     }

--- a/zmsentities/src/Zmsentities/Cluster.php
+++ b/zmsentities/src/Zmsentities/Cluster.php
@@ -8,6 +8,10 @@ class Cluster extends Schema\Entity implements Useraccount\AccessInterface
 
     public static $schema = "cluster.json";
 
+    /**
+     * @return Collection\ScopeList[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -34,6 +38,9 @@ class Cluster extends Schema\Entity implements Useraccount\AccessInterface
         return $workstationCount;
     }
 
+    /**
+     * @return bool
+     */
     public function hasAccess(Useraccount $useraccount)
     {
         if ($useraccount->hasPermissions(['superuser'])) {

--- a/zmsentities/src/Zmsentities/Collection/AppointmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/AppointmentList.php
@@ -11,7 +11,7 @@ class AppointmentList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Appointment';
 
-    public function getByDate($date)
+    public function getByDate($date): Appointment|false
     {
         foreach ($this as $item) {
             if ($item['date'] == $date) {
@@ -21,7 +21,7 @@ class AppointmentList extends Base
         return false;
     }
 
-    public function hasDateScope($date, $scopeId)
+    public function hasDateScope($date, $scopeId): bool
     {
         $item = $this->getByDate($date);
         if ($item && $item->toProperty()->scope->id->get() == $scopeId) {
@@ -30,7 +30,7 @@ class AppointmentList extends Base
         return false;
     }
 
-    public function hasAppointment(\BO\Zmsentities\Appointment $appointment)
+    public function hasAppointment(\BO\Zmsentities\Appointment $appointment): bool
     {
         foreach ($this as $appointmentItem) {
             if ($appointmentItem->isMatching($appointment)) {

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -27,7 +27,7 @@ class AvailabilityList extends Base
         return $max;
     }
 
-    public function withCalculatedSlots()
+    public function withCalculatedSlots(): static
     {
         $list = clone $this;
         foreach ($list as $key => $availability) {
@@ -36,7 +36,7 @@ class AvailabilityList extends Base
         return $list;
     }
 
-    public function withType($type)
+    public function withType(string $type): static
     {
         $collection = new static();
         foreach ($this as $availability) {
@@ -47,7 +47,7 @@ class AvailabilityList extends Base
         return $collection;
     }
 
-    public function withOutDoubles()
+    public function withOutDoubles(): static
     {
         $collection = new static();
         foreach ($this as $availability) {
@@ -58,7 +58,7 @@ class AvailabilityList extends Base
         return $collection;
     }
 
-    public function hasMatchOf(Availability $availability)
+    public function hasMatchOf(Availability $availability): Availability|false
     {
         foreach ($this as $item) {
             if ($item->isMatchOf($availability)) {
@@ -68,7 +68,7 @@ class AvailabilityList extends Base
         return false;
     }
 
-    public function withDateTime(\DateTimeInterface $dateTime)
+    public function withDateTime(\DateTimeInterface $dateTime): self
     {
         $list = new self();
         foreach ($this as $availability) {
@@ -106,7 +106,7 @@ class AvailabilityList extends Base
     /*
      * is opened on a day -> not specified by a time
      */
-    public function isOpenedByDate(\DateTimeInterface $dateTime, $type = false)
+    public function isOpenedByDate(\DateTimeInterface $dateTime, $type = false): bool
     {
         foreach ($this as $availability) {
             if ($availability->isOpenedOnDate($dateTime, $type)) {
@@ -119,7 +119,7 @@ class AvailabilityList extends Base
     /*
      * is opened on a day with specified time
      */
-    public function isOpened(\DateTimeInterface $dateTime, $type = "openinghours")
+    public function isOpened(\DateTimeInterface $dateTime, $type = "openinghours"): bool
     {
         foreach ($this as $availability) {
             if ($availability->isOpened($dateTime, $type)) {
@@ -129,7 +129,7 @@ class AvailabilityList extends Base
         return false;
     }
 
-    public function hasAppointment(\BO\Zmsentities\Appointment $appointment)
+    public function hasAppointment(\BO\Zmsentities\Appointment $appointment): bool
     {
         foreach ($this as $availability) {
             if ($availability->hasAppointment($appointment)) {
@@ -139,7 +139,7 @@ class AvailabilityList extends Base
         return false;
     }
 
-    public function getSlotList()
+    public function getSlotList(): SlotList
     {
         $slotList = new SlotList();
         foreach ($this as $availability) {
@@ -150,7 +150,7 @@ class AvailabilityList extends Base
         return $slotList;
     }
 
-    public function getSlotListByType($type)
+    public function getSlotListByType($type): SlotList
     {
         $slotList = new SlotList();
         foreach ($this as $availability) {
@@ -163,7 +163,7 @@ class AvailabilityList extends Base
         return $slotList;
     }
 
-    public function getConflicts($startDate, $endDate)
+    public function getConflicts($startDate, $endDate): ProcessList
     {
         $processList = new ProcessList();
         foreach ($this as $availability) {
@@ -190,7 +190,7 @@ class AvailabilityList extends Base
         return $processList;
     }
 
-    public function hasOverlapWith(Availability $availability, \DateTimeInterface $currentDate)
+    public function hasOverlapWith(Availability $availability, \DateTimeInterface $currentDate): ProcessList
     {
         $processList = new ProcessList();
         foreach ($this as $availabilityCompare) {
@@ -270,7 +270,7 @@ class AvailabilityList extends Base
     }
 
 
-    public function withScope(\BO\Zmsentities\Scope $scope)
+    public function withScope(\BO\Zmsentities\Scope $scope): static
     {
         $list = clone $this;
         foreach ($list as $key => $availability) {
@@ -279,6 +279,9 @@ class AvailabilityList extends Base
         return $list;
     }
 
+    /**
+     * @return self
+     */
     #[\Override]
     public function withLessData(array $keepArray = [])
     {

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -37,6 +37,10 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $item;
     }
 
+    /**
+     * @return Entity|false
+     *
+     */
     public function getLast()
     {
         $copy = $this->getArrayCopy();
@@ -44,6 +48,10 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $item;
     }
 
+    /**
+     * @return static
+     *
+     */
     public function sortByName()
     {
         $this->uasort(function ($a, $b) {
@@ -55,7 +63,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
-    public function sortByContactName()
+    public function sortByContactName(): static
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
@@ -66,7 +74,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
-    public function sortByCustomKey($key)
+    public function sortByCustomKey(string $key): static
     {
         $this->uasort(function ($a, $b) use ($key) {
             return ($a[$key] - $b[$key]);
@@ -74,7 +82,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
-    public function sortByCustomStringKey($key)
+    public function sortByCustomStringKey($key): static
     {
         $this->uasort(function ($a, $b) use ($key) {
             return strcmp(
@@ -92,7 +100,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         }
     }
 
-    public function hasEntity($primary)
+    public function hasEntity($primary): bool
     {
         foreach ($this as $entity) {
             if (isset($entity->{$entity::PRIMARY}) && $primary == $entity->{$entity::PRIMARY}) {
@@ -102,7 +110,11 @@ class Base extends \ArrayObject implements \JsonSerializable
         return false;
     }
 
-    public function getEntity($primary)
+    /**
+     * @return Entity|null
+     *
+     */
+    public function getEntity(string $primary)
     {
         foreach ($this as $entity) {
             if (isset($entity->{$entity::PRIMARY}) && $primary == $entity->{$entity::PRIMARY}) {
@@ -114,8 +126,9 @@ class Base extends \ArrayObject implements \JsonSerializable
 
     /**
      * @param T $entity
+     *
      */
-    public function addEntity(\BO\Zmsentities\Schema\Entity $entity)
+    public function addEntity(\BO\Zmsentities\Schema\Entity $entity): static
     {
         $this->offsetSet(null, $entity);
         return $this;
@@ -135,7 +148,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         }
     }
 
-    public function addData($mergeData)
+    public function addData($mergeData): static
     {
         foreach ($mergeData as $item) {
             if ($item instanceof Entity) {
@@ -153,7 +166,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
-    public function addList(Base $list)
+    public function addList(Base $list): static
     {
         foreach ($list as $item) {
             $this->addEntity($item);
@@ -161,6 +174,10 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * @return array
+     *
+     */
     public function getIds()
     {
         $list = [];
@@ -170,12 +187,12 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $list;
     }
 
-    public function getIdsCsv()
+    public function getIdsCsv(): string
     {
         return implode(',', $this->getIds());
     }
 
-    public function getCsvForProperty($propertyName, $csvSeperator = ',')
+    public function getCsvForProperty($propertyName, $csvSeperator = ','): string
     {
         $list = [];
         foreach ($this as $entry) {
@@ -186,7 +203,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return implode($csvSeperator, $list);
     }
 
-    public function getCsvForPropertyList(array $propertyList, $propertySeperator = '', $csvSeperator = ',')
+    public function getCsvForPropertyList(array $propertyList, $propertySeperator = '', $csvSeperator = ','): string
     {
         $list = [];
         foreach ($this as $entry) {
@@ -208,8 +225,9 @@ class Base extends \ArrayObject implements \JsonSerializable
 
     /**
      * Change a parameter on all entries
+     *
      */
-    public function withValueFor($param, $newValue)
+    public function withValueFor($param, $newValue): static
     {
         $list = new static();
         foreach ($this as $entry) {
@@ -221,6 +239,8 @@ class Base extends \ArrayObject implements \JsonSerializable
     /**
      * Reduce items data of dereferenced entities to a required minimum
      *
+     * @return static
+     *
      */
     public function withLessData(array $keepArray = [])
     {
@@ -231,14 +251,18 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $list;
     }
 
-    public function setJsonCompressLevel($jsonCompressLevel)
+    public function setJsonCompressLevel($jsonCompressLevel): void
     {
         foreach ($this as $item) {
             $item->setJsonCompressLevel($jsonCompressLevel);
         }
     }
 
-    public function getAsArray()
+    /**
+     * @return Entity[]
+     *
+     */
+    public function getAsArray(): array
     {
         $array = [];
         foreach ($this as $item) {
@@ -297,7 +321,11 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $collection;
     }
 
-    public function chunk($length)
+    /**
+     * @return static[]
+     *
+     */
+    public function chunk($length): array
     {
         $chunks = [new static()];
         $id = 0;

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -114,7 +114,7 @@ class Base extends \ArrayObject implements \JsonSerializable
      * @return Entity|null
      *
      */
-    public function getEntity(string $primary)
+    public function getEntity(string|int $primary)
     {
         foreach ($this as $entity) {
             if (isset($entity->{$entity::PRIMARY}) && $primary == $entity->{$entity::PRIMARY}) {

--- a/zmsentities/src/Zmsentities/Collection/ClosureList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClosureList.php
@@ -9,12 +9,12 @@ class ClosureList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Closure';
 
-    public function hasEntityByDate($date)
+    public function hasEntityByDate($date): bool
     {
         return $this->getByDate($date) ? true : false;
     }
 
-    public function getByDate($date)
+    public function getByDate($date): \BO\Zmsentities\Closure|false
     {
         $date = (new \BO\Zmsentities\Helper\DateTime($date))->format('Y-m-d');
         foreach ($this as $entity) {
@@ -25,7 +25,7 @@ class ClosureList extends Base
         return false;
     }
 
-    public function getEntityByName($name)
+    public function getEntityByName($name): \BO\Zmsentities\Closure|null
     {
         $result = null;
         foreach ($this as $entity) {
@@ -36,7 +36,7 @@ class ClosureList extends Base
         return $result;
     }
 
-    public function withTimestampFromDateformat($fromFormat = 'd.m.Y')
+    public function withTimestampFromDateformat($fromFormat = 'd.m.Y'): self
     {
         $collection = new self();
         foreach ($this as $data) {
@@ -48,7 +48,10 @@ class ClosureList extends Base
         return $collection;
     }
 
-    public function testDatesInYear($year)
+    /**
+     * @return true
+     */
+    public function testDatesInYear($year): bool
     {
         foreach ($this as $data) {
             $entity = new \BO\Zmsentities\Closure($data); // if source is an array
@@ -60,7 +63,7 @@ class ClosureList extends Base
         return true;
     }
 
-    public function withNew(ClosureList $closureList)
+    public function withNew(ClosureList $closureList): self
     {
         $list = new self();
         foreach ($closureList as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/ClusterList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClusterList.php
@@ -9,7 +9,7 @@ class ClusterList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Cluster';
 
-    public function hasScope($scopeId)
+    public function hasScope($scopeId): bool
     {
         foreach ($this as $entity) {
             foreach ($entity['scopes'] as $scope) {
@@ -22,7 +22,7 @@ class ClusterList extends Base
         return false;
     }
 
-    public function withUniqueClusters()
+    public function withUniqueClusters(): self
     {
         $clusterList = new self();
         foreach ($this as $cluster) {
@@ -33,6 +33,9 @@ class ClusterList extends Base
         return $clusterList;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function sortByName()
     {

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -13,9 +13,8 @@ class DayList extends Base implements JsonUnindexed
 
     /**
      * ATTENTION: Performance critical, keep highly optimized
-     *
      */
-    public function getDay($year, $month, $dayNumber, $createDay = true)
+    public function getDay(string $year, string $month, string $dayNumber, bool $createDay = true): Day|null
     {
         $dateHash = Day::getCalculatedDayHash($dayNumber, $month, $year);
         if ($this->offsetExists($dateHash)) {
@@ -55,13 +54,13 @@ class DayList extends Base implements JsonUnindexed
     }
 
 
-    public function hasDay($year, $month, $dayNumber)
+    public function hasDay($year, $month, $dayNumber): bool
     {
         $day = $this->getDay($year, $month, $dayNumber, false);
         return ($day === null) ? false : true;
     }
 
-    public function withAssociatedDays($currentDate)
+    public function withAssociatedDays(\DateTimeInterface $currentDate)
     {
         $dayList = new self();
         $lastDay = $currentDate->format('t');
@@ -73,7 +72,7 @@ class DayList extends Base implements JsonUnindexed
         return $dayList->sortByCustomKey('day');
     }
 
-    public function setStatusByType($slotType, \DateTimeInterface $dateTime)
+    public function setStatusByType($slotType, \DateTimeInterface $dateTime): static
     {
         foreach ($this as $day) {
             $day->getWithStatus($slotType, $dateTime);
@@ -81,7 +80,7 @@ class DayList extends Base implements JsonUnindexed
         return $this;
     }
 
-    public function withAddedDayList(DayList $dayList)
+    public function withAddedDayList(DayList $dayList): self
     {
         $merged = new DayList();
         foreach ($dayList as $day) {
@@ -95,7 +94,7 @@ class DayList extends Base implements JsonUnindexed
         return $merged;
     }
 
-    public function setSortByDate()
+    public function setSortByDate(): static
     {
         $this->uasort(function ($dayA, $dayB) {
             return (
@@ -106,7 +105,7 @@ class DayList extends Base implements JsonUnindexed
         return $this;
     }
 
-    public function setSort($property = 'day')
+    public function setSort($property = 'day'): static
     {
         $this->uasort(function ($dayA, $dayB) use ($property) {
             return strnatcmp($dayA[$property], $dayB[$property]);
@@ -114,7 +113,7 @@ class DayList extends Base implements JsonUnindexed
         return $this;
     }
 
-    public function hasDayWithAppointments()
+    public function hasDayWithAppointments(): bool
     {
         foreach ($this as $day) {
             $day = new Day($day);
@@ -136,7 +135,7 @@ class DayList extends Base implements JsonUnindexed
         return null;
     }
 
-    public function withDaysInDateRange(\DateTimeInterface $startDate, \DateTimeInterface $endDate)
+    public function withDaysInDateRange(\DateTimeInterface $startDate, \DateTimeInterface $endDate): self
     {
         $list = new self();
         foreach ($this as $day) {
@@ -150,7 +149,7 @@ class DayList extends Base implements JsonUnindexed
         return $list;
     }
 
-    public function withDaysFromPeriod(\DateTimeInterface $startDate, \DateTimeInterface $endDate)
+    public function withDaysFromPeriod(\DateTimeInterface $startDate, \DateTimeInterface $endDate): self
     {
         $list = new self();
         do {

--- a/zmsentities/src/Zmsentities/Collection/DayoffList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayoffList.php
@@ -9,12 +9,12 @@ class DayoffList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Dayoff';
 
-    public function hasEntityByDate($date)
+    public function hasEntityByDate($date): bool
     {
         return $this->getByDate($date) ? true : false;
     }
 
-    public function getByDate($date)
+    public function getByDate($date): \BO\Zmsentities\Dayoff|false
     {
         $date = (new \BO\Zmsentities\Helper\DateTime($date))->format('Y-m-d');
         foreach ($this as $entity) {
@@ -25,7 +25,7 @@ class DayoffList extends Base
         return false;
     }
 
-    public function getEntityByName($name)
+    public function getEntityByName($name): \BO\Zmsentities\Dayoff|null
     {
         $result = null;
         foreach ($this as $entity) {
@@ -36,7 +36,7 @@ class DayoffList extends Base
         return $result;
     }
 
-    public function withTimestampFromDateformat($fromFormat = 'd.m.Y')
+    public function withTimestampFromDateformat($fromFormat = 'd.m.Y'): self
     {
         $collection = new self();
         foreach ($this as $data) {
@@ -48,7 +48,10 @@ class DayoffList extends Base
         return $collection;
     }
 
-    public function testDatesInYear($year)
+    /**
+     * @return true
+     */
+    public function testDatesInYear($year): bool
     {
         foreach ($this as $data) {
             $entity = new \BO\Zmsentities\Dayoff($data); // if source is an array
@@ -60,7 +63,7 @@ class DayoffList extends Base
         return true;
     }
 
-    public function withNew(DayoffList $dayoffList)
+    public function withNew(DayoffList $dayoffList): self
     {
         $list = new self();
         foreach ($dayoffList as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/DepartmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/DepartmentList.php
@@ -11,7 +11,7 @@ class DepartmentList extends Base implements JsonUnindexed
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Department';
 
-    public function withOutClusterDuplicates()
+    public function withOutClusterDuplicates(): self
     {
         $departmentList = new self();
         foreach ($this as $department) {
@@ -55,7 +55,7 @@ class DepartmentList extends Base implements JsonUnindexed
         return $clusterList->withUniqueClusters();
     }
 
-    public function withAccess(\BO\Zmsentities\Useraccount $useraccount)
+    public function withAccess(\BO\Zmsentities\Useraccount $useraccount): static
     {
         $list = new static();
         foreach ($this as $department) {
@@ -69,7 +69,7 @@ class DepartmentList extends Base implements JsonUnindexed
         return $list;
     }
 
-    public function withMatchingScopes(ScopeList $scopeList)
+    public function withMatchingScopes(ScopeList $scopeList): static
     {
         $list = new static();
         foreach ($this as $department) {
@@ -88,6 +88,9 @@ class DepartmentList extends Base implements JsonUnindexed
         return $list;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function sortByName()
     {
@@ -103,6 +106,10 @@ class DepartmentList extends Base implements JsonUnindexed
         return $this;
     }
 
+    /**
+     * @return array
+     *
+     */
     #[\Override]
     public function getIds()
     {

--- a/zmsentities/src/Zmsentities/Collection/MailList.php
+++ b/zmsentities/src/Zmsentities/Collection/MailList.php
@@ -9,7 +9,7 @@ class MailList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Mail';
 
-    public function withProcess($processId)
+    public function withProcess($processId): self
     {
         $list = new self();
         foreach ($this as $mail) {

--- a/zmsentities/src/Zmsentities/Collection/MailtemplateList.php
+++ b/zmsentities/src/Zmsentities/Collection/MailtemplateList.php
@@ -9,7 +9,7 @@ class MailtemplateList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Mailtemplate';
 
-    public function prioritizeByName(array $priorityNames)
+    public function prioritizeByName(array $priorityNames): static
     {
         $prioritized = [];
         $others = [];

--- a/zmsentities/src/Zmsentities/Collection/OrganisationList.php
+++ b/zmsentities/src/Zmsentities/Collection/OrganisationList.php
@@ -9,7 +9,7 @@ class OrganisationList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Organisation';
 
-    public function getByDepartmentId($departmentId)
+    public function getByDepartmentId($departmentId): self
     {
         $organisationList = new self();
         foreach ($this as $entity) {
@@ -21,7 +21,7 @@ class OrganisationList extends Base
         return $organisationList;
     }
 
-    public function withAccess(\BO\Zmsentities\Useraccount $useraccount)
+    public function withAccess(\BO\Zmsentities\Useraccount $useraccount): static
     {
         $list = new static();
         foreach ($this as $organisation) {
@@ -38,6 +38,9 @@ class OrganisationList extends Base
         return $list;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function sortByName()
     {
@@ -50,7 +53,7 @@ class OrganisationList extends Base
         return $this;
     }
 
-    public function withMatchingDepartments(DepartmentList $departmentList)
+    public function withMatchingDepartments(DepartmentList $departmentList): static
     {
         $list = new static();
         foreach ($this as $organisation) {

--- a/zmsentities/src/Zmsentities/Collection/OwnerList.php
+++ b/zmsentities/src/Zmsentities/Collection/OwnerList.php
@@ -23,7 +23,11 @@ class OwnerList extends Base
         return $organisationList->sortByName();
     }
 
-    public function toDepartmentListByOrganisationName()
+    /**
+     * @return array[]
+     *
+     */
+    public function toDepartmentListByOrganisationName(): array
     {
         $list = array();
         foreach ($this as $entity) {
@@ -35,7 +39,7 @@ class OwnerList extends Base
         return $list;
     }
 
-    public function withAccess(\BO\Zmsentities\Useraccount $useraccount)
+    public function withAccess(\BO\Zmsentities\Useraccount $useraccount): static
     {
         $list = new static();
         foreach ($this as $owner) {

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -18,7 +18,7 @@ class ProcessList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Process';
 
-    public function toProcessListByTime($format = null)
+    public function toProcessListByTime(string|null $format = null): self
     {
         $list = new self();
         foreach ($this as $process) {
@@ -32,7 +32,7 @@ class ProcessList extends Base
         return $list;
     }
 
-    public function withRequest($requestId)
+    public function withRequest($requestId): self
     {
         $list = new self();
         foreach ($this as $process) {
@@ -43,7 +43,7 @@ class ProcessList extends Base
         return $list;
     }
 
-    public function sortByScopeName()
+    public function sortByScopeName(): static
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
@@ -54,7 +54,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function sortByAppointmentDate()
+    public function sortByAppointmentDate(): static
     {
         $this->uasort(function ($a, $b) {
             return ($a->getFirstAppointment()->date - $b->getFirstAppointment()->date);
@@ -62,7 +62,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function sortByArrivalTime()
+    public function sortByArrivalTime(): static
     {
         $this->uasort(function ($a, $b) {
             return ($a->queue['arrivalTime'] - $b->queue['arrivalTime']);
@@ -70,7 +70,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function sortByEstimatedWaitingTime()
+    public function sortByEstimatedWaitingTime(): static
     {
         $this->uasort(function ($a, $b) {
             return ($a->queue['waitingTimeEstimate'] - $b->queue['waitingTimeEstimate']);
@@ -78,7 +78,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function sortByClientName()
+    public function sortByClientName(): static
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
@@ -89,7 +89,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function sortByTimeKey()
+    public function sortByTimeKey(): static
     {
         $this->uksort(function ($a, $b) {
             return ($a - $b);
@@ -97,7 +97,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function toProcessListByStatusList(array $statusList)
+    public function toProcessListByStatusList(array $statusList): self
     {
         $collection = new self();
         foreach ($this as $process) {
@@ -108,7 +108,11 @@ class ProcessList extends Base
         return $collection;
     }
 
-    public function toConflictListByDay()
+    /**
+     * @return ((mixed|null)[][]|mixed)[][][]
+     *
+     */
+    public function toConflictListByDay(): array
     {
         $list = [];
         $oldList = clone $this;
@@ -158,7 +162,7 @@ class ProcessList extends Base
         return $list->withUniqueRequests();
     }
 
-    public function getAppointmentList()
+    public function getAppointmentList(): AppointmentList
     {
         $appointmentList = new AppointmentList();
         foreach ($this as $process) {
@@ -171,7 +175,7 @@ class ProcessList extends Base
         return $appointmentList;
     }
 
-    public function setTempAppointmentToProcess($dateTime, $scopeId)
+    public function setTempAppointmentToProcess($dateTime, $scopeId): static
     {
         $addedAppointment = false;
         $appointment = (new \BO\Zmsentities\Appointment())->addDate($dateTime->getTimestamp())->addScope($scopeId);
@@ -190,7 +194,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function toQueueList($now)
+    public function toQueueList($now): QueueList
     {
         $queueList = new QueueList();
         foreach ($this as $process) {
@@ -201,7 +205,7 @@ class ProcessList extends Base
         return $queueList;
     }
 
-    public function withAvailability(\BO\Zmsentities\Availability $availability)
+    public function withAvailability(\BO\Zmsentities\Availability $availability): static
     {
         $processList = new static();
         foreach ($this as $process) {
@@ -212,7 +216,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withAvailabilityStrict(\BO\Zmsentities\Availability $availability)
+    public function withAvailabilityStrict(\BO\Zmsentities\Availability $availability): static
     {
         $processList = new static();
         $slotList = $availability->getSlotList();
@@ -224,7 +228,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withDepartmentHasMailFrom()
+    public function withDepartmentHasMailFrom(): static
     {
         $processList = new static();
         foreach ($this as $process) {
@@ -238,7 +242,7 @@ class ProcessList extends Base
 
 
 
-    public function setConflictAmendment()
+    public function setConflictAmendment(): static
     {
         foreach ($this as $process) {
             $process->amendment = 'Die Slots für diesen Zeitraum wurden überbucht';
@@ -252,7 +256,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function withOutAvailability(\BO\Zmsentities\Collection\AvailabilityList $availabilityList)
+    public function withOutAvailability(\BO\Zmsentities\Collection\AvailabilityList $availabilityList): static
     {
         $processList = new static();
         foreach ($this->toProcessListByTime('Y-m-d') as $processListByDate) {
@@ -274,7 +278,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withUniqueScope($oncePerHour = false)
+    public function withUniqueScope($oncePerHour = false): static
     {
         $processList = new static();
         $scopeKeyList = [];
@@ -293,7 +297,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withAccess(\BO\Zmsentities\Useraccount $useraccount)
+    public function withAccess(\BO\Zmsentities\Useraccount $useraccount): static
     {
         $list = new static();
         foreach ($this as $process) {
@@ -305,7 +309,7 @@ class ProcessList extends Base
         return $list;
     }
 
-    public function withScopeId($scopeId)
+    public function withScopeId($scopeId): static
     {
         $processList = new static();
         foreach ($this as $process) {
@@ -316,7 +320,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withOutScopeId($scopeId)
+    public function withOutScopeId($scopeId): static
     {
         $processList = new static();
         foreach ($this as $process) {
@@ -327,7 +331,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withOutProcessId($processId)
+    public function withOutProcessId($processId): static
     {
         $processList = new static();
         foreach ($this as $process) {
@@ -338,7 +342,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withoutExpiredAppointmentDate(\DateTimeInterface $now)
+    public function withoutExpiredAppointmentDate(\DateTimeInterface $now): self
     {
         $conflictList = new self();
         foreach ($this as $process) {
@@ -349,7 +353,7 @@ class ProcessList extends Base
         return $conflictList;
     }
 
-    public function withinExactDate(\DateTimeInterface $now)
+    public function withinExactDate(\DateTimeInterface $now): self
     {
         $processList = new self();
         foreach ($this as $process) {
@@ -360,7 +364,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withoutDublicatedConflicts()
+    public function withoutDublicatedConflicts(): self
     {
         $collection = new self();
         foreach ($this as $conflict) {
@@ -383,7 +387,7 @@ class ProcessList extends Base
         return $collection;
     }
 
-    public function withoutProcessByStatus($process, $status)
+    public function withoutProcessByStatus(Process $process, $status)
     {
         $collection = clone $this;
         $collection = (1 <= $collection->count() && ! Messaging::isEmptyProcessListAllowed($status)) ?
@@ -395,7 +399,7 @@ class ProcessList extends Base
     /*
     * reduce process list to items with appointment time in range of given appointment
     */
-    public function withTimeRangeByAppointment(\BO\Zmsentities\Appointment $appointment)
+    public function withTimeRangeByAppointment(\BO\Zmsentities\Appointment $appointment): self
     {
         $processList = new self();
         if ($this->count()) {

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -9,7 +9,7 @@ class ProviderList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Provider';
 
-    public function hasProvider($providerIdCsv)
+    public function hasProvider($providerIdCsv): bool
     {
         $providerFound = false;
         $providerIds = explode(',', $providerIdCsv);
@@ -21,7 +21,7 @@ class ProviderList extends Base
         return $providerFound;
     }
 
-    public function hasProviderStrict($providerIdCsv)
+    public function hasProviderStrict($providerIdCsv): bool
     {
         $providerIds = explode(',', $providerIdCsv);
         foreach ($providerIds as $providerId) {
@@ -32,7 +32,7 @@ class ProviderList extends Base
         return true;
     }
 
-    public function hasRequest($requestIdCsv)
+    public function hasRequest($requestIdCsv): bool
     {
         $requestIds = explode(',', $requestIdCsv);
         foreach ($this as $entity) {
@@ -45,7 +45,7 @@ class ProviderList extends Base
         return false;
     }
 
-    public function withMatchingByList($providerIdCsv)
+    public function withMatchingByList($providerIdCsv): self
     {
         $collection = new self();
         $providerIds = explode(',', $providerIdCsv);
@@ -57,7 +57,7 @@ class ProviderList extends Base
         return $collection;
     }
 
-    public function withUniqueProvider()
+    public function withUniqueProvider(): self
     {
         $list = new self();
         foreach ($this as $provider) {
@@ -68,7 +68,7 @@ class ProviderList extends Base
         return $list;
     }
 
-    public function withDataAsObject()
+    public function withDataAsObject(): self
     {
         $list = new self();
         foreach ($this as $provider) {

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -32,7 +32,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
 
     protected $fromProcessList = false;
 
-    public function setWaitingTimePreferences($processTimeAverage, $workstationCount)
+    public function setWaitingTimePreferences($processTimeAverage, $workstationCount): static
     {
         if ($processTimeAverage <= 0) {
             throw new \Exception("QueueList::withEstimatedWaitingTime() requires processTimeAverage");
@@ -42,7 +42,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $this;
     }
 
-    public function setTransferedProcessList($bool = true)
+    public function setTransferedProcessList(bool $bool = true): static
     {
         $this->fromProcessList = $bool;
         return $this;
@@ -131,7 +131,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueWithWaitingTime;
     }
 
-    private function getSortPriority($queue): int
+    private function getSortPriority(\BO\Zmsentities\Queue $queue): int
     {
         $priority = self::DEFAULT_PRIORITY_WITHOUT_APPOINTMENT;
         if (empty($queue['priority']) && $queue['withAppointment']) {
@@ -144,7 +144,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $priority;
     }
 
-    public function withWaitingTime(\DateTimeInterface $dateTime)
+    public function withWaitingTime(\DateTimeInterface $dateTime): static
     {
         $queueList = $this;
         $timestamp = $dateTime->getTimestamp();
@@ -156,7 +156,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function withSortedArrival()
+    public function withSortedArrival(): static
     {
         $queueList = $this;
         $queueList->uasort(function ($first, $second) {
@@ -177,7 +177,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList->sortByCustomKey('waitingTimeEstimate');
     }
 
-    public function withAppointment()
+    public function withAppointment(): self
     {
         $queueList = new self();
         foreach ($this as $entity) {
@@ -188,7 +188,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function withOutAppointment()
+    public function withOutAppointment(): self
     {
         $queueList = new self();
         foreach ($this as $entity) {
@@ -199,7 +199,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function getEstimatedWaitingTime($processTimeAverage, $workstationCount, \DateTimeInterface $dateTime)
+    public function getEstimatedWaitingTime($processTimeAverage, $workstationCount, \DateTimeInterface $dateTime): array
     {
         $queueList = $this->withFakeWaitingnumber($dateTime);
         $queueList = $queueList
@@ -212,7 +212,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $dataOfFackedEntity;
     }
 
-    public function withFakeWaitingnumber(\DateTimeInterface $dateTime)
+    public function withFakeWaitingnumber(\DateTimeInterface $dateTime): static
     {
         $queueList = $this;
         $process = new \BO\Zmsentities\Process(['status' => 'deleted']);
@@ -237,7 +237,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $entity;
     }
 
-    public function getQueueByNumber($number)
+    public function getQueueByNumber(int $number): \BO\Zmsentities\Queue|null
     {
         foreach ($this as $entity) {
             if ($entity->number == $number) {
@@ -275,7 +275,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return null;
     }
 
-    public function getQueuePositionByNumber($number)
+    public function getQueuePositionByNumber($number): int|null
     {
         $list = array_values($this->getArrayCopy());
         foreach ($list as $key => $entity) {
@@ -286,7 +286,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return null;
     }
 
-    public function getCountWithWaitingTime(?\DateTimeInterface $dateTime = null)
+    public function getCountWithWaitingTime(?\DateTimeInterface $dateTime = null): self
     {
         $queueList = new self();
         $timestamp = $dateTime ? $dateTime->getTimestamp() : null;
@@ -314,9 +314,8 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
 
     /**
      * @param array $statusList of possible strings in process.status
-     *
      */
-    public function withStatus(array $statusList)
+    public function withStatus(array $statusList): self
     {
         $queueList = new self();
         foreach ($this as $entity) {
@@ -329,9 +328,8 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
 
     /**
      * @param array $statusList of excepted strings in process.status
-     *
      */
-    public function withoutStatus(array $statusList)
+    public function withoutStatus(array $statusList): self
     {
         $queueList = new self();
         foreach ($this as $entity) {
@@ -342,7 +340,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function withShortNameDestinationHint(\BO\Zmsentities\Cluster $cluster, \BO\Zmsentities\Scope $scope)
+    public function withShortNameDestinationHint(\BO\Zmsentities\Cluster $cluster, \BO\Zmsentities\Scope $scope): self
     {
         $queueList = $this;
         $list = new self();
@@ -355,7 +353,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $list;
     }
 
-    public function toProcessList()
+    public function toProcessList(): ProcessList
     {
         $processList = new ProcessList();
         foreach ($this as $queue) {
@@ -367,7 +365,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $processList;
     }
 
-    public function withoutDublicates()
+    public function withoutDublicates(): self
     {
         $list = new self();
         $exists = [];
@@ -381,7 +379,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $list; // Cloning with this function
     }
 
-    public function getWaitingNumberList()
+    public function getWaitingNumberList(): array
     {
         $list = [];
         foreach ($this as $entity) {
@@ -390,12 +388,12 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $list;
     }
 
-    public function getWaitingNumberListCsv()
+    public function getWaitingNumberListCsv(): string
     {
         return implode(',', $this->getWaitingNumberList());
     }
 
-    public function withSelectedProcessFirst(\BO\Zmsentities\Process $process)
+    public function withSelectedProcessFirst(\BO\Zmsentities\Process $process): self
     {
         $queueList = $this;
         $list = new self();
@@ -408,7 +406,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $list;
     }
 
-    public function sortByCallTime(string $order)
+    public function sortByCallTime(string $order): self
     {
         $queueListArray = [];
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/RequestList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestList.php
@@ -11,7 +11,7 @@ class RequestList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Request';
 
-    public function hasRequests($requestIdCsv)
+    public function hasRequests(string $requestIdCsv): bool
     {
         $requestIdCsv = explode(',', $requestIdCsv);
         foreach ($requestIdCsv as $requestId) {
@@ -22,7 +22,11 @@ class RequestList extends Base
         return true;
     }
 
-    public function toSortedByGroup()
+    /**
+     * @return self[]
+     *
+     */
+    public function toSortedByGroup(): array
     {
         $list = array();
         foreach ($this as $entity) {
@@ -58,7 +62,7 @@ class RequestList extends Base
         return $requestList;
     }
 
-    public function hasAppointmentFromProviderData()
+    public function hasAppointmentFromProviderData(): bool
     {
         foreach ($this as $entity) {
             if ($entity->hasAppointmentFromProviderData()) {
@@ -68,7 +72,7 @@ class RequestList extends Base
         return false;
     }
 
-    public function withUniqueRequests()
+    public function withUniqueRequests(): self
     {
         $requestList = new self();
         foreach ($this as $request) {
@@ -79,7 +83,7 @@ class RequestList extends Base
         return $requestList;
     }
 
-    public function withDataAsObject()
+    public function withDataAsObject(): self
     {
         $list = new self();
         foreach ($this as $request) {

--- a/zmsentities/src/Zmsentities/Collection/RequestRelationList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestRelationList.php
@@ -9,7 +9,7 @@ class RequestRelationList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\RequestRelation';
 
-    public function hasRequest($requestIdCsv)
+    public function hasRequest($requestIdCsv): bool
     {
         $requestIdCsv = explode(',', $requestIdCsv);
         foreach ($requestIdCsv as $requestId) {
@@ -20,7 +20,7 @@ class RequestRelationList extends Base
         return true;
     }
 
-    public function hasProvider($providerIdCsv)
+    public function hasProvider($providerIdCsv): bool
     {
         $providerIdCsv = explode(',', $providerIdCsv);
         foreach ($providerIdCsv as $providerId) {
@@ -55,7 +55,7 @@ class RequestRelationList extends Base
         return $providerList->withUniqueProvider();
     }
 
-    public function getFilteredByRequestAndProvider($requestList, $providerList)
+    public function getFilteredByRequestAndProvider($requestList, $providerList): self
     {
         $list = new self();
         foreach ($requestList as $request) {

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -80,7 +80,7 @@ class ScopeList extends Base
         return $date;
     }
 
-    public function withoutDublicates($scopeList = null)
+    public function withoutDublicates($scopeList = null): self
     {
         $collection = new self();
         foreach ($this as $scope) {
@@ -91,7 +91,7 @@ class ScopeList extends Base
         return $collection;
     }
 
-    public function withUniqueScopes()
+    public function withUniqueScopes(): self
     {
         $scopeList = new self();
         foreach ($this as $scope) {
@@ -102,7 +102,7 @@ class ScopeList extends Base
         return $scopeList;
     }
 
-    public function addScopeList($scopeList)
+    public function addScopeList($scopeList): static
     {
         foreach ($scopeList as $scope) {
             $this->addEntity($scope);
@@ -110,6 +110,9 @@ class ScopeList extends Base
         return $this;
     }
 
+    /**
+     * @return self
+     */
     #[\Override]
     public function withLessData(array $keepArray = [])
     {
@@ -120,6 +123,9 @@ class ScopeList extends Base
         return $scopeList;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function sortByName()
     {
@@ -134,7 +140,7 @@ class ScopeList extends Base
         return $this;
     }
 
-    public function withProviderID($source, $providerID)
+    public function withProviderID($source, $providerID): self
     {
         $list = new ScopeList();
         foreach ($this as $scope) {
@@ -145,7 +151,7 @@ class ScopeList extends Base
         return $list;
     }
 
-    public function addRequiredSlots($source, $providerID, $slotsRequired)
+    public function addRequiredSlots($source, $providerID, $slotsRequired): static
     {
         $scopeList = $this->withProviderID($source, $providerID);
         foreach ($scopeList as $scope) {
@@ -165,7 +171,7 @@ class ScopeList extends Base
         return 0;
     }
 
-    public function hasOpenedScope()
+    public function hasOpenedScope(): bool
     {
         $isOpened = false;
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -14,11 +14,14 @@ class SlotList extends Base
 
     /**
      * Compare two slots and return the lower values
+     *
      * @param array $slotA
      * @param array $slotB
+     *
      * @return array $slotA modified
+     *
      */
-    public function takeLowerSlotValue($indexA, $indexB)
+    public function takeLowerSlotValue(int $indexA, int $indexB)
     {
         $slotA = $this[$indexA];
         $slotB = $this[$indexB];
@@ -31,7 +34,7 @@ class SlotList extends Base
         return $this;
     }
 
-    public function setEmptySlotValues($index)
+    public function setEmptySlotValues(int|string $index): static
     {
         $slot = $this->getSlot($index);
         if (null !== $slot) {
@@ -42,7 +45,7 @@ class SlotList extends Base
         return $this;
     }
 
-    public function isAvailableForAll($slotType)
+    public function isAvailableForAll($slotType): bool
     {
         foreach ($this as $slot) {
             if ($slot[$slotType] < 1) {
@@ -54,9 +57,8 @@ class SlotList extends Base
 
     /**
      * Get a slot for a given time
-     *
      */
-    public function getByDateTime(\DateTimeInterface $dateTime)
+    public function getByDateTime(\DateTimeInterface $dateTime): Slot|false
     {
         foreach ($this as $slot) {
             if ($slot->hasTime() && $slot->time == $dateTime->format('H:i')) {
@@ -98,7 +100,7 @@ class SlotList extends Base
         return $slotList;
     }
 
-    public function extendList($slotList, $prevSlot, $appointment)
+    public function extendList(self $slotList, Slot|null $prevSlot, \BO\Zmsentities\Appointment $appointment)
     {
         $startTime = \BO\Zmsentities\Helper\DateTime::create(
             $appointment->toDateTime()->format('Y-m-d') . ' ' . $prevSlot->time
@@ -152,7 +154,7 @@ class SlotList extends Base
         return $containsAppointment;
     }
 
-    public function getSlot($index)
+    public function getSlot($index): Slot|null
     {
         $index = intval($index);
         if (!isset($this[$index])) {
@@ -161,7 +163,7 @@ class SlotList extends Base
         return $this[$index];
     }
 
-    public function getSummerizedSlot($slot = null)
+    public function getSummerizedSlot($slot = null): Slot
     {
         $sum = ($slot instanceof Slot) ? $slot : new Slot();
         $sum->type = Slot::SUM;
@@ -175,7 +177,7 @@ class SlotList extends Base
     /*
      * reduce slotlist from slots smaller than reference time (today) + 1800 seconds
      */
-    public function withTimeGreaterThan(\DateTimeInterface $dateTime)
+    public function withTimeGreaterThan(\DateTimeInterface $dateTime): static
     {
         $slotList = clone $this;
         $referenceTime = $dateTime->getTimestamp() + 1800;
@@ -197,7 +199,7 @@ class SlotList extends Base
         $slotType,
         $requests,
         $slotsRequired
-    ) {
+    ): ProcessList {
         $processList = new ProcessList();
         foreach ($this as $slot) {
             if ($slotsRequired > 1 && $slot->type != Slot::REDUCED) {
@@ -229,7 +231,7 @@ class SlotList extends Base
         return $processList;
     }
 
-    public function withReducedSlots($slotsRequired)
+    public function withReducedSlots($slotsRequired): static
     {
         $slotList = clone $this;
         if ($slotsRequired > 1) {

--- a/zmsentities/src/Zmsentities/Collection/TicketprinterList.php
+++ b/zmsentities/src/Zmsentities/Collection/TicketprinterList.php
@@ -9,7 +9,7 @@ class TicketprinterList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Ticketprinter';
 
-    public function getEntityByHash($hash)
+    public function getEntityByHash($hash): \BO\Zmsentities\Ticketprinter|null
     {
         $result = null;
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/UseraccountList.php
+++ b/zmsentities/src/Zmsentities/Collection/UseraccountList.php
@@ -9,7 +9,7 @@ class UseraccountList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\UserAccount';
 
-    public function withoutDublicates()
+    public function withoutDublicates(): self
     {
         $collection = new self();
         foreach ($this as $useraccount) {
@@ -20,7 +20,7 @@ class UseraccountList extends Base
         return $collection;
     }
 
-    public function withAccessByWorkstation($workstation)
+    public function withAccessByWorkstation($workstation): self
     {
         $collection = new self();
         $departmentList = $workstation->getDepartmentList();

--- a/zmsentities/src/Zmsentities/Config.php
+++ b/zmsentities/src/Zmsentities/Config.php
@@ -6,6 +6,10 @@ class Config extends Schema\Entity
 {
     public static $schema = "config.json";
 
+    /**
+     * @return (int|string)[][]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -33,12 +37,12 @@ class Config extends Schema\Entity
         ];
     }
 
-    public function hasType($type)
+    public function hasType($type): bool
     {
         return (isset($this[$type])) ? true : false;
     }
 
-    public function hasPreference($type, $key)
+    public function hasPreference($type, $key): bool
     {
         return ($this->hasType($type) && isset($this[$type][$key])) ? true : false;
     }
@@ -48,7 +52,7 @@ class Config extends Schema\Entity
         return $this->toProperty()->$type->$key->get();
     }
 
-    public function setPreference($type, $key, $value)
+    public function setPreference($type, $key, $value): static
     {
         $preference = $this->toProperty()->$type->$key->get();
         if (null !== $preference) {

--- a/zmsentities/src/Zmsentities/Day.php
+++ b/zmsentities/src/Zmsentities/Day.php
@@ -18,6 +18,10 @@ class Day extends Schema\Entity
 
     public static $schema = "day.json";
 
+    /**
+     * @return (Slot|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -38,7 +42,7 @@ class Day extends Schema\Entity
         return "Day {$this->status}@{$this->year}-{$this->month}-{$this->day} with " . $this->freeAppointments;
     }
 
-    public function setDateTime(\DateTimeInterface $dateTime)
+    public function setDateTime(\DateTimeInterface $dateTime): static
     {
         $this['year'] = $dateTime->format('Y');
         $this['month'] = $dateTime->format('m');
@@ -65,12 +69,12 @@ class Day extends Schema\Entity
         return (0 < $freeAppointmentCount);
     }
 
-    public function isBookable()
+    public function isBookable(): bool
     {
         return ($this->status == self::BOOKABLE);
     }
 
-    public function hasAppointments()
+    public function hasAppointments(): bool
     {
         return ($this->status == self::BOOKABLE || $this->status == self::FULL);
     }
@@ -96,7 +100,7 @@ class Day extends Schema\Entity
         return $this;
     }
 
-    public function withAddedDay(Day $day)
+    public function withAddedDay(Day $day): static
     {
         $merged = clone $this;
         if (!$merged->freeAppointments instanceof Slot) {
@@ -114,7 +118,7 @@ class Day extends Schema\Entity
         return $this::getCalculatedDayHash($this->day, $this->month, $this->year);
     }
 
-    public static function getCalculatedDayHash($dayNumber, $month, $year)
+    public static function getCalculatedDayHash($dayNumber, $month, $year): string
     {
         $dateHash = str_pad($dayNumber, 2, '0', STR_PAD_LEFT)
             . "-"

--- a/zmsentities/src/Zmsentities/Dayoff.php
+++ b/zmsentities/src/Zmsentities/Dayoff.php
@@ -8,6 +8,10 @@ class Dayoff extends Schema\Entity
 
     public static $schema = "dayoff.json";
 
+    /**
+     * @return (int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -17,7 +21,7 @@ class Dayoff extends Schema\Entity
         ];
     }
 
-    public function setTimestampFromDateformat($fromFormat = 'd.m.Y')
+    public function setTimestampFromDateformat($fromFormat = 'd.m.Y'): static
     {
         $dateTime = \DateTimeImmutable::createFromFormat($fromFormat, $this->date, new \DateTimeZone('UTC'));
         if ($dateTime) {
@@ -26,7 +30,7 @@ class Dayoff extends Schema\Entity
         return $this;
     }
 
-    public function getDateTime()
+    public function getDateTime(): Helper\DateTime
     {
         return (new \BO\Zmsentities\Helper\DateTime())->setTimestamp($this->date);
     }
@@ -44,7 +48,7 @@ class Dayoff extends Schema\Entity
         return ($dateTime->getTimestamp() < $this->lastChange);
     }
 
-    public function isAffectingAvailability(Availability $availabiliy, \DateTimeInterface $now)
+    public function isAffectingAvailability(Availability $availabiliy, \DateTimeInterface $now): bool
     {
         return $availabiliy->isBookable($this->getDateTime(), $now);
     }

--- a/zmsentities/src/Zmsentities/Department.php
+++ b/zmsentities/src/Zmsentities/Department.php
@@ -10,6 +10,10 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
 
     public static $schema = "department.json";
 
+    /**
+     * @return (Collection\ClusterList|Collection\DayoffList|Collection\LinkList|Collection\ScopeList|int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -23,7 +27,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         ];
     }
 
-    public function hasMail()
+    public function hasMail(): bool
     {
         return ($this->toProperty()->email->isAvailable() && $this->toProperty()->email->get());
     }
@@ -33,12 +37,12 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         return $this->toProperty()->contact->name->get();
     }
 
-    public function getContact()
+    public function getContact(): Contact
     {
         return new Contact($this->toProperty()->contact->get());
     }
 
-    public function getDayoffList()
+    public function getDayoffList(): Collection\DayoffList
     {
         if (!$this->dayoff instanceof Collection\DayoffList) {
             $this->dayoff = new Collection\DayoffList((array)$this->dayoff);
@@ -72,7 +76,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
      * Remove duplicate scopes from clusters
      * Move scopes to clusters to keep the same resolveReference Level
      */
-    public function withOutClusterDuplicates()
+    public function withOutClusterDuplicates(): static
     {
         $department = clone $this;
         if ($this->offsetExists('scopes') && $this->scopes) {
@@ -102,14 +106,14 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         return $department;
     }
 
-    public function withCompleteScopeList()
+    public function withCompleteScopeList(): static
     {
         $department = clone $this;
         $department->scopes = $this->getScopeList()->withUniqueScopes();
         return $department;
     }
 
-    public function getScopeList()
+    public function getScopeList(): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         if ($this->toProperty()->clusters->isAvailable()) {
@@ -133,6 +137,9 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         return $scopeList;
     }
 
+    /**
+     * @return bool
+     */
     #[\Override]
     public function hasAccess(Useraccount $useraccount)
     {
@@ -142,6 +149,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData()

--- a/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
+++ b/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
@@ -15,20 +15,20 @@ class SchemaValidation extends \Exception
 
     public $template;
 
-    public function setValidationError(array $validationErrorList)
+    public function setValidationError(array $validationErrorList): static
     {
         $this->setMessages($validationErrorList);
         return $this;
     }
 
-    public function setSchemaName($schemaName)
+    public function setSchemaName($schemaName): static
     {
         $this->schemaName = $schemaName . '.json';
         $this->template = $schemaName;
         return $this;
     }
 
-    protected function setMessages($validationErrorList)
+    protected function setMessages(array $validationErrorList): static
     {
         foreach ($validationErrorList as $error) {
             $pointer = is_array($error->data()->path())

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -20,6 +20,10 @@ class Exchange extends Schema\Entity
 
     public static $schema = "exchange.json";
 
+    /**
+     * @return (Day|array|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -32,7 +36,7 @@ class Exchange extends Schema\Entity
         ];
     }
 
-    public function setPeriod(\DateTimeInterface $firstDay, \DateTimeInterface $lastDay, $period = 'day')
+    public function setPeriod(\DateTimeInterface $firstDay, \DateTimeInterface $lastDay, $period = 'day'): static
     {
         $this->firstDay = (new Day())->setDateTime($firstDay);
         $this->lastDay = (new Day())->setDateTime($lastDay);
@@ -40,7 +44,7 @@ class Exchange extends Schema\Entity
         return $this;
     }
 
-    public function addDictionaryEntry($variable, $type = 'string', $description = '', $reference = '')
+    public function addDictionaryEntry($variable, $type = 'string', $description = '', $reference = ''): static
     {
         $position = count($this['dictionary']);
         $this['dictionary'][$position] = [
@@ -53,7 +57,13 @@ class Exchange extends Schema\Entity
         return $this;
     }
 
-    public function addDataSet($values)
+    /**
+     * @param (float|int|string)[] $values
+     *
+     *
+     * @return void
+     */
+    public function addDataSet(array $values)
     {
         if (!is_array($values) && !$values instanceof \Traversable) {
             throw new \Exception("Values have to be of type array");
@@ -64,6 +74,9 @@ class Exchange extends Schema\Entity
         $this->data[] = $values;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function withLessData()
     {
@@ -80,7 +93,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function getPositionByName($name)
+    public function getPositionByName(string $name)
     {
         if (isset($this->dictionary)) {
             foreach ($this->dictionary as $entry) {
@@ -92,7 +105,7 @@ class Exchange extends Schema\Entity
         return false;
     }
 
-    public function withCalculatedTotals(array $keysToCalculate = ['count'], $dateName = 'name')
+    public function withCalculatedTotals(array $keysToCalculate = ['count'], $dateName = 'name'): static
     {
         $entity = clone $this;
         $namePosition = $this->getPositionByName($dateName);
@@ -114,7 +127,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function withMaxByHour(array $keysToCalculate = ['count'])
+    public function withMaxByHour(array $keysToCalculate = ['count']): static
     {
         $entity = clone $this;
         $maxima = [];
@@ -133,7 +146,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function withRequestsSum($keysToCalculate = ['requestscount'])
+    public function withRequestsSum($keysToCalculate = ['requestscount']): static
     {
         $entity = clone $this;
         $sum = [];
@@ -151,7 +164,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function withAverage($keyToCalculate)
+    public function withAverage($keyToCalculate): static
     {
         $entity = clone $this;
         $average = [];
@@ -234,7 +247,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function withMaxAndAverageFromWaitingTime()
+    public function withMaxAndAverageFromWaitingTime(): static
     {
         $entity = clone $this;
         foreach ($entity->data as $date => $dateItems) {
@@ -268,7 +281,7 @@ class Exchange extends Schema\Entity
         return null;
     }
 
-    public function toHashed(array $hashfields = [])
+    public function toHashed(array $hashfields = []): static
     {
         $entity = clone $this;
         $entity->data = $this->getHashData($hashfields);
@@ -276,7 +289,11 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function getHashData(array $hashfields = [], $first = false)
+    /**
+     * @return (array|mixed)[]|false
+     *
+     */
+    public function getHashData(array $hashfields = [], bool $first = false): array|false
     {
         $hash = [];
         foreach ($this->dictionary as $entry) {
@@ -295,7 +312,7 @@ class Exchange extends Schema\Entity
         return ($first) ? reset($hash) : $hash;
     }
 
-    public function toGrouped(array $fields, array $hashfields)
+    public function toGrouped(array $fields, array $hashfields): static
     {
         $entity = clone $this;
         $entity->data = $this->getGroupedHashSet($fields, $hashfields);

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -63,7 +63,7 @@ class Exchange extends Schema\Entity
      *
      * @return void
      */
-    public function addDataSet(array $values)
+    public function addDataSet($values)
     {
         if (!is_array($values) && !$values instanceof \Traversable) {
             throw new \Exception("Values have to be of type array");

--- a/zmsentities/src/Zmsentities/Helper/DateTime.php
+++ b/zmsentities/src/Zmsentities/Helper/DateTime.php
@@ -4,7 +4,7 @@ namespace BO\Zmsentities\Helper;
 
 class DateTime extends \DateTimeImmutable implements \JsonSerializable
 {
-    public static function create($time = 'now', \DateTimeZone $timezone = null)
+    public static function create(string|\DateTimeInterface|false $time = 'now', \DateTimeZone $timezone = null): self
     {
         if ($time instanceof \BO\Zmsentities\Helper\DateTime) {
             $dateTime = $time;
@@ -25,7 +25,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $dateTime;
     }
 
-    public function getWeekOfMonth()
+    public function getWeekOfMonth(): float
     {
         // Todo: This is correct way of calculating week of month by date, but zms1 has 1-7 = 1, 8-14 = 2,...
         /*
@@ -39,19 +39,19 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $weekOfMonth;
     }
 
-    public function isWeekOfMonth($number)
+    public function isWeekOfMonth($number): bool
     {
         return (int)$this->getWeekOfMonth() === (int)$number;
     }
 
-    public function isLastWeekOfMonth()
+    public function isLastWeekOfMonth(): bool
     {
         $weekOfMonth = $this->getWeekOfMonth();
         $lastDay = $this->modify('last day of this month');
         return $weekOfMonth == $lastDay->getWeekOfMonth();
     }
 
-    public function getSecondsOfDay()
+    public function getSecondsOfDay(): int|float
     {
         $hours = $this->format('G');
         $minutes = $this->format('i');
@@ -59,12 +59,16 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $hours * 3600 + $minutes * 60 + $seconds;
     }
 
+    /**
+     *
+     * @return false|string
+     */
     public static function getFormatedDates(
         \DateTimeInterface $date,
-        $pattern = 'MMMM',
+        string $pattern = 'MMMM',
         $locale = 'de_DE',
         $timezone = 'Europe/Berlin'
-    ) {
+    ): string|false {
         $dateFormatter = new \IntlDateFormatter(
             $locale,
             \IntlDateFormatter::MEDIUM,
@@ -76,7 +80,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $dateFormatter->format($date->getTimestamp());
     }
 
-    public static function getSummerTimeStartDateTime($year = null)
+    public static function getSummerTimeStartDateTime($year = null): \DateTime
     {
         $year = ($year) ? $year : date('Y');
         $dateTimeMarch = new \DateTime($year . '-03-01', new \DateTimeZone('Europe/Berlin'));
@@ -84,7 +88,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $lastSunday->setTime('02', '00', '00');
     }
 
-    public static function getSummerTimeEndDateTime($year = null)
+    public static function getSummerTimeEndDateTime($year = null): \DateTime
     {
         $year = ($year) ? $year : date('Y');
         $dateTimeOctober = new \DateTime($year . '-10-01', new \DateTimeZone('Europe/Berlin'));

--- a/zmsentities/src/Zmsentities/Helper/Delegate.php
+++ b/zmsentities/src/Zmsentities/Helper/Delegate.php
@@ -29,7 +29,7 @@ class Delegate
         };
     }
 
-    private static function setValueAtPath(&$container, array $propertyPath, mixed $newValue): void
+    private static function setValueAtPath(mixed &$container, array $propertyPath, mixed $newValue): void
     {
         $property = array_shift($propertyPath);
         if ($propertyPath === []) {

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -162,7 +162,7 @@ class Messaging
      * @return ((int|mixed)[][]|Client|Process|\DateTimeImmutable|mixed|null|string)[]
      *
      */
-    public static function generateMailParameters(ProcessList $processList, Config $config, $initiator, string $status): array
+    public static function generateMailParameters(Process|ProcessList $processList, Config $config, $initiator, string $status): array
     {
         $collection = (new ProcessList())
             ->testProcessListLength($processList, self::isEmptyProcessListAllowed($status));
@@ -263,7 +263,7 @@ class Messaging
         Config $config,
         $status = 'appointment',
         $initiator = null,
-        bool $now = false,
+        $now = false,
         $templateProvider = false
     ): \BO\Zmsentities\Ics {
         $ics = new \BO\Zmsentities\Ics();

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -37,7 +37,7 @@ class Messaging
         \BO\Zmsentities\Config $config,
         \BO\Zmsentities\Process $process,
         $status
-    ) {
+    ): bool {
         $client = $process->getFirstClient();
         $noAttachmentDomains = $config->toProperty()->notifications->noAttachmentDomains->get();
         $noAttachmentDomains = explode(',', (string)$noAttachmentDomains);
@@ -49,7 +49,7 @@ class Messaging
         return (in_array($status, self::$icsRequiredForStatus));
     }
 
-    public static function isEmptyProcessListAllowed($status)
+    public static function isEmptyProcessListAllowed($status): bool
     {
         return (in_array($status, self::$allowEmptyProcesses));
     }
@@ -107,7 +107,7 @@ class Messaging
         return $twig;
     }
 
-    protected static function dbTwigView($templateProvider)
+    protected static function dbTwigView($templateProvider): Environment
     {
         $loader = new \Twig\Loader\ArrayLoader($templateProvider->getTemplates());
         $twig = new \Twig\Environment($loader);
@@ -116,7 +116,7 @@ class Messaging
         return $twig;
     }
 
-    public static function getMailContentPreview($templateContent, $process)
+    public static function getMailContentPreview($templateContent, $process): string
     {
         $parameters = self::generateMailParameters(
             $process,
@@ -129,7 +129,7 @@ class Messaging
     }
 
     public static function getMailContent(
-        $processList,
+        Process|ProcessList $processList,
         Config $config,
         $initiator = null,
         $status = 'appointment',
@@ -157,7 +157,12 @@ class Messaging
         return $message;
     }
 
-    public static function generateMailParameters($processList, $config, $initiator, $status)
+    /**
+     *
+     * @return ((int|mixed)[][]|Client|Process|\DateTimeImmutable|mixed|null|string)[]
+     *
+     */
+    public static function generateMailParameters(ProcessList $processList, Config $config, $initiator, string $status): array
     {
         $collection = (new ProcessList())
             ->testProcessListLength($processList, self::isEmptyProcessListAllowed($status));
@@ -202,7 +207,7 @@ class Messaging
         \BO\Zmsentities\Collection\ProcessList $processList,
         \BO\Zmsentities\Scope $scope,
         \DateTimeInterface $dateTime
-    ) {
+    ): string {
         $message = self::twigView()->render(
             'messaging/mail_scopeadmin_processlist.twig',
             array(
@@ -214,7 +219,7 @@ class Messaging
         return $message;
     }
 
-    protected static function getTemplate($type, $status)
+    protected static function getTemplate(string $type, $status)
     {
         $template = null;
         if (Property::__keyExists($type, self::$templates)) {
@@ -231,7 +236,7 @@ class Messaging
         $initiator = null,
         $status = 'appointment',
         $templateProvider = null
-    ) {
+    ): string {
         $appointment = $process->getFirstAppointment();
         $parameters = [
             'date' => $appointment ? $appointment->toDateTime()->format('U') : null,
@@ -258,9 +263,9 @@ class Messaging
         Config $config,
         $status = 'appointment',
         $initiator = null,
-        $now = false,
+        bool $now = false,
         $templateProvider = false
-    ) {
+    ): \BO\Zmsentities\Ics {
         $ics = new \BO\Zmsentities\Ics();
         $message = self::getMailContent($process, $config, $initiator, $status, $templateProvider);
         $ics->content = self::generateIcsContent($process, $config, $status, $now, $templateProvider, $message);
@@ -324,7 +329,7 @@ class Messaging
         return self::getTextWithFoldedLines($icsString);
     }
 
-    public static function getPlainText($content, $lineBreak = "\n")
+    public static function getPlainText($content, $lineBreak = "\n"): string
     {
         $converter = new \League\HTMLToMarkdown\HtmlConverter();
         $converter->getConfig()->setOption('remove_nodes', 'script');
@@ -338,7 +343,7 @@ class Messaging
         return trim($text);
     }
 
-    public static function getTextWithFoldedLines($content)
+    public static function getTextWithFoldedLines(string $content): string
     {
         $newLines = [];
         $lines = explode("\n", $content);

--- a/zmsentities/src/Zmsentities/Helper/Property.php
+++ b/zmsentities/src/Zmsentities/Helper/Property.php
@@ -25,18 +25,18 @@ class Property implements \ArrayAccess
         $this->access = $access;
     }
 
-    public static function create($access)
+    public static function create(mixed $access): self
     {
         return new self($access);
     }
 
-    public function isAvailable()
+    public function isAvailable(): bool
     {
         //shorter to avoid extra unit testing
         return (null !== $this->access) ? true : false;
     }
 
-    public function get($default = null)
+    public function get(mixed $default = null): mixed
     {
         if (null !== $this->access) {
             return $this->access;

--- a/zmsentities/src/Zmsentities/Helper/Sorter.php
+++ b/zmsentities/src/Zmsentities/Helper/Sorter.php
@@ -10,7 +10,7 @@ class Sorter
     /**
      * @todo check against ISO definition
      */
-    public static function toSortableString($string)
+    public static function toSortableString(string $string): string
     {
         $string = strtr($string, array(
             'Ä' => 'Ae',
@@ -25,7 +25,7 @@ class Sorter
         return $string;
     }
 
-    public static function toSortedCsv($csvString)
+    public static function toSortedCsv($csvString): string
     {
         $csvElements = explode(',', $csvString ?? '');
         sort($csvElements);

--- a/zmsentities/src/Zmsentities/Helper/TemplateFinder.php
+++ b/zmsentities/src/Zmsentities/Helper/TemplateFinder.php
@@ -10,7 +10,7 @@ class TemplateFinder
     /**
      * @todo check against ISO definition
      */
-    public static function getTemplatePath()
+    public static function getTemplatePath(): string
     {
         return realpath(__DIR__) . '/../../../templates';
     }

--- a/zmsentities/src/Zmsentities/Link.php
+++ b/zmsentities/src/Zmsentities/Link.php
@@ -8,6 +8,10 @@ class Link extends Schema\Entity
 
     public static $schema = "link.json";
 
+    /**
+     * @return (bool|int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {

--- a/zmsentities/src/Zmsentities/Mail.php
+++ b/zmsentities/src/Zmsentities/Mail.php
@@ -19,6 +19,10 @@ class Mail extends Schema\Entity
 
     protected $templateProvider = false;
 
+    /**
+     * @return (Client|Collection\MimepartList|Department|Process)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -40,18 +44,18 @@ class Mail extends Schema\Entity
         return $this->toProperty()->process->authKey->get();
     }
 
-    public function addMultiPart($multiPart)
+    public function addMultiPart($multiPart): static
     {
         $this->multipart = $multiPart;
         return $this;
     }
 
-    public function hasContent()
+    public function hasContent(): bool
     {
         return ($this->getHtmlPart() && $this->getPlainPart());
     }
 
-    public function hasIcs()
+    public function hasIcs(): bool
     {
         return (null != $this->getIcsPart());
     }
@@ -109,7 +113,7 @@ class Mail extends Schema\Entity
         return $client;
     }
 
-    public function toCustomMessageEntity(Process $process, $collection)
+    public function toCustomMessageEntity(Process $process, $collection): static
     {
         $entity = clone $this;
         $message = '';
@@ -211,7 +215,7 @@ class Mail extends Schema\Entity
         Collection\ProcessList $processList,
         Scope $scope,
         \DateTimeInterface $dateTime
-    ) {
+    ): static {
         $entity = clone $this;
         $content = Messaging::getScopeAdminProcessListContent($processList, $scope, $dateTime);
         $entity->subject = 'Termine am ' . $dateTime->format('Y-m-d');
@@ -235,7 +239,7 @@ class Mail extends Schema\Entity
         return $entity;
     }
 
-    public function withDepartment($department)
+    public function withDepartment($department): static
     {
         $this->department = $department;
         return $this;
@@ -252,7 +256,7 @@ class Mail extends Schema\Entity
         return $this['client']['email'];
     }
 
-    public function setTemplateProvider($templateProvider)
+    public function setTemplateProvider($templateProvider): static
     {
         $this->templateProvider = $templateProvider;
         return $this;

--- a/zmsentities/src/Zmsentities/Mailtemplate.php
+++ b/zmsentities/src/Zmsentities/Mailtemplate.php
@@ -6,6 +6,10 @@ class Mailtemplate extends Schema\Entity
 {
     public static $schema = "mailtemplate.json";
 
+    /**
+     * @return array
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -13,12 +17,12 @@ class Mailtemplate extends Schema\Entity
         ];
     }
 
-    public function hasType($type)
+    public function hasType($type): bool
     {
         return (isset($this[$type])) ? true : false;
     }
 
-    public function hasPreference($type, $key)
+    public function hasPreference($type, $key): bool
     {
         return ($this->hasType($type) && isset($this[$type][$key])) ? true : false;
     }
@@ -28,7 +32,7 @@ class Mailtemplate extends Schema\Entity
         return $this->toProperty()->$type->$key->get();
     }
 
-    public function setPreference($type, $key, $value)
+    public function setPreference($type, $key, $value): static
     {
         $preference = $this->toProperty()->$type->$key->get();
         if (null !== $preference) {

--- a/zmsentities/src/Zmsentities/Mimepart.php
+++ b/zmsentities/src/Zmsentities/Mimepart.php
@@ -8,6 +8,10 @@ class Mimepart extends Schema\Entity
 
     public static $schema = "mimepart.json";
 
+    /**
+     * @return string[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -17,22 +21,22 @@ class Mimepart extends Schema\Entity
             ];
     }
 
-    public function isBase64Encoded()
+    public function isBase64Encoded(): bool
     {
         return ($this->base64) ? true : false;
     }
 
-    public function isHtml()
+    public function isHtml(): bool
     {
         return ($this->mime == 'text/html') ? true : false;
     }
 
-    public function isText()
+    public function isText(): bool
     {
         return ($this->mime == 'text/plain') ? true : false;
     }
 
-    public function isIcs()
+    public function isIcs(): bool
     {
         return ($this->mime == 'text/calendar') ? true : false;
     }
@@ -42,7 +46,11 @@ class Mimepart extends Schema\Entity
         return ($this->isBase64Encoded()) ? \base64_decode($this->content) : $this->content;
     }
 
-    public function getExtension()
+    /**
+     * @return null|string|string[]
+     *
+     */
+    public function getExtension(): array|string|null
     {
         return preg_replace('#^.*/#', '', $this->mime);
     }

--- a/zmsentities/src/Zmsentities/Month.php
+++ b/zmsentities/src/Zmsentities/Month.php
@@ -10,6 +10,10 @@ class Month extends Schema\Entity
 
     public static $schema = "month.json";
 
+    /**
+     * @return Collection\DayList[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -24,7 +28,7 @@ class Month extends Schema\Entity
         return $dateTime->modify('00:00:00');
     }
 
-    public function getDayList()
+    public function getDayList(): Collection\DayList
     {
         if (!$this->days instanceof Collection\DayList) {
             $this->days = new Collection\DayList($this->days);
@@ -32,7 +36,7 @@ class Month extends Schema\Entity
         return $this->days;
     }
 
-    public function setDays(Collection\DayList $dayList)
+    public function setDays(Collection\DayList $dayList): static
     {
         foreach ($this->getDayList() as $key => $day) {
             if (!$day instanceof Day) {
@@ -46,7 +50,7 @@ class Month extends Schema\Entity
     public static function createForDateFromDayList(
         \DateTimeInterface $currentDate,
         \BO\Zmsentities\Collection\DayList $dayList
-    ) {
+    ): self {
         $startDow = date('w', mktime(0, 0, 0, $currentDate->format('m'), 1, $currentDate->format('Y')));
         $monthDayList = $dayList->withAssociatedDays($currentDate);
         $month = (new self(

--- a/zmsentities/src/Zmsentities/Organisation.php
+++ b/zmsentities/src/Zmsentities/Organisation.php
@@ -8,6 +8,10 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
 
     public static $schema = "organisation.json";
 
+    /**
+     * @return (Collection\DepartmentList|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -22,7 +26,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
         return $this->getDepartmentList()->hasEntity($departmentId);
     }
 
-    public function getDepartmentList()
+    public function getDepartmentList(): Collection\DepartmentList
     {
         if (!$this->departments instanceof Collection\DepartmentList) {
             $this->departments = new Collection\DepartmentList((array)$this->departments);
@@ -38,6 +42,9 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
         return $this->toProperty()->preferences->$index->get();
     }
 
+    /**
+     * @return bool
+     */
     #[\Override]
     public function hasAccess(Useraccount $useraccount)
     {
@@ -48,6 +55,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData(array $keepArray = [])

--- a/zmsentities/src/Zmsentities/Owner.php
+++ b/zmsentities/src/Zmsentities/Owner.php
@@ -8,6 +8,10 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
 
     public static $schema = "owner.json";
 
+    /**
+     * @return (Collection\OrganisationList|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -22,7 +26,7 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
         return $this->getOrganisationList()->hasEntity($organisationId);
     }
 
-    public function getOrganisationList()
+    public function getOrganisationList(): Collection\OrganisationList
     {
         if (!$this->organisations instanceof Collection\OrganisationList) {
             $this->organisations = new Collection\OrganisationList($this->organisations);
@@ -34,6 +38,9 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
     }
 
 
+    /**
+     * @return bool
+     */
     #[\Override]
     public function hasAccess(Useraccount $useraccount)
     {
@@ -44,6 +51,7 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData()

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -31,6 +31,10 @@ class Process extends Schema\Entity
     public const string STATUS_BLOCKED = 'blocked';
     public const string STATUS_CONFLICT = 'conflict';
     public static $schema = "process.json";
+    /**
+     * @return (Apiclient|Collection\AppointmentList|Collection\ClientList|Collection\RequestList|Queue|Scope|false|int|null|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -62,7 +66,7 @@ class Process extends Schema\Entity
         ];
     }
 
-    public static function createFromScope(Scope $scope, \DateTimeInterface $dateTime)
+    public static function createFromScope(Scope $scope, \DateTimeInterface $dateTime): static
     {
         $appointment = new Appointment();
         $appointment->addScope($scope->id);
@@ -107,13 +111,13 @@ class Process extends Schema\Entity
         return $this->getRequests()->getIdsCsv();
     }
 
-    public function addScope($scopeId)
+    public function addScope($scopeId): static
     {
         $this->scope = new Scope(array('id' => $scopeId));
         return $this;
     }
 
-    public function addQueue($number, \DateTimeInterface $dateTime)
+    public function addQueue($number, \DateTimeInterface $dateTime): static
     {
         $this->queue = new Queue(array(
             'number' => $number,
@@ -123,7 +127,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addRequests($source, $requestCSV)
+    public function addRequests($source, $requestCSV): static
     {
         $requestList = $this->getRequests();
         foreach (explode(',', $requestCSV) as $id) {
@@ -137,7 +141,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function updateRequests($source, $requestCSV = '')
+    public function updateRequests($source, int|string $requestCSV = ''): static
     {
         $this->requests = new Collection\RequestList();
         if ($requestCSV) {
@@ -151,32 +155,32 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function hasScopeAdmin()
+    public function hasScopeAdmin(): bool
     {
         return ('' != $this->toProperty()->scope->contact->email->get());
     }
 
-    public function sendAdminMailOnConfirmation()
+    public function sendAdminMailOnConfirmation(): bool
     {
         return (bool) ((int) $this->toProperty()->scope->preferences->client->adminMailOnAppointment->get());
     }
 
-    public function sendAdminMailOnDeleted()
+    public function sendAdminMailOnDeleted(): bool
     {
         return (bool) ((int) $this->toProperty()->scope->preferences->client->adminMailOnDeleted->get());
     }
 
-    public function sendAdminMailOnUpdated()
+    public function sendAdminMailOnUpdated(): bool
     {
         return (bool) ((int) $this->toProperty()->scope->preferences->client->adminMailOnUpdated->get());
     }
 
-    public function shouldSendAdminMailOnClerkMail()
+    public function shouldSendAdminMailOnClerkMail(): bool
     {
         return (bool) ((int) $this->toProperty()->scope->preferences->client->adminMailOnMailSent->get());
     }
 
-    public function withUpdatedData($requestData, \DateTimeInterface $dateTime, $scope = null, $notice = '')
+    public function withUpdatedData($requestData, \DateTimeInterface $dateTime, $scope = null, $notice = ''): static
     {
         $this->scope = ($scope) ? $scope : $this->scope;
         $this->addAppointmentFromRequest($requestData, $dateTime);
@@ -191,7 +195,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addAppointmentFromRequest($requestData, \DateTimeInterface $dateTime)
+    public function addAppointmentFromRequest($requestData, \DateTimeInterface $dateTime): static
     {
         $this->appointments = null;
         if (isset($requestData['selecteddate'])) {
@@ -212,7 +216,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addClientFromForm($requestData)
+    public function addClientFromForm($requestData): static
     {
         $client = new Client();
         foreach ($requestData as $key => $value) {
@@ -225,7 +229,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function setStatus($status)
+    public function setStatus(string $status): static
     {
         $this->status = $status;
         return $this;
@@ -242,7 +246,7 @@ class Process extends Schema\Entity
         return ($timestamp) ? $timestamp : 0;
     }
 
-    public function addReminderTimestamp($input, \DateTimeInterface $dateTime)
+    public function addReminderTimestamp($input, \DateTimeInterface $dateTime): static
     {
         $this->reminderTimestamp = (
             Property::__keyExists('headsUpTime', $input) &&
@@ -294,7 +298,7 @@ class Process extends Schema\Entity
      * check if process is with appointment and not only queued
      * return Boolean
      */
-    public function isWithAppointment()
+    public function isWithAppointment(): bool
     {
         $appointment = $this->getFirstAppointment();
         if ($appointment->hasTime()) {
@@ -303,19 +307,19 @@ class Process extends Schema\Entity
         return (1 == $this->toProperty()->queue->withAppointment->get());
     }
 
-    public function hasProcessCredentials()
+    public function hasProcessCredentials(): bool
     {
         return (isset($this['id']) && isset($this['authKey']) && $this['id'] && $this['authKey']);
     }
 
-    public function withReassignedCredentials($process)
+    public function withReassignedCredentials($process): static
     {
         $this->id = $process->getId();
         $this->authKey = $process->getAuthKey();
         return $this;
     }
 
-    public function hasQueueNumber()
+    public function hasQueueNumber(): bool
     {
         return (isset($this['queue']) && isset($this['queue']['number']) && $this['queue']['number']);
     }
@@ -325,7 +329,7 @@ class Process extends Schema\Entity
         return $this['queue']['number'];
     }
 
-    public function addAppointment(Appointment $newappointment)
+    public function addAppointment(Appointment $newappointment): static
     {
         $this->appointments[] = $newappointment;
         return $this;
@@ -394,7 +398,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->finishTime->get();
     }
 
-    public function addAmendment($input, $notice = '')
+    public function addAmendment($input, $notice = ''): static
     {
         $this->amendment = $notice;
         $this->amendment .= (isset($input['amendment']) && $input['amendment']) ? $input['amendment'] : '';
@@ -407,7 +411,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->customTextfield->get();
     }
 
-    public function addCustomTextfield($input)
+    public function addCustomTextfield($input): static
     {
         $this->customTextfield = (
             isset($input['customTextfield']) && $input['customTextfield']
@@ -421,7 +425,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->customTextfield2->get();
     }
 
-    public function addCustomTextfield2($input)
+    public function addCustomTextfield2($input): static
     {
         $this->customTextfield2 = (
             isset($input['customTextfield2']) && $input['customTextfield2']
@@ -430,7 +434,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addPriority($input)
+    public function addPriority($input): static
     {
         $this->priority = isset($input['priority']) && $input['priority'] ? $input['priority'] : null;
 
@@ -442,17 +446,17 @@ class Process extends Schema\Entity
         return $this->toProperty()->authKey->get();
     }
 
-    public function getPriority()
+    public function getPriority(): int
     {
         return (int) $this->toProperty()->priority->get();
     }
 
-    public function setRandomAuthKey()
+    public function setRandomAuthKey(): void
     {
         $this->authKey = bin2hex(random_bytes(32));
     }
 
-    public function setCallTime($dateTime = null)
+    public function setCallTime($dateTime = null): static
     {
         $this->queue['callTime'] = ($dateTime) ? $dateTime->getTimestamp() : 0;
         return $this;
@@ -473,7 +477,7 @@ class Process extends Schema\Entity
         return $callDateTime;
     }
 
-    public function getFirstClient()
+    public function getFirstClient(): Client
     {
         $client = $this->getClients()->getFirst();
         if (!$client) {
@@ -494,7 +498,7 @@ class Process extends Schema\Entity
         return $appointment;
     }
 
-    public function setStatusBySettings()
+    public function setStatusBySettings(): static
     {
         $scope = new Scope($this->scope);
         if ('called' == $this->status && $this->queue['callCount'] > $scope->getPreference('queue', 'callCountMax')) {
@@ -507,7 +511,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function setClientsCount($count)
+    public function setClientsCount($count): static
     {
         $clientList = $this->getClients();
         while ($clientList->count() < $count) {
@@ -517,7 +521,7 @@ class Process extends Schema\Entity
     }
 
 
-    public function withoutPersonalData()
+    public function withoutPersonalData(): static
     {
         $entity = clone $this;
         if ($this->toProperty()->clients->isAvailable()) {
@@ -531,6 +535,7 @@ class Process extends Schema\Entity
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData(array $keepArray = [])
@@ -585,7 +590,7 @@ class Process extends Schema\Entity
         return $entity;
     }
 
-    public function toCalendar()
+    public function toCalendar(): Calendar
     {
         $calendar = new Calendar();
         $dateTime = $this->getFirstAppointment()->toDateTime();
@@ -617,7 +622,7 @@ class Process extends Schema\Entity
         return $queue->setProcess($this);
     }
 
-    public function hasArrivalTime()
+    public function hasArrivalTime(): bool
     {
         if ($this->isWithAppointment()) {
             $arrivalTime = $this->getFirstAppointment()->date;
@@ -627,7 +632,11 @@ class Process extends Schema\Entity
         return ($arrivalTime) ? true : false;
     }
 
-    public function getArrivalTime($default = 'now', $timezone = null)
+    /**
+     * @param \DateTimeInterface|string $default
+     *
+     */
+    public function getArrivalTime(string|\DateTimeInterface $default = 'now', $timezone = null)
     {
         $queueArrivalTime = $this->toProperty()->queue->arrivalTime->get();
 
@@ -648,7 +657,7 @@ class Process extends Schema\Entity
         return $arrivalDateTime;
     }
 
-    public function setArrivalTime(\DateTimeInterface $dateTime = null)
+    public function setArrivalTime(\DateTimeInterface $dateTime = null): static
     {
         $this->queue['arrivalTime'] = ($dateTime) ? $dateTime->getTimestamp() : 0;
         return $this;
@@ -677,7 +686,7 @@ class Process extends Schema\Entity
         return $this->getWaySeconds($defaultTime) / 60;
     }
 
-    public function setWasMissed(bool $bool)
+    public function setWasMissed(bool $bool): static
     {
         $this->wasMissed = $bool;
         $this->status = self::STATUS_MISSED;
@@ -689,7 +698,7 @@ class Process extends Schema\Entity
         return (bool) $this->wasMissed;
     }
 
-    public function toDerefencedAmendment()
+    public function toDerefencedAmendment(): string|null
     {
         $lastChange = (new \DateTimeImmutable())->setTimestamp($this->createTimestamp)->format('c');
         return var_export(array(
@@ -701,7 +710,7 @@ class Process extends Schema\Entity
             ), 1);
     }
 
-    public function toDerefencedCustomTextfield()
+    public function toDerefencedCustomTextfield(): string|null
     {
         $lastChange = (new \DateTimeImmutable())->setTimestamp($this->createTimestamp)->format('c');
         return var_export(array(
@@ -713,7 +722,7 @@ class Process extends Schema\Entity
             ), 1);
     }
 
-    public function toDerefencedCustomTextfield2()
+    public function toDerefencedCustomTextfield2(): string|null
     {
         $lastChange = (new \DateTimeImmutable())->setTimestamp($this->createTimestamp)->format('c');
         return var_export(array(
@@ -750,7 +759,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->externalUserId->get();
     }
 
-    public function setExternalUserId($externalUserId)
+    public function setExternalUserId($externalUserId): static
     {
         $this->externalUserId = $externalUserId;
         return $this;
@@ -761,7 +770,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->parkedBy->get();
     }
 
-    public function setParkedBy($name)
+    public function setParkedBy($name): void
     {
         $this->parkedBy = $name;
     }

--- a/zmsentities/src/Zmsentities/Provider.php
+++ b/zmsentities/src/Zmsentities/Provider.php
@@ -8,6 +8,10 @@ class Provider extends Schema\Entity
 
     public static $schema = "provider.json";
 
+    /**
+     * @return (int|null|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -42,12 +46,12 @@ class Provider extends Schema\Entity
         return parent::addData($mergeData);
     }
 
-    public function hasRequest($requestId)
+    public function hasRequest(string $requestId)
     {
         return $this->getRequestList()->hasRequests($requestId);
     }
 
-    public function getRequestList()
+    public function getRequestList(): Collection\RequestList
     {
         $requestList = new \BO\Zmsentities\Collection\RequestList();
         if (isset($this['data']['services'])) {
@@ -78,7 +82,7 @@ class Provider extends Schema\Entity
         return $this->toProperty()->display_name->get();
     }
 
-    public function getContact()
+    public function getContact(): Contact
     {
         $contact = $this->toProperty()->contact->get();
         return new Contact($contact);

--- a/zmsentities/src/Zmsentities/Queue.php
+++ b/zmsentities/src/Zmsentities/Queue.php
@@ -10,6 +10,10 @@ class Queue extends Schema\Entity implements Helper\NoSanitize
 
     protected $process;
 
+    /**
+     * @return (int|null)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -26,13 +30,13 @@ class Queue extends Schema\Entity implements Helper\NoSanitize
         ];
     }
 
-    public function setProcess(Process $parentProcess)
+    public function setProcess(Process $parentProcess): static
     {
         $this->process = $parentProcess;
         return $this;
     }
 
-    public function getProcess()
+    public function getProcess(): Process|null
     {
         if ($this->process instanceof Process) {
             $process = clone $this->process;

--- a/zmsentities/src/Zmsentities/Request.php
+++ b/zmsentities/src/Zmsentities/Request.php
@@ -8,6 +8,10 @@ class Request extends Schema\Entity
 
     public static $schema = "request.json";
 
+    /**
+     * @return (null|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -29,7 +33,7 @@ class Request extends Schema\Entity
         return parent::withReference($additionalData);
     }
 
-    public function hasAppointmentFromProviderData()
+    public function hasAppointmentFromProviderData(): bool
     {
         if (isset($this['data']) && isset($this['data']['locations'])) {
             foreach ($this['data']['locations'] as $provider) {

--- a/zmsentities/src/Zmsentities/RequestRelation.php
+++ b/zmsentities/src/Zmsentities/RequestRelation.php
@@ -6,6 +6,10 @@ class RequestRelation extends Schema\Entity
 {
     public static $schema = "requestrelation.json";
 
+    /**
+     * @return (Provider|Request|null|string|true)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -39,7 +43,7 @@ class RequestRelation extends Schema\Entity
         return $this->toProperty()->maxQuantity->get();
     }
 
-    public function isPublic()
+    public function isPublic(): bool
     {
         return (bool) $this->toProperty()->public->get();
     }

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -83,6 +83,9 @@ class Entity extends \ArrayObject implements \JsonSerializable
     }
     /**
      * Set Default values
+     *
+     * @return array
+     *
      */
     public function getDefaults()
     {
@@ -91,8 +94,9 @@ class Entity extends \ArrayObject implements \JsonSerializable
 
     /**
      * This method is private, because the used library should not be used outside of this class!
+     *
      */
-    public function getValidator($locale = 'de_DE', $resolveLevel = 0)
+    public function getValidator(string $locale = 'de_DE', int $resolveLevel = 0): Validator
     {
         $jsonSchema = self::readJsonSchema()->withResolvedReferences($resolveLevel);
         $data = (new Schema($this))->withoutRefs();
@@ -167,7 +171,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return self::$schemaCache[$class];
     }
 
-    public function getEntityName()
+    public function getEntityName(): string
     {
         $entity = get_class($this);
         $entity = preg_replace('#.*[\\\]#', '', $entity);
@@ -175,7 +179,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $entity;
     }
 
-    public function setJsonCompressLevel($jsonCompressLevel)
+    public function setJsonCompressLevel($jsonCompressLevel): static
     {
         $this->jsonCompressLevel = $jsonCompressLevel;
         return $this;
@@ -217,7 +221,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
      * Performs a merge with an iterable
      * Sub-entities are preserved
      */
-    public function addData($mergeData): static
+    public function addData(array|object $mergeData): static
     {
         foreach ($mergeData as $key => $item) {
             if (isset($this[$key])) {
@@ -243,14 +247,14 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Performs addData on a cloned entity
      */
-    public function withData($mergeData)
+    public function withData($mergeData): static
     {
         $entity = clone $this;
         $entity->addData($mergeData);
         return $entity;
     }
 
-    public function hasId()
+    public function hasId(): bool
     {
         return (false !== $this->getId()) ? true : false;
     }
@@ -276,7 +280,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $this->toProperty()->{$propertyName}->isAvailable();
     }
 
-    public function getProperty($propertyName, $default = '')
+    public function getProperty(string $propertyName, $default = '')
     {
         return $this->toProperty()->{$propertyName}->get($default);
     }
@@ -284,7 +288,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Change property without changing original
      */
-    public function withProperty($propertyName, $newValue)
+    public function withProperty($propertyName, $newValue): static
     {
         $entity = clone $this;
         $entity[$propertyName] = $newValue;
@@ -294,6 +298,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     public function withLessData()
     {
@@ -303,6 +308,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     public function withCleanedUpFormData()
     {

--- a/zmsentities/src/Zmsentities/Schema/Factory.php
+++ b/zmsentities/src/Zmsentities/Schema/Factory.php
@@ -19,7 +19,7 @@ class Factory
         $this->data = $data;
     }
 
-    public static function create($data)
+    public static function create($data): self
     {
         return new self($data);
     }

--- a/zmsentities/src/Zmsentities/Schema/Loader.php
+++ b/zmsentities/src/Zmsentities/Schema/Loader.php
@@ -6,7 +6,7 @@ use Exception;
 
 class Loader
 {
-    public static function asArray($schemaFilename)
+    public static function asArray(string $schemaFilename): Schema
     {
         $jsonString = self::asJson($schemaFilename);
         $array = json_decode($jsonString, true);
@@ -30,7 +30,10 @@ class Loader
         return $schema;
     }
 
-    public static function asJson($schemaFilename)
+    /**
+     * @return false|string
+     */
+    public static function asJson($schemaFilename): string|false
     {
         if (!$schemaFilename) {
             throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile("Missing JSON-Schema file");
@@ -40,7 +43,10 @@ class Loader
         return file_get_contents($filename);
     }
 
-    public static function getSchemaPath()
+    /**
+     * @return false|string
+     */
+    public static function getSchemaPath(): string|false
     {
         $pathTrace = [
             __DIR__,

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -48,7 +48,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function resolveReferences($hash, $resolveLevel)
+    protected function resolveReferences(array|self $hash, $resolveLevel)
     {
         foreach ($hash as $key => $value) {
             $hash[$key] = $this->resolveKey($key, $value, $resolveLevel);
@@ -72,18 +72,18 @@ class Schema extends \ArrayObject
         return $data;
     }
 
-    public function setJsonObject(\stdClass $asObject)
+    public function setJsonObject(\stdClass $asObject): static
     {
         $this->asObject = $asObject;
         return $this;
     }
 
-    public function setDefaults($defaults)
+    public function setDefaults($defaults): void
     {
         $this->defaults = $defaults;
     }
 
-    public function setJsonCompressLevel($jsonCompressLevel)
+    public function setJsonCompressLevel(int $jsonCompressLevel): static
     {
         $this->jsonCompressLevel = $jsonCompressLevel;
         return $this;
@@ -100,7 +100,7 @@ class Schema extends \ArrayObject
      * Sanitize value for valid export as JSON
      *
      */
-    protected function toSanitizedValue($value, $keepEmpty = false, $defaults = [])
+    protected function toSanitizedValue(array $value, $keepEmpty = false, $defaults = [])
     {
         if ($value instanceof \BO\Zmsentities\Helper\NoSanitize) {
             return $value;
@@ -122,7 +122,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function toSanitizedList($value, $keepEmpty, $defaults = [])
+    protected function toSanitizedList(array $value, $keepEmpty, $defaults = [])
     {
         foreach ($value as $key => $item) {
             if ($this->jsonCompressLevel > 0 && isset($defaults[$key])) {
@@ -140,7 +140,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected static function isItemEmpty($item)
+    protected static function isItemEmpty($item): bool
     {
         return (
             null === $item
@@ -182,7 +182,7 @@ class Schema extends \ArrayObject
         return $this->getWithoutRefs(clone $this);
     }
 
-    protected function getWithoutRefs($data)
+    protected function getWithoutRefs(array|self $data)
     {
         foreach ($data as $key => $value) {
             if (is_array($value)) {

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -100,7 +100,7 @@ class Schema extends \ArrayObject
      * Sanitize value for valid export as JSON
      *
      */
-    protected function toSanitizedValue(array $value, $keepEmpty = false, $defaults = [])
+    protected function toSanitizedValue(mixed $value, $keepEmpty = false, $defaults = [])
     {
         if ($value instanceof \BO\Zmsentities\Helper\NoSanitize) {
             return $value;

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -44,7 +44,7 @@ class Validator
         $this->validationResult = $this->validator->validate($data, $schemaJson);
     }
 
-    private function loadSchemas()
+    private function loadSchemas(): void
     {
         $schemaPath = realpath(dirname(__FILE__) . '/../../../schema') . '/';
         $this->validator->resolver()->registerPrefix('schema://', $schemaPath);
@@ -80,7 +80,7 @@ class Validator
         return $errorsReducedList;
     }
 
-    private function extractErrors(OpisValidationError $error)
+    private function extractErrors(OpisValidationError $error): array
     {
         $errors = [];
 
@@ -120,7 +120,7 @@ class Validator
         return $error->message();
     }
 
-    public static function getOriginPointer(OpisValidationError $error)
+    public static function getOriginPointer(OpisValidationError $error): string
     {
         $dataInfo = $error->data();
 

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -14,6 +14,10 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
 
     public static $schema = "scope.json";
 
+    /**
+     * @return (Contact|DayoffList|Provider|int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -103,7 +107,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
     }
 
 
-    public function getProvider()
+    public function getProvider(): Provider
     {
         if (!isset($this->provider)) {
             throw new Exception\ScopeMissingProvider("Provider is missing", 500);
@@ -124,7 +128,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->getProvider()->id;
     }
 
-    public function getDayoffList()
+    public function getDayoffList(): DayoffList
     {
         if (!isset($this->dayoff) || !$this->dayoff instanceof Collection\DayoffList) {
             $this->dayoff = (!isset($this->dayoff) || !is_array($this->dayoff)) ? [] : $this->dayoff;
@@ -138,7 +142,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->dayoff;
     }
 
-    public function getClosureList()
+    public function getClosureList(): ClosureList
     {
         if (!isset($this->closure) || !$this->closure instanceof Collection\ClosureList) {
             $this->closure = (!isset($this->closure) || !is_array($this->closure)) ? [] : $this->closure;
@@ -157,13 +161,17 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->getProvider()->getRequestList();
     }
 
-    public function getPreference($preferenceKey, $index, $isBool = false, $default = null)
+    /**
+     * @param false|null|string $isBool
+     *
+     */
+    public function getPreference(string $preferenceKey, string $index, string|false|null $isBool = false, $default = null)
     {
         $preference = $this->toProperty()->preferences->$preferenceKey->$index->get($default);
         return ($isBool) ? ($preference ? 1 : 0) : $preference;
     }
 
-    public function getStatus($statusKey, $index)
+    public function getStatus(string $statusKey, string $index)
     {
         return $this->toProperty()->status->$statusKey->$index->get();
     }
@@ -270,7 +278,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return ($scopeEndDate) ? $now->modify('+' . $scopeEndDate . 'days') : $now;
     }
 
-    public function updateStatusQueue(\DateTimeInterface $dateTime)
+    public function updateStatusQueue(\DateTimeInterface $dateTime): static
     {
         $lastQueueUpdateDate = Helper\DateTime::create()
             ->setTimestamp($this->getStatus('queue', 'lastGivenNumberTimestamp'));
@@ -290,7 +298,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this;
     }
 
-    public function incrementDisplayNumber()
+    public function incrementDisplayNumber(): static
     {
         if ($this->getStatus('queue', 'lastDisplayNumber') >= $this->getStatus('queue', 'maxDisplayNumber')) {
             $this->setStatusQueue('lastDisplayNumber', 1);
@@ -301,25 +309,28 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this;
     }
 
-    public function hasEmailFrom()
+    public function hasEmailFrom(): bool
     {
         $emailFrom = $this->getPreference('client', 'emailFrom');
         return ($emailFrom) ? true : false;
     }
 
-    public function isEmailRequired()
+    public function isEmailRequired(): bool
     {
         $emailFrom = $this->getPreference('client', 'emailFrom');
         $emailRequired = $this->getPreference('client', 'emailRequired');
         return ($emailFrom && $emailRequired) ? true : false;
     }
 
-    public function isTelephoneRequired()
+    public function isTelephoneRequired(): bool
     {
         $telephoneRequired = $this->getPreference('client', 'telephoneRequired');
         return $telephoneRequired ? true : false;
     }
 
+    /**
+     * @return bool
+     */
     #[\Override]
     public function hasAccess(Useraccount $useraccount)
     {
@@ -340,6 +351,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
     /**
      * Reduce data of dereferenced entities to a required minimum
      *
+     * @return static
      */
     #[\Override]
     public function withLessData(array $keepArray = [])
@@ -358,13 +370,13 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $entity;
     }
 
-    public function setStatusQueue($key, $value)
+    public function setStatusQueue(string $key, int $value): static
     {
         $this->status['queue'][$key] = $value;
         return $this;
     }
 
-    public function setStatusAvailability($key, $value)
+    public function setStatusAvailability($key, $value): static
     {
         $this->status['availability'][$key] = $value;
         return $this;

--- a/zmsentities/src/Zmsentities/Session.php
+++ b/zmsentities/src/Zmsentities/Session.php
@@ -21,6 +21,10 @@ class Session extends Schema\Entity
 
     public static $schema = "session.json";
 
+    /**
+     * @return ((int|int[]|string)[]|string)[][]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -105,6 +109,10 @@ class Session extends Schema\Entity
         return $this->toProperty()->content->basket->authKey->get();
     }
 
+    /**
+     * @return (int|string)|false|null
+     *
+     */
     public function getLastStep()
     {
         $steps = $this->toProperty()->content->human->step->get();
@@ -117,7 +125,7 @@ class Session extends Schema\Entity
         return $this->toProperty()->content->status->get();
     }
 
-    public function removeLastStep()
+    public function removeLastStep(): static
     {
         unset($this->content['human']['step'][$this->getLastStep()]);
         return $this;
@@ -145,67 +153,67 @@ class Session extends Schema\Entity
         return $this->toProperty()->content->entry->get();
     }
 
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return (! $this->hasProvider() && ! $this->hasRequests() && ! $this->hasScope()) ? true : false;
     }
 
-    public function isInChange()
+    public function isInChange(): bool
     {
         return ('inChange' == $this->getStatus()) ? true : false;
     }
 
-    public function isStalled()
+    public function isStalled(): bool
     {
         return ('stalled' == $this->getStatus()) ? true : false;
     }
 
-    public function isReserved()
+    public function isReserved(): bool
     {
         return ('reserved' == $this->getStatus()) ? true : false;
     }
 
-    public function isConfirmed()
+    public function isConfirmed(): bool
     {
         return ('confirmed' == $this->getStatus()) ? true : false;
     }
 
-    public function isPreconfirmed()
+    public function isPreconfirmed(): bool
     {
         return ('preconfirmed' == $this->getStatus()) ? true : false;
     }
 
-    public function isFinished()
+    public function isFinished(): bool
     {
         return ('finished' == $this->getStatus()) ? true : false;
     }
 
-    public function isProcessDeleted()
+    public function isProcessDeleted(): bool
     {
         return ! $this->hasProcess();
     }
 
-    public function hasStatus()
+    public function hasStatus(): bool
     {
         return (null === $this->getStatus()) ? false : true;
     }
 
-    public function hasProcess()
+    public function hasProcess(): bool
     {
         return (null === $this->getProcess()) ? false : true;
     }
 
-    public function hasAuthKey()
+    public function hasAuthKey(): bool
     {
         return (null === $this->getAuthKey()) ? false : true;
     }
 
-    public function hasChangedProcess()
+    public function hasChangedProcess(): bool
     {
         return ('inChange' == $this->getStatus()) ? true : false;
     }
 
-    public function hasPreviousAppointmentSearch()
+    public function hasPreviousAppointmentSearch(): bool
     {
         return ('inProgress' == $this->getStatus()) ? true : false;
     }
@@ -273,7 +281,7 @@ class Session extends Schema\Entity
          ) ? true : false;
     }
 
-    public function withOidcDataOnly()
+    public function withOidcDataOnly(): static
     {
         $entity = clone $this;
         if ($entity->toProperty()->content->basket->isAvailable()) {

--- a/zmsentities/src/Zmsentities/Slot.php
+++ b/zmsentities/src/Zmsentities/Slot.php
@@ -37,6 +37,10 @@ class Slot extends Schema\Entity
      */
     public const string TIMESTAMP = 'timestamp';
 
+    /**
+     * @return (int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -47,12 +51,12 @@ class Slot extends Schema\Entity
         ];
     }
 
-    public function setTime(Helper\DateTime $slotTime)
+    public function setTime(Helper\DateTime $slotTime): void
     {
         $this->time = $slotTime->format('H:i');
     }
 
-    public function hasTime()
+    public function hasTime(): bool
     {
         return ($this->toProperty()->time->get()) ? true : false;
     }
@@ -68,7 +72,7 @@ class Slot extends Schema\Entity
         return $this->toProperty()->time->get();
     }
 
-    public function removeAppointment()
+    public function removeAppointment(): static
     {
         if ($this->intern <= 0) {
             throw new Exception\SlotFull("Could not remove another appointment from $this");
@@ -80,7 +84,7 @@ class Slot extends Schema\Entity
         return $this;
     }
 
-    public function withAddedSlot(Slot $slot)
+    public function withAddedSlot(Slot $slot): self
     {
         $slot = clone $slot;
         $slot->type = 'sum';

--- a/zmsentities/src/Zmsentities/Source.php
+++ b/zmsentities/src/Zmsentities/Source.php
@@ -8,6 +8,10 @@ class Source extends Schema\Entity
 
     public static $schema = 'source.json';
 
+    /**
+     * @return (Collection\ProviderList|Collection\RequestList|Collection\RequestRelationList|Contact|false|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -40,7 +44,7 @@ class Source extends Schema\Entity
         return $this->toProperty()->contact->get();
     }
 
-    public function getProviderList()
+    public function getProviderList(): Collection\ProviderList
     {
         $providerList = new Collection\ProviderList();
         foreach ($this->toProperty()->providers->get() as $provider) {
@@ -52,7 +56,7 @@ class Source extends Schema\Entity
         return $providerList;
     }
 
-    public function getScopeList()
+    public function getScopeList(): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         $scopes = $this->toProperty()->scopes->get();
@@ -67,7 +71,7 @@ class Source extends Schema\Entity
         return $scopeList;
     }
 
-    public function getRequestList()
+    public function getRequestList(): Collection\RequestList
     {
         $requestList = new Collection\RequestList();
         $requests = $this->toProperty()->requests->get();
@@ -82,7 +86,7 @@ class Source extends Schema\Entity
         return $requestList;
     }
 
-    public function hasProvider($providerIdCsv)
+    public function hasProvider($providerIdCsv): bool
     {
         $providerIds = explode(',', $providerIdCsv);
         foreach ($providerIds as $providerId) {
@@ -93,7 +97,7 @@ class Source extends Schema\Entity
         return true;
     }
 
-    public function getRequestRelationList()
+    public function getRequestRelationList(): Collection\RequestRelationList
     {
         $requestRelationList = new \BO\Zmsentities\Collection\RequestRelationList();
         if (isset($this['requestrelation'])) {
@@ -107,7 +111,7 @@ class Source extends Schema\Entity
         return $requestRelationList;
     }
 
-    public function hasRequest($requestIdCsv)
+    public function hasRequest($requestIdCsv): bool
     {
         $requestIds = explode(',', $requestIdCsv);
         foreach ($requestIds as $requestId) {
@@ -118,12 +122,12 @@ class Source extends Schema\Entity
         return true;
     }
 
-    public function isEditable()
+    public function isEditable(): bool
     {
         return ($this->toProperty()->editable->get()) ? true : false;
     }
 
-    public function isCompleteAndEditable()
+    public function isCompleteAndEditable(): bool
     {
         $source = $this->getSource();
         if (empty($source) || !is_string($source)) {

--- a/zmsentities/src/Zmsentities/Status.php
+++ b/zmsentities/src/Zmsentities/Status.php
@@ -7,6 +7,10 @@ class Status extends Schema\Entity
     public const string PRIMARY = 'version';
     public static $schema = "status.json";
 
+    /**
+     * @return (float|int|string)[][]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {

--- a/zmsentities/src/Zmsentities/Ticketprinter.php
+++ b/zmsentities/src/Zmsentities/Ticketprinter.php
@@ -18,6 +18,10 @@ class Ticketprinter extends Schema\Entity
         'r' => 'request'
     ];
 
+    /**
+     * @return (false|int)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -27,7 +31,7 @@ class Ticketprinter extends Schema\Entity
         ];
     }
 
-    public function getHashWith($organisiationId)
+    public function getHashWith($organisiationId): static
     {
         $this->hash = $organisiationId . "abcdefghijklmnopqrstuvwxyz";
         //$this->hash = $organisiationId . bin2hex(openssl_random_pseudo_bytes(16));
@@ -39,7 +43,7 @@ class Ticketprinter extends Schema\Entity
         return $this->enabled;
     }
 
-    public function toStructuredButtonList()
+    public function toStructuredButtonList(): static
     {
         $ticketprinter = clone $this;
         $ticketprinter->buttons = array();
@@ -55,7 +59,7 @@ class Ticketprinter extends Schema\Entity
         return $ticketprinter;
     }
 
-    public function getScopeList()
+    public function getScopeList(): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         if ($this->toProperty()->buttons->isAvailable()) {
@@ -68,7 +72,7 @@ class Ticketprinter extends Schema\Entity
         return $scopeList;
     }
 
-    public function getClusterList()
+    public function getClusterList(): Collection\ClusterList
     {
         $clusterList = new Collection\ClusterList();
         if ($this->toProperty()->buttons->isAvailable()) {
@@ -81,7 +85,7 @@ class Ticketprinter extends Schema\Entity
         return $clusterList;
     }
 
-    protected function getValidButtonWithType($string)
+    protected function getValidButtonWithType(string $string): array
     {
         $type = $this->getButtonType($string);
         $value = $this->getButtonValue($string, $type);
@@ -93,7 +97,7 @@ class Ticketprinter extends Schema\Entity
         );
     }
 
-    protected function getButtonData($string, $button)
+    protected function getButtonData(string $string, $button)
     {
         $value = $this->getButtonValue($string, $this->getButtonType($string));
         if ('link' == $button['type']) {
@@ -120,7 +124,7 @@ class Ticketprinter extends Schema\Entity
         return $value->getValue();
     }
 
-    protected function getButtonType($string)
+    protected function getButtonType($string): string
     {
         return substr($string, 0, 1);
     }

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -15,6 +15,10 @@ class Useraccount extends Schema\Entity
 
     public static $schema = "useraccount.json";
 
+    /**
+     * @return (Collection\DepartmentList|false[])[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -55,7 +59,10 @@ class Useraccount extends Schema\Entity
         ];
     }
 
-    public function hasProperties()
+    /**
+     * @return true
+     */
+    public function hasProperties(): bool
     {
         foreach (func_get_args() as $property) {
             if (!$this->toProperty()->$property->get()) {
@@ -66,7 +73,7 @@ class Useraccount extends Schema\Entity
         return true;
     }
 
-    public function getDepartmentList()
+    public function getDepartmentList(): Collection\DepartmentList
     {
         if (!$this->departments instanceof Collection\DepartmentList) {
             $this->departments = new Collection\DepartmentList($this->departments);
@@ -77,7 +84,7 @@ class Useraccount extends Schema\Entity
         return $this->departments;
     }
 
-    public function addDepartment($department)
+    public function addDepartment(Department $department): static
     {
         $this->departments[] = $department;
         return $this;
@@ -106,7 +113,7 @@ class Useraccount extends Schema\Entity
     }
 
 
-    public function setPermissions()
+    public function setPermissions(): static
     {
         $givenPermissions = func_get_args();
         foreach ($givenPermissions as $permission) {
@@ -216,7 +223,7 @@ class Useraccount extends Schema\Entity
         return in_array($role, $this->getRoles(), true);
     }
 
-    public function testPermissions(array $requiredPermissions)
+    public function testPermissions(array $requiredPermissions): static
     {
         if (! $this->hasId()) {
             throw new Exception\UserAccountMissingLogin();
@@ -231,7 +238,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function testAnyPermission(array $requiredPermissions)
+    public function testAnyPermission(array $requiredPermissions): static
     {
         if (! $this->hasId()) {
             throw new Exception\UserAccountMissingLogin();
@@ -246,7 +253,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function isOveraged(\DateTimeInterface $dateTime)
+    public function isOveraged(\DateTimeInterface $dateTime): bool
     {
         if (Property::__keyExists('lastLogin', $this)) {
             $lastLogin = (new \DateTimeImmutable())->setTimestamp($this['lastLogin'])->modify('23:59:59');
@@ -260,7 +267,7 @@ class Useraccount extends Schema\Entity
         return $this->toProperty()->permissions?->superuser?->get() ?? false;
     }
 
-    public function getDepartmentById($departmentId)
+    public function getDepartmentById($departmentId): Department
     {
         foreach ($this->departments as $department) {
             if ($departmentId == $department['id']) {
@@ -270,7 +277,7 @@ class Useraccount extends Schema\Entity
         return new Department();
     }
 
-    public function getDepartmentByIds(array $departmentIds)
+    public function getDepartmentByIds(array $departmentIds): Department
     {
         foreach ($this->departments as $department) {
             if (in_array($department['id'], $departmentIds)) {
@@ -291,7 +298,7 @@ class Useraccount extends Schema\Entity
         return $department;
     }
 
-    public function setPassword($input)
+    public function setPassword($input): static
     {
         if (isset($input['password']) && '' != $input['password']) {
             $this->password = $input['password'];
@@ -305,7 +312,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function withDepartmentList()
+    public function withDepartmentList(): static
     {
         $departmentList = new Collection\DepartmentList();
         $entity = clone $this;
@@ -319,6 +326,9 @@ class Useraccount extends Schema\Entity
         return $entity;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function withCleanedUpFormData($keepPassword = false)
     {
@@ -362,7 +372,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function withVerifiedHash($password)
+    public function withVerifiedHash($password): static
     {
         $useraccount = clone $this;
         if ($useraccount->isPasswordNeedingRehash()) {
@@ -371,7 +381,7 @@ class Useraccount extends Schema\Entity
         return $useraccount;
     }
 
-    public function isPasswordNeedingRehash()
+    public function isPasswordNeedingRehash(): bool
     {
         return password_needs_rehash($this->password, PASSWORD_DEFAULT);
     }
@@ -381,12 +391,15 @@ class Useraccount extends Schema\Entity
      *
      * @return string $hash
     */
-    public function getHash($string)
+    public function getHash(string $string)
     {
         $hash = password_hash($string, PASSWORD_DEFAULT);
         return $hash;
     }
 
+    /**
+     * @return static
+     */
     #[\Override]
     public function withLessData()
     {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -84,7 +84,7 @@ class Useraccount extends Schema\Entity
         return $this->departments;
     }
 
-    public function addDepartment(Department $department): static
+    public function addDepartment(Department|array $department): static
     {
         $this->departments[] = $department;
         return $this;

--- a/zmsentities/src/Zmsentities/Workstation.php
+++ b/zmsentities/src/Zmsentities/Workstation.php
@@ -20,6 +20,10 @@ class Workstation extends Schema\Entity
 
     public static $schema = "workstation.json";
 
+    /**
+     * @return (Process|Scope|Useraccount|int|string)[]
+     *
+     */
     #[\Override]
     public function getDefaults()
     {
@@ -45,7 +49,7 @@ class Workstation extends Schema\Entity
         return $result;
     }
 
-    public function getUseraccount()
+    public function getUseraccount(): Useraccount
     {
         if (!$this->useraccount instanceof Useraccount) {
             $this->useraccount = new Useraccount($this->useraccount);
@@ -58,7 +62,7 @@ class Workstation extends Schema\Entity
         return $this->getUseraccount()->getDepartmentById($departmentId);
     }
 
-    public function getDepartmentList()
+    public function getDepartmentList(): Collection\DepartmentList
     {
         $departmentList = new Collection\DepartmentList();
         foreach ($this->getUseraccount()->departments as $department) {
@@ -67,6 +71,9 @@ class Workstation extends Schema\Entity
         return $departmentList;
     }
 
+    /**
+     * @return void
+     */
     public function testDepartmentList()
     {
         if (0 == $this->getDepartmentList()->count()) {
@@ -89,17 +96,17 @@ class Workstation extends Schema\Entity
         return $this->getUseraccount()->hasPermissions(['logs']);
     }
 
-    public function getAuthKey()
+    public function getAuthKey(): string
     {
         return bin2hex(openssl_random_pseudo_bytes(16));
     }
 
-    public function hasAuthKey()
+    public function hasAuthKey(): bool
     {
         return (isset($this->authkey)) ? true : false;
     }
 
-    public function getVariantName()
+    public function getVariantName(): string
     {
         return (! trim($this->name)) ? 'counter' : 'workstation';
     }
@@ -129,7 +136,7 @@ class Workstation extends Schema\Entity
         return $process;
     }
 
-    public function getScopeList($cluster = null)
+    public function getScopeList($cluster = null): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         $scopeList->addEntity(new Scope($this->getScope()));
@@ -140,7 +147,7 @@ class Workstation extends Schema\Entity
         return $scopeList;
     }
 
-    public function getScopeListFromAssignedDepartments()
+    public function getScopeListFromAssignedDepartments(): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         foreach ($this->getDepartmentList() as $department) {
@@ -154,6 +161,9 @@ class Workstation extends Schema\Entity
         return $scopeList;
     }
 
+    /**
+     * @return void
+     */
     public function validateProcessScopeAccess($scopeList, $process = null)
     {
         if (null === $process) {
@@ -180,7 +190,7 @@ class Workstation extends Schema\Entity
         }
     }
 
-    public function setValidatedName(array $formData)
+    public function setValidatedName(array $formData): static
     {
         if (isset($formData['workstation']) && trim($formData['workstation']->getValue())) {
             $this->name = $formData['workstation']->getValue();
@@ -190,7 +200,7 @@ class Workstation extends Schema\Entity
         return $this;
     }
 
-    public function setValidatedHint(array $formData)
+    public function setValidatedHint(array $formData): static
     {
         if (isset($formData['hint']) && $formData['hint']->getValue()) {
             $this->hint = $formData['hint']->getValue();
@@ -200,7 +210,7 @@ class Workstation extends Schema\Entity
         return $this;
     }
 
-    public function setValidatedScope(array $formData)
+    public function setValidatedScope(array $formData): static
     {
         if (isset($formData['scope']) && 'cluster' === $formData['scope']->getValue()) {
             $this->queue['clusterEnabled'] = 1;
@@ -213,7 +223,7 @@ class Workstation extends Schema\Entity
         return $this;
     }
 
-    public function setValidatedAppointmentsOnly(array $formData)
+    public function setValidatedAppointmentsOnly(array $formData): static
     {
         $this->queue['appointmentsOnly'] = (isset($formData['appointmentsOnly'])) ?
             $formData['appointmentsOnly']->getValue() :
@@ -221,12 +231,12 @@ class Workstation extends Schema\Entity
         return $this;
     }
 
-    public function isClusterEnabled()
+    public function isClusterEnabled(): bool
     {
         return $this->queue['clusterEnabled'] ? true : false;
     }
 
-    public function hasAccessToUseraccount($useraccount)
+    public function hasAccessToUseraccount($useraccount): bool
     {
         $departmentList = $this->getDepartmentList();
         $accessedList = $departmentList->withAccess($useraccount);

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -33,12 +33,12 @@ class BaseController
         return static::$logList;
     }
 
-    public static function clearLogList()
+    public static function clearLogList(): void
     {
         static::$logList = [];
     }
 
-    protected function getSpendTime()
+    protected function getSpendTime(): float
     {
         $time = round(microtime(true) - $this->startTime, 3);
         return $time;
@@ -59,7 +59,10 @@ class BaseController
         return $mailer;
     }
 
-    protected function removeEntityOlderThanOneHour($entity)
+    /**
+     * @return false|null
+     */
+    protected function removeEntityOlderThanOneHour(Mail $entity)
     {
         if (3600 < \App::$now->getTimestamp() - $entity->createTimestamp) {
             $this->deleteEntityFromQueue($entity);
@@ -71,7 +74,7 @@ class BaseController
         }
     }
 
-    public function deleteEntityFromQueue($entity)
+    public function deleteEntityFromQueue(Mail $entity): bool
     {
         if (!($entity instanceof Mail)) {
             return false;
@@ -87,7 +90,10 @@ class BaseController
         return (bool) $entity;
     }
 
-    public function testEntity($entity)
+    /**
+     * @return void
+     */
+    public function testEntity(Mail $entity)
     {
         if (!isset($entity['department'])) {
             throw new \Exception("Could not resolve department for message " . $entity['id']);
@@ -121,7 +127,7 @@ class BaseController
         }
     }
 
-    protected function monitorProcesses($processHandles)
+    protected function monitorProcesses(array $processHandles): void
     {
         $running = true;
         while ($running) {
@@ -155,7 +161,7 @@ class BaseController
 
 
 
-    public function log($message)
+    public function log(string $message): void
     {
         if (is_array($message)) {
             $message = print_r($message, true);
@@ -177,7 +183,7 @@ class BaseController
         }
     }
 
-    protected function convertCollectionToArray($collection)
+    protected function convertCollectionToArray($collection): array
     {
         $this->log("Converting collection to array");
         $array = [];

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -34,7 +34,11 @@ class Mail extends BaseController
         }
     }
 
-    public function initQueueTransmission($action = false)
+    /**
+     * @return (mixed|string[])[]
+     *
+     */
+    public function initQueueTransmission($action = false): array
     {
         $resultList = [];
         if ($this->messagesQueue && count($this->messagesQueue)) {
@@ -111,7 +115,11 @@ class Mail extends BaseController
         return $resultList;
     }
 
-    public function sendQueueItems($action, array $itemIds)
+    /**
+     * @return ((array|mixed|null|string)[]|string)[]
+     *
+     */
+    public function sendQueueItems($action, array $itemIds): array
     {
         $endpoint = '/mails/';
         $params = [
@@ -256,7 +264,7 @@ class Mail extends BaseController
      * @SuppressWarnings("CyclomaticComplexity")
      * @SuppressWarnings("NPathComplexity")
      */
-    protected function readMailer(MailEntity $entity)
+    protected function readMailer(MailEntity $entity): PHPMailer
     {
         $this->testEntity($entity);
         $encoding = 'base64';
@@ -314,7 +322,11 @@ class Mail extends BaseController
         return $mailer;
     }
 
-    private function startProcess($command, $ids)
+    /**
+     * @return (mixed|resource|resource[])[]|null
+     *
+     */
+    private function startProcess(string $command, string $ids): array|null
     {
         $descriptorSpec = [
             0 => ["pipe", "r"], // stdin

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- *
- */
-
 namespace BO\Zmsmessaging\PhpUnit;
 
 use BO\Zmsentities\Schema\Entity;
@@ -40,7 +36,7 @@ abstract class Base extends TestCase
     {
     }
 
-    protected function getApiMockup()
+    protected function getApiMockup(): object
     {
         $mock = $this->prophesize('BO\Zmsclient\Http');
         foreach ($this->getApiCalls() as $options) {
@@ -99,7 +95,7 @@ abstract class Base extends TestCase
         return $this->apiCalls;
     }
 
-    public function setApiCalls($apiCalls)
+    public function setApiCalls($apiCalls): void
     {
         $this->apiCalls = $apiCalls;
         \App::$http = $this->getApiMockup();

--- a/zmsslim/src/Slim/Bootstrap.php
+++ b/zmsslim/src/Slim/Bootstrap.php
@@ -26,7 +26,7 @@ class Bootstrap
 {
     protected static $instance = null;
 
-    public static function init()
+    public static function init(): void
     {
         Profiler::init();
         $bootstrap = self::getInstance();
@@ -85,19 +85,22 @@ class Bootstrap
         return false;
     }
 
-    public static function getInstance()
+    public static function getInstance(): self
     {
         self::$instance = (self::$instance instanceof Bootstrap) ? self::$instance : new self();
         return self::$instance;
     }
 
-    protected function configureAppStatics()
+    protected function configureAppStatics(): void
     {
         if (getenv('ZMS_URL_SIGNATURE_KEY') !== false) {
             App::$urlSignatureSecret = getenv('ZMS_URL_SIGNATURE_KEY');
         }
     }
 
+    /**
+     * @return never
+     */
     protected function configureLocale(
         $charset = App::CHARSET,
         $timezone = App::TIMEZONE
@@ -119,7 +122,7 @@ class Bootstrap
         'EMERGENCY' => Logger::EMERGENCY,
     );
 
-    protected function parseDebugLevel($level)
+    protected function parseDebugLevel(string $level)
     {
         return isset(static::$debuglevels[$level]) ? static::$debuglevels[$level] : static::$debuglevels['DEBUG'];
     }
@@ -205,7 +208,7 @@ class Bootstrap
         PhpErrorHandler::register();
     }
 
-    protected function configureSlim()
+    protected function configureSlim(): void
     {
         $container = $this->buildContainer();
 
@@ -264,7 +267,10 @@ class Bootstrap
         );
     }
 
-    public static function readCacheDir()
+    /**
+     * @return false|string
+     */
+    public static function readCacheDir(): string|false
     {
         $path = false;
         if (App::TWIG_CACHE) {
@@ -281,26 +287,29 @@ class Bootstrap
         return $path;
     }
 
-    public static function addTwigExtension($extension)
+    public static function addTwigExtension(TwigExtensionsAndFilter|DebugExtension|\Symfony\Bridge\Twig\Extension\TranslationExtension $extension): void
     {
         /** @var Twig $twig */
         $twig = App::$slim->getContainer()->get('view');
         $twig->addExtension($extension);
     }
 
-    public static function addTwigFilter($filter)
+    public static function addTwigFilter($filter): void
     {
         $twig = App::$slim->getContainer()->get('view');
         $twig->getEnvironment()->addFilter($filter);
     }
 
-    public static function addTwigTemplateDirectory($namespace, $path)
+    public static function addTwigTemplateDirectory($namespace, $path): void
     {
         $twig = App::$slim->getContainer()->get('view');
         $loader = $twig->getLoader();
         $loader->addPath($path, $namespace);
     }
 
+    /**
+     * @return void
+     */
     public static function loadRouting($filename)
     {
         $container = App::$slim->getContainer();

--- a/zmsslim/src/Slim/Bootstrap.php
+++ b/zmsslim/src/Slim/Bootstrap.php
@@ -287,7 +287,7 @@ class Bootstrap
         return $path;
     }
 
-    public static function addTwigExtension(TwigExtensionsAndFilter|DebugExtension|\Symfony\Bridge\Twig\Extension\TranslationExtension $extension): void
+    public static function addTwigExtension(\Twig\Extension\ExtensionInterface $extension): void
     {
         /** @var Twig $twig */
         $twig = App::$slim->getContainer()->get('view');

--- a/zmsslim/src/Slim/Controller.php
+++ b/zmsslim/src/Slim/Controller.php
@@ -60,7 +60,7 @@ abstract class Controller
     }
 
     // init the request with language translation
-    public static function prepareRequest(RequestInterface $request)
+    public static function prepareRequest(RequestInterface $request): RequestInterface
     {
         \App::$language = (\App::MULTILANGUAGE) ?
             new \BO\Slim\Language($request, \App::$supportedLanguages) :

--- a/zmsslim/src/Slim/Git.php
+++ b/zmsslim/src/Slim/Git.php
@@ -12,7 +12,7 @@ namespace BO\Slim;
   */
 class Git
 {
-    public static function readCurrentHead()
+    public static function readCurrentHead(): string|null
     {
         $headString = "no version control";
         $githead = \App::APP_PATH . '/.git/HEAD';
@@ -34,7 +34,11 @@ class Git
         return $headString;
     }
 
-    public static function readCurrentVersion()
+    /**
+     * @return null|string|string[]
+     *
+     */
+    public static function readCurrentVersion(): array|string|null
     {
         $headString = static::readCurrentHead();
         $headString = preg_replace('#refs/heads/#', '', $headString);

--- a/zmsslim/src/Slim/Helper.php
+++ b/zmsslim/src/Slim/Helper.php
@@ -8,18 +8,30 @@ namespace BO\Slim;
 
 class Helper
 {
-    public static function proxySanitizeUri($uri)
+    /**
+     * @param null|string|string[] $uri
+     *
+     *
+     * @return string|string[]
+     *
+     */
+    public static function proxySanitizeUri(array|string|null $uri): array|string
     {
         $uri = str_replace(':80/', '/', $uri);
         return $uri;
     }
 
+    /**
+     * @param \DateTimeImmutable|int $timestamp
+     *
+     * @return false|string
+     */
     public static function getFormatedDates(
-        $timestamp,
-        $pattern = 'MMMM',
+        int|\DateTimeImmutable $timestamp,
+        string $pattern = 'MMMM',
         $locale = 'de_DE',
         $timezone = 'Europe/Berlin'
-    ) {
+    ): string|false {
         $dateFormatter = new \IntlDateFormatter(
             $locale,
             \IntlDateFormatter::MEDIUM,
@@ -37,7 +49,7 @@ class Helper
         array $queryVariables,
         array $parameters,
         string $hashFunction = 'md5'
-    ) {
+    ): string {
         $content = $section . self::getContentForHash($queryVariables, $parameters);
         $hashString = $hashFunction($content . \App::$urlSignatureSecret);
         $firstHalf  = substr($hashString, 0, floor(strlen($hashString) / 2));
@@ -52,7 +64,7 @@ class Helper
         return $firstHalf;
     }
 
-    protected static function getContentForHash(array $queryVariables, array $parameters)
+    protected static function getContentForHash(array $queryVariables, array $parameters): string
     {
         $content = '';
         foreach ($parameters as $parameter) {

--- a/zmsslim/src/Slim/Helper/Sanitizer.php
+++ b/zmsslim/src/Slim/Helper/Sanitizer.php
@@ -13,7 +13,11 @@ final class Sanitizer
         return $trace;
     }
 
-    protected static function applyCatchAllPatterns($trace)
+    /**
+     * @return null|string|string[]
+     *
+     */
+    protected static function applyCatchAllPatterns($trace): array|string|null
     {
         $trace = preg_replace('/mysql:dbname=[^;]+;host=[^;]+;port=\d+/', 'mysql:dbname=***;host=***;port=***', $trace);
         $trace = preg_replace('/sqlite:[^;]+/', 'sqlite:***', $trace);

--- a/zmsslim/src/Slim/Language.php
+++ b/zmsslim/src/Slim/Language.php
@@ -72,7 +72,7 @@ class Language
         return $this->currentLocale;
     }
 
-    public function setCurrentLocale()
+    public function setCurrentLocale(): void
     {
         if (class_exists("Locale")) {
             \Locale::setDefault($this->currentLocale);
@@ -80,7 +80,11 @@ class Language
         \setlocale(LC_ALL, $this->getLocaleList($this->currentLocale));
     }
 
-    protected function getLocaleList($locale)
+    /**
+     * @return (mixed|string)[]
+     *
+     */
+    protected function getLocaleList($locale): array
     {
         $localeList[] = $this->getCurrentLanguage();
         $localeList[] = $locale;
@@ -122,7 +126,7 @@ class Language
         return $language;
     }
 
-    protected function getLanguageFromUri($request)
+    protected function getLanguageFromUri(RequestInterface $request)
     {
         $requestParamLang = $request->getParam('lang');
         return ($requestParamLang) ? $requestParamLang : $this->getDefault();

--- a/zmsslim/src/Slim/LanguageTranslator.php
+++ b/zmsslim/src/Slim/LanguageTranslator.php
@@ -41,7 +41,7 @@ class LanguageTranslator
         return $this->translator;
     }
 
-    protected function setJsonFileLoader()
+    protected function setJsonFileLoader(): void
     {
         $this->translator->addLoader('json', new JsonFileLoader());
         foreach (\App::$supportedLanguages as $language) {
@@ -53,7 +53,7 @@ class LanguageTranslator
         }
     }
 
-    protected function setPoFileLoader()
+    protected function setPoFileLoader(): void
     {
         $this->translator->addLoader('pofile', new PoFileLoader());
         foreach (\App::$supportedLanguages as $locale => $language) {

--- a/zmsslim/src/Slim/LoggerService.php
+++ b/zmsslim/src/Slim/LoggerService.php
@@ -261,6 +261,10 @@ class LoggerService
         return $path . ($queryParts ? '?' . implode('&', $queryParts) : '');
     }
 
+    /**
+     * @param (int|string) $key
+     *
+     */
     private static function formatQueryParamForLog(mixed $key, mixed $value): string
     {
         $encodedKey = urlencode((string) $key);

--- a/zmsslim/src/Slim/Middleware/IpAddress.php
+++ b/zmsslim/src/Slim/Middleware/IpAddress.php
@@ -131,7 +131,7 @@ class IpAddress
         return $ipAddress;
     }
 
-    protected function isCheckProxyHeaders($ipAddress)
+    protected function isCheckProxyHeaders($ipAddress): bool
     {
         $checkProxyHeaders = $this->checkProxyHeaders;
         if ($checkProxyHeaders && ($this->trustedProxies === true || !empty($this->trustedProxies))) {

--- a/zmsslim/src/Slim/Middleware/OAuth/KeycloakInstance.php
+++ b/zmsslim/src/Slim/Middleware/OAuth/KeycloakInstance.php
@@ -25,7 +25,7 @@ class KeycloakInstance
         return $this->provider;
     }
 
-    public function doLogin(ServerRequestInterface $request, ResponseInterface $response)
+    public function doLogin(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         \App::$log->info('OIDC login attempt', [
             'event' => 'oauth_login_start',
@@ -67,14 +67,14 @@ class KeycloakInstance
         return $response;
     }
 
-    public function doLogout(ResponseInterface $response)
+    public function doLogout(ResponseInterface $response): ResponseInterface
     {
         $this->writeDeleteSession();
         $realmData = $this->provider->getBasicOptionsFromJsonFile();
         return $response->withStatus(301)->withHeader('Location', $realmData['logoutUri']);
     }
 
-    public function writeNewAccessTokenIfExpired()
+    public function writeNewAccessTokenIfExpired(): bool
     {
         try {
             $accessTokenData = $this->readTokenDataFromSession();
@@ -93,6 +93,9 @@ class KeycloakInstance
         return true;
     }
 
+    /**
+     * @return void
+     */
     private function validateAccess(AccessToken $token)
     {
         \App::$log->info('Validating OIDC token', [
@@ -203,6 +206,9 @@ class KeycloakInstance
         ]);
     }
 
+    /**
+     * @return void
+     */
     private function validateOwnerData(array $ownerInputData)
     {
         $config = $this->oauthService->readConfig();
@@ -239,7 +245,7 @@ class KeycloakInstance
         }
     }
 
-    private function writeTokenToSession($token)
+    private function writeTokenToSession(AccessToken $token): bool
     {
         \App::$log->info('Writing token to session', [
             'event' => 'oauth_write_token',
@@ -253,7 +259,7 @@ class KeycloakInstance
         return $sessionHandler->close();
     }
 
-    private function writeDeleteSession()
+    private function writeDeleteSession(): void
     {
         \App::$log->info('Deleting session', [
             'event' => 'oauth_delete_session',

--- a/zmsslim/src/Slim/Middleware/Session/SessionContainer.php
+++ b/zmsslim/src/Slim/Middleware/Session/SessionContainer.php
@@ -8,24 +8,30 @@ class SessionContainer implements SessionInterface
 
     private $sessionLoader;
 
-    public static function fromContainer(callable $sessionLoader)
+    public static function fromContainer(callable $sessionLoader): static
     {
         $instance = new static();
         $instance->sessionLoader = $sessionLoader;
         return $instance;
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function setGroup(array $group, $clear = false)
     {
         $this->getSession()->setGroup($group, $clear);
     }
 
-    public function writeData()
+    public function writeData(): void
     {
         $this->getSession()->writeData();
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function set($key, $value, $groupIndex = null)
     {
@@ -44,23 +50,32 @@ class SessionContainer implements SessionInterface
         return $this->getSession()->getEntity();
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function remove($key, $groupIndex = null)
     {
         $this->getSession()->remove($key, $groupIndex);
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function clear()
     {
         $this->getSession()->clear();
     }
 
-    public function restart()
+    public function restart(): void
     {
         $this->getSession()->restart();
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function clearGroup($groupIndex = null)
     {

--- a/zmsslim/src/Slim/Middleware/Session/SessionData.php
+++ b/zmsslim/src/Slim/Middleware/Session/SessionData.php
@@ -53,12 +53,15 @@ class SessionData implements SessionInterface
         return $instance;
     }
 
-    public function writeData()
+    public function writeData(): void
     {
         session_write_close();
         $this->isLocked = true;
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function setGroup(array $group, $clear)
     {
@@ -75,10 +78,13 @@ class SessionData implements SessionInterface
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
      *
      * @return array
+     *
+     * @param (int|string) $key
+     * @param (int|string)|null $groupIndex
+     *
      */
     #[\Override]
     public function set($key, $value, $groupIndex = null)
@@ -117,12 +123,15 @@ class SessionData implements SessionInterface
         return $sessionContent;
     }
 
-    public function setEntityClass($entityClass)
+    public function setEntityClass(object $entityClass): static
     {
         $this->entityClass = $entityClass;
         return $this;
     }
 
+    /**
+     * @return void
+     */
     #[\Override]
     public function remove($key, $groupIndex = null)
     {
@@ -134,10 +143,12 @@ class SessionData implements SessionInterface
     }
 
     /**
-     *
      * @SuppressWarnings(Superglobals)
      *
      * @return self
+     *
+     * @param (int|string)|null $groupIndex
+     *
      */
     #[\Override]
     public function clearGroup($groupIndex = null)
@@ -179,6 +190,9 @@ class SessionData implements SessionInterface
         }
     }
 
+    /**
+     * @return bool|null
+     */
     #[\Override]
     public function has($key, $groupIndex = null)
     {
@@ -191,6 +205,9 @@ class SessionData implements SessionInterface
         }
     }
 
+    /**
+     * @return bool
+     */
     #[\Override]
     public function isEmpty()
     {

--- a/zmsslim/src/Slim/Middleware/Session/SessionData.php
+++ b/zmsslim/src/Slim/Middleware/Session/SessionData.php
@@ -123,7 +123,7 @@ class SessionData implements SessionInterface
         return $sessionContent;
     }
 
-    public function setEntityClass(object $entityClass): static
+    public function setEntityClass($entityClass): static
     {
         $this->entityClass = $entityClass;
         return $this;

--- a/zmsslim/src/Slim/Middleware/Session/SessionHuman.php
+++ b/zmsslim/src/Slim/Middleware/Session/SessionHuman.php
@@ -13,7 +13,7 @@ class SessionHuman extends SessionContainer
 
     const int MIN_TIME = 3;
 
-    public function writeVerifySession($request, $origin = '')
+    public function writeVerifySession($request, $origin = ''): void
     {
         $clientIp = $request->getAttribute('ip_address');
         $this->set('client', 1, 'human');
@@ -24,7 +24,7 @@ class SessionHuman extends SessionContainer
         $this->set('remoteAddress', $clientIp, 'human');
     }
 
-    public function writeBotSession($origin = '')
+    public function writeBotSession($origin = ''): void
     {
         $this->set('client', 0, 'human');
         $this->set('ts', 0, 'human');
@@ -73,7 +73,7 @@ class SessionHuman extends SessionContainer
         return false;
     }
 
-    public function isOverAged()
+    public function isOverAged(): bool
     {
         if (!$this->has('ts', 'human') || time() > ($this->get('ts', 'human') + self::MAX_TIME)) {
             return true;
@@ -81,7 +81,7 @@ class SessionHuman extends SessionContainer
         return false;
     }
 
-    public function isUnderAged()
+    public function isUnderAged(): bool
     {
         if (!$this->has('ts', 'human') || time() < ($this->get('ts', 'human') + self::MIN_TIME)) {
             return true;
@@ -139,7 +139,7 @@ class SessionHuman extends SessionContainer
         return false;
     }
 
-    public function isVerified()
+    public function isVerified(): bool
     {
         if ($this->has('client', 'human') && $this->get('client', 'human')) {
             return true;
@@ -151,8 +151,9 @@ class SessionHuman extends SessionContainer
      * check if is origin
      *
      * @return boolean
+     *
      */
-    protected function isOrigin($originName)
+    protected function isOrigin(string $originName)
     {
         if ($this->has('origin', 'human') && $originName == $this->get('origin', 'human')) {
             return true;

--- a/zmsslim/src/Slim/Middleware/SessionMiddleware.php
+++ b/zmsslim/src/Slim/Middleware/SessionMiddleware.php
@@ -38,7 +38,7 @@ class SessionMiddleware
         return $response;
     }
 
-    public function getSessionContainer($request)
+    public function getSessionContainer(ServerRequestInterface $request): Session\SessionData
     {
         $session = Session\SessionData::getSession($request);
         $session->setEntityClass($this->sessionClass);

--- a/zmsslim/src/Slim/Middleware/Validator.php
+++ b/zmsslim/src/Slim/Middleware/Validator.php
@@ -9,9 +9,6 @@ use BO\Slim\Factory\ResponseFactory;
 
 class Validator
 {
-    /**
-     *
-     */
     public function __invoke(
         ServerRequestInterface $request,
         ?RequestHandlerInterface $next
@@ -25,7 +22,7 @@ class Validator
         return $response;
     }
 
-    public static function withValidator(ServerRequestInterface $request)
+    public static function withValidator(ServerRequestInterface $request): ServerRequestInterface
     {
         if ("GET" == $request->getMethod()) {
             $validator = new \BO\Mellon\Validator($request->getQueryParams());

--- a/zmsslim/src/Slim/Middleware/ZmsSlimRequest.php
+++ b/zmsslim/src/Slim/Middleware/ZmsSlimRequest.php
@@ -31,7 +31,7 @@ class ZmsSlimRequest
         return $next->handle($decoratedRequest);
     }
 
-    public static function getDecoratedRequest(Request $request)
+    public static function getDecoratedRequest(Request $request): \BO\Slim\Request
     {
         $zmsSlimRequest = new \BO\Slim\Request(
             $request->getMethod(),

--- a/zmsslim/src/Slim/PhpUnit/Base.php
+++ b/zmsslim/src/Slim/PhpUnit/Base.php
@@ -174,7 +174,7 @@ abstract class Base extends TestCase
 
     protected function render(
         array $arguments = [],
-        $parameters = [],
+        array $parameters = [],
         $sessionData = null,
         $method = 'GET'
     ) {
@@ -231,7 +231,7 @@ abstract class Base extends TestCase
         return $request;
     }
 
-    protected function setValidatorInstance($parameters)
+    protected function setValidatorInstance(array $parameters): void
     {
         $validator = new \BO\Mellon\Validator($parameters);
         if (array_key_exists('__body', $parameters)) {
@@ -240,7 +240,7 @@ abstract class Base extends TestCase
         $validator->makeInstance();
     }
 
-    public function assertRedirect($response, $uri, $status = 302)
+    public function assertRedirect($response, $uri, $status = 302): void
     {
         $this->assertEquals($status, $response->getStatusCode());
         $this->assertEquals($uri, $response->getHeaderLine('Location'));

--- a/zmsslim/src/Slim/Profiler.php
+++ b/zmsslim/src/Slim/Profiler.php
@@ -9,9 +9,8 @@ class Profiler
 
     /**
      * @SuppressWarnings(Superglobal)
-     *
      */
-    public static function init()
+    public static function init(): void
     {
         static::$startupMicrotime = microtime(true);
         if (isset($_SERVER["REQUEST_TIME_FLOAT"])) {
@@ -19,20 +18,20 @@ class Profiler
         }
     }
 
-    public static function add($message)
+    public static function add(string $message): static
     {
         $profile = new static($message);
         static::$profileList[] = $profile;
         return $profile;
     }
 
-    public static function addMemoryPeak($message = 'Mem')
+    public static function addMemoryPeak($message = 'Mem'): void
     {
         $memoryKb = round(memory_get_peak_usage() / 1024, 0);
         static::add("$message " . $memoryKb . "kb");
     }
 
-    public static function getList()
+    public static function getList(): string
     {
         return implode(";", static::$profileList);
     }
@@ -48,7 +47,7 @@ class Profiler
         $this->includedFiles = count(get_included_files());
     }
 
-    public function getSeconds()
+    public function getSeconds(): float
     {
         return round(($this->instanceMicrotime - static::$startupMicrotime), 3);
     }

--- a/zmsslim/src/Slim/Render.php
+++ b/zmsslim/src/Slim/Render.php
@@ -38,7 +38,7 @@ class Render
     /**
      * @return ResponseInterface
      */
-    public static function withHtml(ResponseInterface $response, $template, $parameters = array(), $status = 200)
+    public static function withHtml(ResponseInterface $response, $template, array $parameters = array(), $status = 200)
     {
         Profiler::add("Controller");
         $response  = $response->withStatus($status);
@@ -65,7 +65,7 @@ class Render
         return self::$response;
     }
 
-    public static function withXml(ResponseInterface $response, $data, $status = 200)
+    public static function withXml(ResponseInterface $response, $data, $status = 200): ResponseInterface
     {
         Profiler::add("Controller");
         $response = $response->withStatus($status);
@@ -75,7 +75,7 @@ class Render
         return $response;
     }
 
-    public static function withJson(ResponseInterface $response, $data, $status = 200)
+    public static function withJson(ResponseInterface $response, $data, $status = 200): ResponseInterface
     {
         Profiler::add("Controller");
         $response = $response->withStatus($status);
@@ -106,13 +106,16 @@ class Render
     /**
      * Add `Last-Modified` header to PSR7 response object
      *
-     * @param  ResponseInterface $response A PSR7 response object
-     * @param  int|string        $time     A UNIX timestamp or a valid `strtotime()` string
+     * @param ResponseInterface $response A PSR7 response object
+     * @param int|string        $time     A UNIX timestamp or a valid `strtotime()` string
+     * @param int|string $date
      *
      * @return ResponseInterface           A new PSR7 response object with `Last-Modified` header
+     *
      * @throws InvalidArgumentException if the last modified date cannot be parsed
+     *
      */
-    public static function withLastModified(ResponseInterface $response, $date, $expires = '+5 minutes')
+    public static function withLastModified(ResponseInterface $response, string|int $date, string $expires = '+5 minutes')
     {
         return self::getCachableResponse($response, $date, $expires);
     }
@@ -164,10 +167,10 @@ class Render
      * @param array $arguments parameters in the route path
      * @param array $parameter parameters to append with "?"
      * @param Int $statuscode see an HTTP reference
-     *
+
      * \Psr\Http\Message\ResponseInterface
      */
-    public static function redirect($route_name, $arguments, $parameter = null, $statuscode = 302)
+    public static function redirect($route_name, $arguments, $parameter = null, $statuscode = 302): Response
     {
         Profiler::add("Controller");
 

--- a/zmsslim/src/Slim/TwigExceptionHandler.php
+++ b/zmsslim/src/Slim/TwigExceptionHandler.php
@@ -12,9 +12,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Interfaces\ErrorHandlerInterface;
 
-/**
-  *
-  */
 class TwigExceptionHandler implements ErrorHandlerInterface
 {
     const string DEFAULT_TEMPLATE = "exception/default.twig";
@@ -133,7 +130,10 @@ class TwigExceptionHandler implements ErrorHandlerInterface
         return $template;
     }
 
-    protected static function getRequestData(RequestInterface $request)
+    /**
+     * @return false|string
+     */
+    protected static function getRequestData(RequestInterface $request): string|false
     {
         $requestdata = array_merge((array)$request->getQueryParams(), (array)$request->getParsedBody());
         $json_opt = JSON_HEX_TAG | JSON_PRETTY_PRINT | JSON_HEX_AMP;
@@ -145,7 +145,7 @@ class TwigExceptionHandler implements ErrorHandlerInterface
         return $requestdata;
     }
 
-    public static function getExtendedExceptionInfo(\Throwable $exception, RequestInterface $request)
+    public static function getExtendedExceptionInfo(\Throwable $exception, RequestInterface $request): array
     {
         $servertime = Helper::getFormatedDates((new \DateTimeImmutable())->getTimestamp(), 'yyyy-MM-dd HH:mm:ss');
         $exceptionclass = get_class($exception);

--- a/zmsslim/src/Slim/TwigExtension.php
+++ b/zmsslim/src/Slim/TwigExtension.php
@@ -29,7 +29,7 @@ class TwigExtension extends AbstractExtension
         $this->container = $container;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'boslimExtension';
     }
@@ -75,12 +75,12 @@ class TwigExtension extends AbstractExtension
         return $language['name'] ?? null;
     }
 
-    public static function isNumeric($var)
+    public static function isNumeric($var): bool
     {
         return is_numeric($var);
     }
 
-    public static function getNow()
+    public static function getNow(): \DateTimeInterface
     {
         if (\App::$now instanceof \DateTimeInterface) {
             return \App::$now;
@@ -88,12 +88,15 @@ class TwigExtension extends AbstractExtension
         return new \DateTimeImmutable();
     }
 
-    public static function getSystemStatus($env)
+    /**
+     * @return false|string
+     */
+    public static function getSystemStatus($env): string|false
     {
         return getenv($env);
     }
 
-    public function toTextFormat($string)
+    public function toTextFormat($string): string
     {
         $string = \strip_tags($string, '<br />');
         $temp = str_replace(array("<br />"), "\n", $string);
@@ -108,7 +111,11 @@ class TwigExtension extends AbstractExtension
         return addSlashes($result);
     }
 
-    public function formatDateTime($dateString)
+    /**
+     * @return (false|float|int|mixed|string)[]
+     *
+     */
+    public function formatDateTime($dateString): array
     {
         $dateTime = new \DateTimeImmutable(
             $dateString->year . '-' . $dateString->month . '-' . $dateString->day,
@@ -128,7 +135,11 @@ class TwigExtension extends AbstractExtension
         return $formatDate;
     }
 
-    public function currentRoute($lang = null)
+    /**
+     * @return (array|mixed|string)[]
+     *
+     */
+    public function currentRoute($lang = null): array
     {
         $route = array(
             'name' => 'noroute',
@@ -156,7 +167,7 @@ class TwigExtension extends AbstractExtension
         return (\App::MULTILANGUAGE) ? \App::$language->getCurrentLanguage() : 'de';
     }
 
-    public function currentLocale()
+    public function currentLocale(): string
     {
         $locale = 'de_DE';
         if (\App::MULTILANGUAGE) {
@@ -182,7 +193,7 @@ class TwigExtension extends AbstractExtension
         return Helper::proxySanitizeUri($url);
     }
 
-    public function csvProperty($list, $property)
+    public function csvProperty($list, $property): string
     {
         $propertylist = array();
         foreach ($list as $item) {
@@ -193,7 +204,11 @@ class TwigExtension extends AbstractExtension
         return implode(',', array_unique($propertylist));
     }
 
-    public function azPrefixList($list, $property)
+    /**
+     * @return (array|mixed)[][]
+     *
+     */
+    public function azPrefixList($list, $property): array
     {
         $azList = array();
         foreach ($list as $item) {
@@ -213,7 +228,11 @@ class TwigExtension extends AbstractExtension
         return $azList;
     }
 
-    public function azPrefixListCollator($list, $property, $locale)
+    /**
+     * @return (array|mixed)[][]
+     *
+     */
+    public function azPrefixListCollator($list, $property, $locale): array
     {
         $collator = collator_create($locale);
         $collator->setAttribute(\Collator::QUATERNARY, \Collator::ON);
@@ -243,7 +262,7 @@ class TwigExtension extends AbstractExtension
         return $azList;
     }
 
-    public function isValueInArray($value, $params)
+    public function isValueInArray($value, $params): bool
     {
         $paramsArr = explode(',', $params);
         if (in_array($value, $paramsArr)) {
@@ -252,7 +271,7 @@ class TwigExtension extends AbstractExtension
         return false;
     }
 
-    public static function remoteInclude($uri)
+    public static function remoteInclude($uri): string
     {
         $prepend = '';
         $append = '';
@@ -282,7 +301,7 @@ class TwigExtension extends AbstractExtension
         }
     }
 
-    public function getEsiFromPath($path, $locale = false)
+    public function getEsiFromPath($path, $locale = false): string
     {
         $localePath = ($locale && 'de' != $locale) ? '/' . $locale : '';
         return \App::$esiBaseUrl . $localePath . \App::$$path;
@@ -300,7 +319,7 @@ class TwigExtension extends AbstractExtension
         return $hostname;
     }
 
-    protected static function toSortableString($string)
+    protected static function toSortableString(string $string): string
     {
         $string = strtr($string, array(
             'Ä' => 'Ae',
@@ -315,7 +334,7 @@ class TwigExtension extends AbstractExtension
         return $string;
     }
 
-    protected static function sortByName($left, $right)
+    protected static function sortByName($left, $right): int
     {
         return strcmp(
             self::toSortableString(strtolower($left['name'])),
@@ -323,7 +342,7 @@ class TwigExtension extends AbstractExtension
         );
     }
 
-    protected static function sortFirstChar($string)
+    protected static function sortFirstChar($string): string
     {
         $firstChar = mb_substr($string, 0, 1);
         $firstChar = mb_strtoupper($firstChar);
@@ -331,7 +350,7 @@ class TwigExtension extends AbstractExtension
         return $firstChar;
     }
 
-    public function dumpAppProfiler()
+    public function dumpAppProfiler(): string
     {
         $output = '<h2>App Profiles</h2>'
             . ' <p>For debugging: This log contains runtime information.
@@ -346,7 +365,7 @@ class TwigExtension extends AbstractExtension
         return $output . '</ul>';
     }
 
-    public function kindOfPayment($code)
+    public function kindOfPayment($code): string
     {
         $result = '';
         if ($code == 0) {

--- a/zmsslim/src/Slim/TwigExtensionsAndFilter.php
+++ b/zmsslim/src/Slim/TwigExtensionsAndFilter.php
@@ -24,7 +24,7 @@ class TwigExtensionsAndFilter extends TwigExtension
         );
     }
 
-    public function decodeEntities($string)
+    public function decodeEntities($string): string
     {
         return $string === null ? '' : trim(nl2br(html_entity_decode($string)));
     }
@@ -58,7 +58,7 @@ class TwigExtensionsAndFilter extends TwigExtension
         return $array;
     }
 
-    public function getObjectName($object)
+    public function getObjectName($object): string
     {
         return (new \ReflectionClass($object))->getShortName();
     }

--- a/zmsslim/src/Slim/Version.php
+++ b/zmsslim/src/Slim/Version.php
@@ -15,7 +15,11 @@ class Version
         return static::UNKNOWN;
     }
 
-    public static function getArray()
+    /**
+     * @return string[]
+     *
+     */
+    public static function getArray(): array
     {
         $version = static::getString();
         $array = [];

--- a/zmsstatistic/src/Zmsstatistic/Download/Base.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/Base.php
@@ -135,7 +135,7 @@ class Base extends BaseController
         return $spreadsheet;
     }
 
-    protected function writeInfoHeader(array $args, Spreadsheet $spreadsheet)
+    protected function writeInfoHeader(array $args, Spreadsheet $spreadsheet): Spreadsheet|null
     {
         $sheet = $spreadsheet->getActiveSheet();
         $infoData[] = static::$subjectTranslations[$args['category']];
@@ -179,7 +179,7 @@ class Base extends BaseController
         return $spreadsheet;
     }
 
-    protected function setDateTime($dateString)
+    protected function setDateTime($dateString): \DateTime
     {
         $dateArr = explode('-', $dateString);
         if (2 == count($dateArr)) {
@@ -194,7 +194,10 @@ class Base extends BaseController
         return new \DateTime($dateString);
     }
 
-    protected function getFormatedDates($date, $pattern = 'MMMM')
+    /**
+     * @return false|string
+     */
+    protected function getFormatedDates($date, $pattern = 'MMMM'): string|false
     {
         $dateFormatter = new \IntlDateFormatter(
             'de-DE',

--- a/zmsstatistic/src/Zmsstatistic/Download/ClientReport.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/ClientReport.php
@@ -45,10 +45,10 @@ class ClientReport extends Base
     public function writeReport(
         ReportEntity $report,
         Spreadsheet $spreadsheet,
-        $datePatternTotals = 'MMMM',
-        $datePatternCol1 = 'ccc',
-        $datePatternCol2 = 'dd.MM.yy'
-    ) {
+        string $datePatternTotals = 'MMMM',
+        string $datePatternCol1 = 'ccc',
+        string $datePatternCol2 = 'dd.MM.yy'
+    ): Spreadsheet {
         $sheet = $spreadsheet->getActiveSheet();
         $this->writeReportHeader($report, $sheet);
         $this->writeTotalsRow($report, $sheet, $datePatternTotals);
@@ -57,7 +57,7 @@ class ClientReport extends Base
         return $spreadsheet;
     }
 
-    public function writeReportHeader(ReportEntity $report, $sheet)
+    public function writeReportHeader(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet): void
     {
         $reportHeader = [];
         if ('totals' == end($report->data)['date'] || 'month' == $report->period) {
@@ -85,7 +85,7 @@ class ClientReport extends Base
         $sheet->fromArray($reportHeader, null, 'A' . ($sheet->getHighestRow() + 2));
     }
 
-    public function writeTotalsRow(ReportEntity $report, $sheet, $datePatternTotals)
+    public function writeTotalsRow(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $datePatternTotals): void
     {
         if ('totals' == end($report->data)['date']) {
             $totals = array_pop($report->data);
@@ -116,7 +116,7 @@ class ClientReport extends Base
         }
     }
 
-    public function writeReportData(ReportEntity $report, $sheet, $datePatternCol1, $datePatternCol2)
+    public function writeReportData(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $datePatternCol1, $datePatternCol2): void
     {
         $reportData = [];
 
@@ -150,7 +150,7 @@ class ClientReport extends Base
         $sheet->fromArray($reportData, null, 'A' . ($sheet->getHighestRow() + 1));
     }
 
-    private function calculateNoAppointment($totals)
+    private function calculateNoAppointment($totals): string
     {
         if (isset($totals['clientscount']) && isset($totals['withappointment'])) {
             return (string) ($totals['clientscount'] - $totals['withappointment']);
@@ -158,7 +158,7 @@ class ClientReport extends Base
         return 'N/A';
     }
 
-    private function calculateMissedNoAppointment($totals)
+    private function calculateMissedNoAppointment($totals): string
     {
         if (isset($totals['missed']) && isset($totals['missedwithappointment'])) {
             return (string) ($totals['missed'] - $totals['missedwithappointment']);
@@ -166,7 +166,7 @@ class ClientReport extends Base
         return 'N/A';
     }
 
-    private function calculateNoAppointmentForRow($entry)
+    private function calculateNoAppointmentForRow($entry): string
     {
         if (isset($entry['clientscount']) && isset($entry['withappointment'])) {
             return (string) ($entry['clientscount'] - $entry['withappointment']);
@@ -174,7 +174,7 @@ class ClientReport extends Base
         return 'N/A';
     }
 
-    private function calculateMissedNoAppointmentForRow($entry)
+    private function calculateMissedNoAppointmentForRow($entry): string
     {
         if (isset($entry['missed']) && isset($entry['missedwithappointment'])) {
             return (string) ($entry['missed'] - $entry['missedwithappointment']);

--- a/zmsstatistic/src/Zmsstatistic/Download/RequestReport.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/RequestReport.php
@@ -53,8 +53,8 @@ class RequestReport extends Base
     public function writeReport(
         ReportEntity $report,
         Spreadsheet $spreadsheet,
-        $datePatternCol = 'dd.MM.yyyy'
-    ) {
+        string $datePatternCol = 'dd.MM.yyyy'
+    ): Spreadsheet {
         $sheet = $spreadsheet->getActiveSheet();
 
         $firstDay = $report->firstDay->year . '-' . $report->firstDay->month . '-' . $report->firstDay->day;
@@ -68,7 +68,7 @@ class RequestReport extends Base
         return $spreadsheet;
     }
 
-    public function writeHeader(ReportEntity $report, $sheet, $datePatternCol)
+    public function writeHeader(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $datePatternCol): void
     {
         $reportHeader = [];
         $reportHeader[] = 'Dienstleistung';
@@ -85,7 +85,7 @@ class RequestReport extends Base
     /**
      * @SuppressWarnings(Unused)
      */
-    public function writeReportData(ReportEntity $report, $sheet)
+    public function writeReportData(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet): void
     {
         $reportData = [];
         $firstDataRow = $sheet->getHighestRow() + 1;

--- a/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
+++ b/zmsstatistic/src/Zmsstatistic/Download/WaitingReport.php
@@ -100,8 +100,8 @@ class WaitingReport extends Base
         ReportEntity $report,
         Spreadsheet $spreadsheet,
         string $customerType,
-        $datePatternCol = 'dd.MM.yyyy',
-    ) {
+        string $datePatternCol = 'dd.MM.yyyy',
+    ): Spreadsheet {
         $this->assertValidCustomerType($customerType);
 
         $sheet = $spreadsheet->getActiveSheet();
@@ -121,7 +121,7 @@ class WaitingReport extends Base
         return $spreadsheet;
     }
 
-    public function writeHeader(ReportEntity $report, $sheet, $datePatternCol)
+    public function writeHeader(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $datePatternCol): void
     {
         $reportHeader = [];
         $reportHeader[] = null;
@@ -169,7 +169,7 @@ class WaitingReport extends Base
         return $keyMappings[$customerType];
     }
 
-    public function writeTotals(ReportEntity $report, $sheet, string $customerType)
+    public function writeTotals(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, string $customerType): void
     {
         $this->assertValidCustomerType($customerType);
 
@@ -195,7 +195,7 @@ class WaitingReport extends Base
         $sheet->fromArray($reportTotal, null, 'A' . ($sheet->getHighestRow() + 1));
     }
 
-    public function writeReportPart(ReportEntity $report, $sheet, $rangeName, $headline)
+    public function writeReportPart(ReportEntity $report, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $rangeName, $headline): void
     {
         $entity = clone $report;
         $totals = $entity->data['max'];

--- a/zmsstatistic/src/Zmsstatistic/Healthcheck.php
+++ b/zmsstatistic/src/Zmsstatistic/Healthcheck.php
@@ -18,6 +18,8 @@ class Healthcheck extends BaseController
 
     /**
      * @SuppressWarnings(UnusedFormalParameter)
+     *
+     * @return ResponseInterface
      */
     #[\Override]
     public function readResponse(

--- a/zmsstatistic/src/Zmsstatistic/Helper/Access.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/Access.php
@@ -29,7 +29,7 @@ class Access extends \BO\Slim\Controller
 
     protected $owner = null;
 
-    protected function initAccessRights($request)
+    protected function initAccessRights($request): void
     {
         $this->workstation = $this->readWorkstation();
         if ($this->workstation && isset($this->workstation->scope['id']) && $this->workstation->scope['id'] > 0) {
@@ -73,13 +73,16 @@ class Access extends \BO\Slim\Controller
         }
     }
 
-    protected function validateAccessRights($request)
+    protected function validateAccessRights($request): void
     {
         $path = $request->getUri()->getPath();
         $this->validateAccess($path);
         $this->validateScope($path);
     }
 
+    /**
+     * @return void
+     */
     protected function validateAccess($path)
     {
         if (
@@ -91,6 +94,9 @@ class Access extends \BO\Slim\Controller
         }
     }
 
+    /**
+     * @return void
+     */
     protected function validateScope($path)
     {
         if (
@@ -101,7 +107,7 @@ class Access extends \BO\Slim\Controller
         }
     }
 
-    protected function isPathWithoutScope($path)
+    protected function isPathWithoutScope($path): bool
     {
         // TODO: refactor to integrate these access rules in the controller to make them visible
         return (false === strpos($path, 'select')
@@ -111,6 +117,10 @@ class Access extends \BO\Slim\Controller
         );
     }
 
+    /**
+     * @return (mixed|string|string[][][])[]|Workstation
+     *
+     */
     protected function testLogin($input)
     {
         $userAccount = new Useraccount(array(

--- a/zmsstatistic/src/Zmsstatistic/Helper/Download.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/Download.php
@@ -72,12 +72,12 @@ class Download
     }
 
     public function setSpreadSheet(
-        $title = 'statistic',
+        string $title = 'statistic',
         $creator = 'berlinonline',
         $subject = '',
         $description = 'statistic document',
         $keywords = 'statistic zms'
-    ) {
+    ): static {
         $this->title = $title;
         $this->spreadsheet = new Spreadsheet();
         $this->spreadsheet

--- a/zmsstatistic/src/Zmsstatistic/Helper/LoginForm.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/LoginForm.php
@@ -10,13 +10,14 @@
 namespace BO\Zmsstatistic\Helper;
 
 use BO\Mellon\Validator;
+use BO\Mellon\Collection;
 
 class LoginForm
 {
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromLoginParameters(): Validator
+    public static function fromLoginParameters(): Collection
     {
         $collection = array();
         // loginName
@@ -37,7 +38,7 @@ class LoginForm
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromAdditionalParameters(): Validator
+    public static function fromAdditionalParameters(): Collection
     {
         $collection = array();
 
@@ -72,7 +73,7 @@ class LoginForm
         return $collection;
     }
 
-    public static function fromQuickLogin(): Validator
+    public static function fromQuickLogin(): Collection
     {
         $loginData = static::fromLoginParameters();
         $additionalData = static::fromAdditionalParameters();

--- a/zmsstatistic/src/Zmsstatistic/Helper/LoginForm.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/LoginForm.php
@@ -16,7 +16,7 @@ class LoginForm
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromLoginParameters()
+    public static function fromLoginParameters(): Validator
     {
         $collection = array();
         // loginName
@@ -37,7 +37,7 @@ class LoginForm
     /**
      * form data for reuse in multiple controllers
      */
-    public static function fromAdditionalParameters()
+    public static function fromAdditionalParameters(): Validator
     {
         $collection = array();
 
@@ -72,7 +72,7 @@ class LoginForm
         return $collection;
     }
 
-    public static function fromQuickLogin()
+    public static function fromQuickLogin(): Validator
     {
         $loginData = static::fromLoginParameters();
         $additionalData = static::fromAdditionalParameters();
@@ -82,7 +82,7 @@ class LoginForm
         return $collection;
     }
 
-    public static function writeWorkstationUpdate($data, $workstation)
+    public static function writeWorkstationUpdate($data, $workstation): bool
     {
         if (isset($workstation->useraccount)) {
             $formData = $data->getValues();

--- a/zmsstatistic/src/Zmsstatistic/Helper/ReportHelper.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/ReportHelper.php
@@ -7,7 +7,7 @@ use DateTimeImmutable;
 
 class ReportHelper
 {
-    public static function withMaxAndAverage($entity, $targetKey)
+    public static function withMaxAndAverage($entity, string $targetKey)
     {
         foreach ($entity->data as $date => $dateItems) {
             $maxima = 0;

--- a/zmsstatistic/src/Zmsstatistic/Index.php
+++ b/zmsstatistic/src/Zmsstatistic/Index.php
@@ -148,7 +148,7 @@ class Index extends BaseController
         }
         return $exceptionData;
     }
-    protected function getProviderList($config)
+    protected function getProviderList($config): array
     {
         $allowedProviderList = explode(',', $config->getPreference('oidc', 'provider') ?? '');
         $oidcproviderlist = [];

--- a/zmsstatistic/src/Zmsstatistic/ReportCapacityIndex.php
+++ b/zmsstatistic/src/Zmsstatistic/ReportCapacityIndex.php
@@ -142,14 +142,14 @@ class ReportCapacityIndex extends BaseController
     }
 
     private function renderHtmlResponse(
-        $response,
-        $args,
+        ResponseInterface $response,
+        array $args,
         $capacityPeriod,
-        $dateRange,
+        array|null $dateRange,
         $exchangeCapacity,
-        $exchangeCapacityChart,
-        $exchangeCapacityChartSparse,
-        $selectedScopes = [],
+        Exchange|null $exchangeCapacityChart,
+        Exchange|null $exchangeCapacityChartSparse,
+        array $selectedScopes = [],
         array $scopeDateBounds = [],
         ?string $scopeSlotTimeHint = null
     ): ResponseInterface {

--- a/zmsstatistic/src/Zmsstatistic/ReportClientIndex.php
+++ b/zmsstatistic/src/Zmsstatistic/ReportClientIndex.php
@@ -69,13 +69,13 @@ class ReportClientIndex extends BaseController
      * Handle download request and return Excel file
      */
     private function handleDownloadRequest(
-        $request,
-        $response,
-        $args,
+        RequestInterface $request,
+        ResponseInterface $response,
+        array $args,
         $exchangeClient,
-        $dateRange,
-        $selectedScopes = [],
-        $reportClientService = null
+        array|null $dateRange,
+        array $selectedScopes = [],
+        ReportClientService|null $reportClientService = null
     ): ResponseInterface {
         if ($reportClientService === null) {
             $reportClientService = new ReportClientService();
@@ -94,12 +94,12 @@ class ReportClientIndex extends BaseController
      * Render HTML response for the report page
      */
     private function renderHtmlResponse(
-        $response,
-        $args,
+        ResponseInterface $response,
+        array $args,
         $clientPeriod,
-        $dateRange,
+        array|null $dateRange,
         $exchangeClient,
-        $selectedScopes = []
+        array $selectedScopes = []
     ): ResponseInterface {
         return Render::withHtml(
             $response,

--- a/zmsstatistic/src/Zmsstatistic/ReportRequestIndex.php
+++ b/zmsstatistic/src/Zmsstatistic/ReportRequestIndex.php
@@ -76,13 +76,13 @@ class ReportRequestIndex extends BaseController
      * Handle download request and return Excel file
      */
     private function handleDownloadRequest(
-        $request,
-        $response,
-        $args,
+        RequestInterface $request,
+        ResponseInterface $response,
+        array $args,
         $exchangeRequest,
-        $dateRange,
-        $selectedScopes = [],
-        $reportRequestService = null
+        array|null $dateRange,
+        array $selectedScopes = [],
+        ReportRequestService|null $reportRequestService = null
     ): ResponseInterface {
         if ($reportRequestService === null) {
             $reportRequestService = new ReportRequestService();
@@ -101,12 +101,12 @@ class ReportRequestIndex extends BaseController
      * Render HTML response for the report page
      */
     private function renderHtmlResponse(
-        $response,
-        $args,
+        ResponseInterface $response,
+        array $args,
         $requestPeriod,
-        $dateRange,
+        array|null $dateRange,
         $exchangeRequest,
-        $selectedScopes = []
+        array $selectedScopes = []
     ): ResponseInterface {
         return Render::withHtml(
             $response,

--- a/zmsstatistic/src/Zmsstatistic/ReportWaitingIndex.php
+++ b/zmsstatistic/src/Zmsstatistic/ReportWaitingIndex.php
@@ -76,13 +76,13 @@ class ReportWaitingIndex extends BaseController
      * Handle download request and return Excel file
      */
     private function handleDownloadRequest(
-        $request,
-        $response,
-        $args,
+        RequestInterface $request,
+        ResponseInterface $response,
+        array $args,
         $exchangeWaiting,
-        $dateRange,
-        $selectedScopes = [],
-        $reportWaitingService = null
+        array|null $dateRange,
+        array $selectedScopes = [],
+        ReportWaitingService|null $reportWaitingService = null
     ): ResponseInterface {
         if ($reportWaitingService === null) {
             $reportWaitingService = new ReportWaitingService();
@@ -101,12 +101,12 @@ class ReportWaitingIndex extends BaseController
      * Render HTML response for the waiting report page
      */
     private function renderHtmlResponse(
-        $response,
-        $args,
+        ResponseInterface $response,
+        array $args,
         $waitingPeriod,
-        $dateRange,
+        array|null $dateRange,
         $exchangeWaiting,
-        $selectedScopes = []
+        array $selectedScopes = []
     ): ResponseInterface {
         return Render::withHtml(
             $response,

--- a/zmsticketprinter/src/Zmsticketprinter/Helper/EntryFromOldRoute.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Helper/EntryFromOldRoute.php
@@ -13,7 +13,7 @@ use BO\Mellon\Validator;
 
 class EntryFromOldRoute
 {
-    protected static function getScopes($request)
+    protected static function getScopes($request): string|null
     {
         $scopes = [ ];
         $validator = $request->getAttribute('validator');
@@ -31,7 +31,7 @@ class EntryFromOldRoute
         return (0 < count($scopes)) ? implode(',', $scopes) : null;
     }
 
-    protected static function getClusters($request)
+    protected static function getClusters($request): string|null
     {
         $clusters = [ ];
         $validator = $request->getAttribute('validator');
@@ -49,7 +49,7 @@ class EntryFromOldRoute
         return (0 < count($clusters)) ? implode(',', $clusters) : null;
     }
 
-    public static function getFromOldMehrfachKiosk($request)
+    public static function getFromOldMehrfachKiosk(\Psr\Http\Message\RequestInterface $request): string
     {
         $scopes = self::getScopes($request);
         $clusters = self::getClusters($request);

--- a/zmsticketprinter/src/Zmsticketprinter/Helper/HomeUrl.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Helper/HomeUrl.php
@@ -18,8 +18,7 @@ class HomeUrl
      * otherwise set current uri from request as new home url
      *
      **/
-
-    public static function create($request)
+    public static function create(\Psr\Http\Message\RequestInterface $request)
     {
         $homeUrl = null;
         $validator = $request->getAttribute('validator');
@@ -38,8 +37,11 @@ class HomeUrl
 
     /**
      * Remove accumulated /& patterns from URL that occur due to redirect chain issues
+     *
+     * @return null|string|string[]
+     *
      */
-    public static function sanitizeUrl($url)
+    public static function sanitizeUrl($url): array|string|null
     {
         // Remove repeated /& patterns (e.g., ?/&/&/& becomes ?)
         $url = preg_replace('#\?(/&)+#', '?', $url);

--- a/zmsticketprinter/src/Zmsticketprinter/Helper/QueueListHelper.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Helper/QueueListHelper.php
@@ -49,7 +49,7 @@ class QueueListHelper
         return (static::getList()->getQueuePositionByNumber($entity->number));
     }
 
-    protected static function createFullList($scope)
+    protected static function createFullList(Scope $scope)
     {
         $fullList = \App::$http
             ->readGetResult('/scope/' . $scope->getId() . '/queue/')
@@ -57,7 +57,7 @@ class QueueListHelper
         return ($fullList) ? $fullList : new QueueList();
     }
 
-    protected static function createQueueList($process)
+    protected static function createQueueList(Process|null $process): QueueList
     {
         $queueList = new QueueList();
         if (static::$fullList->count()) {

--- a/zmsticketprinter/src/Zmsticketprinter/Helper/TemplateFinder.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Helper/TemplateFinder.php
@@ -39,9 +39,8 @@ class TemplateFinder
     /**
      * get a customized Template if it exists, otherwise return default
      * department preferred before cluster
-     *
-     **/
-    public function setCustomizedTemplate($ticketprinter, $organisation)
+     */
+    public function setCustomizedTemplate(\BO\Zmsentities\Ticketprinter $ticketprinter, \BO\Zmsentities\Organisation $organisation): static
     {
         $template = null;
         if ($this->defaultTemplate == 'default') {
@@ -51,7 +50,7 @@ class TemplateFinder
         return $this;
     }
 
-    public function getButtonTemplateType($ticketprinter)
+    public function getButtonTemplateType($ticketprinter): string
     {
         if (1 == count($ticketprinter->buttons)) {
             $buttonDisplay = 'button_single';
@@ -97,7 +96,7 @@ class TemplateFinder
         return $template;
     }
 
-    protected function getExistingTemplate(Entity $entity)
+    protected function getExistingTemplate(Entity $entity): string|null
     {
         $path = $this->subPath . '/buttonDisplay_' . $entity->getEntityName() . '_' . $entity->id . '.twig';
         if ($entity->hasId() && $this->isTemplateReadable($path)) {
@@ -106,7 +105,7 @@ class TemplateFinder
         return null;
     }
 
-    protected function isTemplateReadable($path)
+    protected function isTemplateReadable(string $path): bool
     {
         return is_readable($this->getTemplatePath() . $path);
     }
@@ -114,7 +113,7 @@ class TemplateFinder
     /**
      * @todo check against ISO definition
      */
-    protected function getTemplatePath()
+    protected function getTemplatePath(): string
     {
         return realpath(__DIR__) . '/../../../templates';
     }

--- a/zmsticketprinter/src/Zmsticketprinter/Index.php
+++ b/zmsticketprinter/src/Zmsticketprinter/Index.php
@@ -105,7 +105,7 @@ class Index extends BaseController
         return $lang ?: ($languageConfig['defaultLanguage'] ?? 'de');
     }
 
-    private function getQueryStringWithLang()
+    private function getQueryStringWithLang(): string
     {
         $queryString = $_SERVER['QUERY_STRING'] ?? '';
         if (!strpos($queryString, 'lang=')) {
@@ -114,7 +114,11 @@ class Index extends BaseController
         return str_replace('/&', '', $queryString);
     }
 
-    private function getTranslations($languageConfig, $currentLang)
+    /**
+     * @return ((mixed|null|string)[]|mixed|string)[]
+     *
+     */
+    private function getTranslations($languageConfig, $currentLang): array
     {
         $translations = ['printText' => ''];
 
@@ -145,7 +149,7 @@ class Index extends BaseController
         return $translations;
     }
 
-    private function getAvailableLanguages($languageConfig)
+    private function getAvailableLanguages($languageConfig): array
     {
         return array_values(array_unique(
             array_column($languageConfig['languages'] ?? [], 'language')
@@ -157,12 +161,12 @@ class Index extends BaseController
         return \App::$http->readGetResult('/scope/' . $scope->id . '/department/')->getEntity();
     }
 
-    private function shouldRedirectToScope($ticketprinter)
+    private function shouldRedirectToScope(\BO\Zmsentities\Ticketprinter $ticketprinter): bool
     {
         return count($ticketprinter->buttons) === 1 && $ticketprinter->buttons[0]['type'] === 'scope';
     }
 
-    private function hasDisabledButton($ticketprinter)
+    private function hasDisabledButton(\BO\Zmsentities\Ticketprinter $ticketprinter): bool
     {
         foreach ($ticketprinter->buttons as $button) {
             if (!isset($button['enabled']) || $button['enabled'] != 1) {
@@ -172,7 +176,7 @@ class Index extends BaseController
         return false;
     }
 
-    protected function getQueryString($validator, $ticketprinter, $defaultTemplate)
+    protected function getQueryString($validator, \BO\Zmsentities\Ticketprinter $ticketprinter, $defaultTemplate): array
     {
         $query = ($defaultTemplate->getValue() === 'default') ? [] : ['template' => $defaultTemplate->getValue()];
         if (isset($ticketprinter['home'])) {


### PR DESCRIPTION
## Summary
- Add native param/return types for Psalm `MissingParamType` and `MissingReturnType` (the two largest remaining code-scanning rules).
- Keep shared overrides and interfaces wide enough for PHP 8.3 inheritance (no call-site-narrowed `mixed` replacements that fail to load).
- phpcs PSR-12 and phpmd pass locally on all scanned modules.

## Test plan
- [ ] Combined workflow / php-code-quality on this PR
- [ ] Spot-check a backend request that uses `Query\Base` fetch helpers
- [ ] After merge: `gh workflow run psalm.yml --ref next -f run_dead_code=true`