### PR TITLE
fix(ZMSKVR-1457): snap out-of-range calendar slots instead of 500

### DIFF
--- a/zmsbackend/src/Zmsbackend/Calendar/Service/CalendarAvailability.php
+++ b/zmsbackend/src/Zmsbackend/Calendar/Service/CalendarAvailability.php
@@ -247,7 +247,7 @@ class CalendarAvailability extends \BO\Zmsbackend\Base
 
     /**
      * Defaults slots window to the day range. When one side is missing, use the day range bound.
-     * Clamps the slots window to the day range intersection.
+     * Clamps the slots window to the day range intersection. No overlap snaps to the nearest bound.
      */
     private function resolveSlotsDateRange(
         string $startDate,
@@ -281,9 +281,14 @@ class CalendarAvailability extends \BO\Zmsbackend\Base
             $slotsEnd = $endDate;
         }
         if ($slotsStart > $slotsEnd) {
-            throw new \BO\Zmsbackend\Slot\Exception\Calendar\InvalidAvailabilityInput(
-                'slots date range does not overlap startDate/endDate'
-            );
+            // No overlap: snap to the nearest day in the horizon instead of failing.
+            if ($slotsEnd < $startDate) {
+                $slotsStart = $startDate;
+                $slotsEnd = $startDate;
+            } else {
+                $slotsStart = $endDate;
+                $slotsEnd = $endDate;
+            }
         }
 
         return [$slotsStart, $slotsEnd];

--- a/zmsbackend/tests/Zmsbackend/Calendar/Api/CalendarAvailabilityGetTest.php
+++ b/zmsbackend/tests/Zmsbackend/Calendar/Api/CalendarAvailabilityGetTest.php
@@ -134,6 +134,51 @@ class CalendarAvailabilityGetTest extends \BO\Zmsbackend\Tests\Api\Base
         }
     }
 
+    public function testSlotsWindowBeforeStartDateSnapsToStart()
+    {
+        $now = \App::$now;
+        $end = (clone $now)->modify('+1 month');
+        $yesterday = (clone $now)->modify('-1 day')->format('Y-m-d');
+        $response = $this->render([], [
+            'startDate' => $now->format('Y-m-d'),
+            'endDate' => $end->format('Y-m-t'),
+            'slotsStartDate' => $yesterday,
+            'slotsEndDate' => $yesterday,
+            'officeIds' => '122217',
+            'serviceIds' => '120703',
+            'serviceCounts' => '1',
+        ], []);
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertTrue(200 == $response->getStatusCode());
+        $this->assertGreaterThanOrEqual($now->format('Y-m-d'), $body['data']['slotsStartDate']);
+        $this->assertLessThanOrEqual($end->format('Y-m-t'), $body['data']['slotsEndDate']);
+        $this->assertSame($body['data']['slotsStartDate'], $body['data']['slotsEndDate']);
+    }
+
+    public function testSlotsWindowAfterEndDateSnapsToEnd()
+    {
+        $now = \App::$now;
+        $end = (clone $now)->modify('+1 month');
+        $afterHorizon = (clone $end)->modify('last day of this month')->modify('+1 day')->format('Y-m-d');
+        $horizonEnd = $end->format('Y-m-t');
+        $response = $this->render([], [
+            'startDate' => $now->format('Y-m-d'),
+            'endDate' => $horizonEnd,
+            'slotsStartDate' => $afterHorizon,
+            'slotsEndDate' => $afterHorizon,
+            'officeIds' => '122217',
+            'serviceIds' => '120703',
+            'serviceCounts' => '1',
+        ], []);
+        $body = json_decode((string) $response->getBody(), true);
+
+        $this->assertTrue(200 == $response->getStatusCode());
+        $this->assertGreaterThanOrEqual($now->format('Y-m-d'), $body['data']['slotsStartDate']);
+        $this->assertLessThanOrEqual($horizonEnd, $body['data']['slotsEndDate']);
+        $this->assertSame($body['data']['slotsStartDate'], $body['data']['slotsEndDate']);
+    }
+
     public function testServiceCountExceedsMaximum()
     {
         $this->expectException(\BO\Zmsbackend\Calendar\Exception\InvalidFirstDay::class);

--- a/zmsbackend/tests/Zmsbackend/Service/CalendarAvailabilityTest.php
+++ b/zmsbackend/tests/Zmsbackend/Service/CalendarAvailabilityTest.php
@@ -38,6 +38,31 @@ class CalendarAvailabilityTest extends Base
         }
     }
 
+    public function testSlotsWindowOutsideHorizonDoesNotThrow()
+    {
+        $start = \App::$now;
+        $end = (clone $start)->modify('+1 month');
+        $yesterday = (clone $start)->modify('-1 day')->format('Y-m-d');
+        $result = (new Query())->readFromQuery(
+            \App::$now,
+            'public',
+            0,
+            $start->format('Y-m-d'),
+            $end->format('Y-m-t'),
+            '122217',
+            '120703',
+            '1',
+            'dldb',
+            'dldb',
+            $yesterday,
+            $yesterday
+        );
+
+        $this->assertGreaterThanOrEqual($start->format('Y-m-d'), $result['slotsStartDate']);
+        $this->assertLessThanOrEqual($end->format('Y-m-t'), $result['slotsEndDate']);
+        $this->assertSame($result['slotsStartDate'], $result['slotsEndDate']);
+    }
+
     public function testServiceCountExceedsMaximum()
     {
         $this->expectException(\BO\Zmsbackend\Slot\Exception\Calendar\InvalidAvailabilityInput::class);


### PR DESCRIPTION
## Summary
- Calendar availability was throwing a fatal 500 when `slotsStartDate`/`slotsEndDate` sat entirely outside `startDate`/`endDate` (timezone off-by-one or list-view paging past the 6-month cap).
- Snap the slots window to the nearest day in the horizon instead of failing; keep the existing throw when slots start after slots end.
- Add API and service tests for slots windows before start and after end.

## Test plan
- [ ] Hit `/calendar/availability/` with `slotsStartDate`/`slotsEndDate` = yesterday and `startDate` = today; expect 200, slots inside the horizon
- [ ] Same endpoint with slots after `endDate`; expect 200, slots inside the horizon
- [ ] Normal overlapping slots window still returns bookable days
- [ ] `slotsStartDate` after `slotsEndDate` still rejected