### PR TITLE
fix(ZMS): stop flaky DateTimeFormatTest failing ocassionally across a second boundary

### DIFF
--- a/zmsslim/tests/Slim/DateTimeFormatTest.php
+++ b/zmsslim/tests/Slim/DateTimeFormatTest.php
@@ -11,8 +11,17 @@ class DateTimeFormatTest extends TestCase
     {
         $request = \BO\Slim\Tests\Base::createBasicRequest('GET', '/unittest/');
         $exception = new \BO\Slim\Exception\SessionFailed();
+        $before = time();
         $infoArr = \BO\Slim\TwigExceptionHandler::getExtendedExceptionInfo($exception, $request);
-        $this->assertEquals($infoArr['servertime'], (new \DateTimeImmutable())->format('Y-m-d H:i:s'));
+        $after = time();
+        $serverTime = \DateTimeImmutable::createFromFormat(
+            'Y-m-d H:i:s',
+            $infoArr['servertime'],
+            new \DateTimeZone('Europe/Berlin')
+        );
+        $this->assertInstanceOf(\DateTimeImmutable::class, $serverTime);
+        $this->assertGreaterThanOrEqual($before, $serverTime->getTimestamp());
+        $this->assertLessThanOrEqual($after, $serverTime->getTimestamp());
     }
 
     public function testTwigDateFormat()

--- a/zmsslim/tests/Slim/DateTimeFormatTest.php
+++ b/zmsslim/tests/Slim/DateTimeFormatTest.php
@@ -14,14 +14,14 @@ class DateTimeFormatTest extends TestCase
         $before = time();
         $infoArr = \BO\Slim\TwigExceptionHandler::getExtendedExceptionInfo($exception, $request);
         $after = time();
-        $serverTime = \DateTimeImmutable::createFromFormat(
-            'Y-m-d H:i:s',
-            $infoArr['servertime'],
-            new \DateTimeZone('Europe/Berlin')
-        );
-        $this->assertInstanceOf(\DateTimeImmutable::class, $serverTime);
-        $this->assertGreaterThanOrEqual($before, $serverTime->getTimestamp());
-        $this->assertLessThanOrEqual($after, $serverTime->getTimestamp());
+        $expectedTimes = [];
+        for ($timestamp = $before; $timestamp <= $after; $timestamp++) {
+            $formatted = \BO\Slim\Helper::getFormatedDates($timestamp, 'yyyy-MM-dd HH:mm:ss');
+            if (is_string($formatted) && $formatted !== '') {
+                $expectedTimes[] = $formatted;
+            }
+        }
+        $this->assertContains($infoArr['servertime'], array_values(array_unique($expectedTimes)));
     }
 
     public function testTwigDateFormat()


### PR DESCRIPTION
## Summary
- `DateTimeFormatTest::testDateTimeFormat` compared `servertime` to a second `now()` snapshot, so CI failed when the clock ticked between the two calls (off by one second).
- The test now asserts `servertime` falls in a before/after window, matching Europe/Berlin as used by `Helper::getFormatedDates`.

```
There was 1 failure:

1) BO\Slim\Tests\DateTimeFormatTest::testDateTimeFormat
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'2026-08-21 10:50:27'
+'2026-08-21 10:50:28'

/__w/eappointment/eappointment/zmsslim/tests/Slim/DateTimeFormatTest.php:15

FAILURES!
Tests: 87, Assertions: 189, Failures: 1.
```

## Test plan
- [x] Ran `zmsslim` `DateTimeFormatTest::testDateTimeFormat` locally
- [x] Confirm zmsslim PHPUnit job on this PR is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and time validation to account for timezone conversion and execution timing.
  * Reduced false failures caused by comparing generated server times against an exact expected string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->