### PR TITLE
fix(ZMS): avoid gateway timeout on large request-scope reports

### DIFF
--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestscope.php
@@ -32,7 +32,7 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Query\Base
             END
         ) as name,
         SUM(agg.requestscount) as requestscount,
-        SUM(agg.processingtime * agg.requestscount) / NULLIF(SUM(agg.requestscount), 0) as processingtime
+        SUM(agg.processingsum) / NULLIF(SUM(agg.processingcount), 0) as processingtime
     FROM (
         SELECT
             s.anliegenid,
@@ -40,7 +40,8 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Query\Base
             MIN(s.behoerdenid) as behoerdenid,
             MIN(s.organisationsid) as organisationsid,
             COUNT(*) as requestscount,
-            AVG(s.processing_time) as processingtime,
+            SUM(s.processing_time) as processingsum,
+            COUNT(s.processing_time) as processingcount,
             s.datum
         FROM ' . self::TABLE . ' AS s
         WHERE s.standortid IN (:scopeid) AND s.datum BETWEEN :datestart AND :dateend

--- a/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Repository/ExchangeRequestscope.php
@@ -13,26 +13,42 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Query\Base
 
     const string REQUESTTABLE = 'request';
 
+    /**
+     * Aggregate raw statistik rows by day and request first so the request
+     * name join and DATE_FORMAT grouping run on a small result, not every fact row.
+     * Inner GROUP BY uses the (standortid, datum) index; outer DATE_FORMAT is cheap.
+     */
     const QUERY_READ_REPORT = '
     SELECT
-        s.`standortid` as scopeid,
-        s.`behoerdenid` as departmentid,
-        s.`organisationsid` as organisationid,
-        DATE_FORMAT(s.`Datum`, :groupby) as date,
+        MIN(agg.standortid) as scopeid,
+        MIN(agg.behoerdenid) as departmentid,
+        MIN(agg.organisationsid) as organisationid,
+        DATE_FORMAT(agg.datum, :groupby) as date,
         (
             CASE
-              WHEN s.anliegenid = -1 THEN \'' . Exchange::REQUEST_STAT_NAME_UNCATEGORIZED . '\'
-              WHEN s.anliegenid = 0 THEN \'' . Exchange::REQUEST_STAT_NAME_NONEXISTENT . '\'
+              WHEN agg.anliegenid = -1 THEN \'' . Exchange::REQUEST_STAT_NAME_UNCATEGORIZED . '\'
+              WHEN agg.anliegenid = 0 THEN \'' . Exchange::REQUEST_STAT_NAME_NONEXISTENT . '\'
               ELSE r.name
             END
         ) as name,
-        COUNT(s.anliegenid) as requestscount,
-        AVG(s.processing_time) as processingtime
-    FROM ' . self::TABLE . ' AS s
-        LEFT JOIN ' . self::REQUESTTABLE . ' as r ON r.id = s.anliegenid
-    WHERE s.`standortid` IN (:scopeid) AND s.`Datum` BETWEEN :datestart AND :dateend
-    GROUP BY date, s.anliegenid
-    ORDER BY r.name
+        SUM(agg.requestscount) as requestscount,
+        SUM(agg.processingtime * agg.requestscount) / NULLIF(SUM(agg.requestscount), 0) as processingtime
+    FROM (
+        SELECT
+            s.anliegenid,
+            MIN(s.standortid) as standortid,
+            MIN(s.behoerdenid) as behoerdenid,
+            MIN(s.organisationsid) as organisationsid,
+            COUNT(*) as requestscount,
+            AVG(s.processing_time) as processingtime,
+            s.datum
+        FROM ' . self::TABLE . ' AS s
+        WHERE s.standortid IN (:scopeid) AND s.datum BETWEEN :datestart AND :dateend
+        GROUP BY s.datum, s.anliegenid
+    ) as agg
+        LEFT JOIN ' . self::REQUESTTABLE . ' as r ON r.id = agg.anliegenid
+    GROUP BY date, name, agg.anliegenid
+    ORDER BY name
     ';
 
     const QUERY_SUBJECTS = '
@@ -57,15 +73,9 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Query\Base
     ';
 
     const QUERY_PERIODLIST_MONTH = '
-        SELECT date
-        FROM ' . \BO\Zmsbackend\Query\Scope::TABLE . ' AS scope
-            INNER JOIN (
-              SELECT
-                `StandortID`,
-                DATE_FORMAT(`Datum`,"%Y-%m") AS date
-              FROM ' . self::TABLE . '
-            ) s ON scope.`StandortID` = s.`standortid`
-        WHERE scope.`StandortID` = :scopeid
+        SELECT DATE_FORMAT(`datum`, "%Y-%m") AS date
+        FROM ' . self::TABLE . '
+        WHERE standortid = :scopeid
         GROUP BY date
         ORDER BY date ASC
     ';

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestscope.php
@@ -18,9 +18,13 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Base
         \DateTimeInterface $dateend,
         $period = 'day'
     ): Exchange {
-        $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectid);
+        $subjectIdList = array_values(array_filter(array_map('trim', explode(',', (string) $subjectid))));
+        $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectIdList[0] ?? $subjectid);
         $entity = new Exchange();
-        $entity['title'] = "Dienstleistungsstatistik " . $scope->contact->name . " " . $scope->shortName;
+        $entity['title'] = "Dienstleistungsstatistik "
+            . ($scope?->contact?->name ?? '')
+            . " "
+            . ($scope?->shortName ?? '');
         $entity->setPeriod($datestart, $dateend, $period);
         $entity->addDictionaryEntry('scopeid', 'string', 'ID of a scope', 'scope.id');
         $entity->addDictionaryEntry('departmentid', 'string', 'ID of a department', '');
@@ -29,7 +33,10 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Base
         $entity->addDictionaryEntry('name', 'string', 'Name of request');
         $entity->addDictionaryEntry('requestscount', 'number', 'Amount of requests');
         $entity->addDictionaryEntry('processingtime', 'number', 'Average processing time in minutes');
-        $subjectIdList = explode(',', $subjectid);
+
+        if ($subjectIdList === []) {
+            return $entity;
+        }
 
         $raw = $this
             ->getReader()

--- a/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestscope.php
+++ b/zmsbackend/src/Zmsbackend/Exchange/Service/ExchangeRequestscope.php
@@ -19,7 +19,9 @@ class ExchangeRequestscope extends \BO\Zmsbackend\Base
         $period = 'day'
     ): Exchange {
         $subjectIdList = array_values(array_filter(array_map('trim', explode(',', (string) $subjectid))));
-        $scope = (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectIdList[0] ?? $subjectid);
+        $scope = $subjectIdList === []
+            ? null
+            : (new \BO\Zmsbackend\Scope\Service\Scope())->readEntity($subjectIdList[0]);
         $entity = new Exchange();
         $entity['title'] = "Dienstleistungsstatistik "
             . ($scope?->contact?->name ?? '')

--- a/zmsbackend/tests/Zmsbackend/Exchange/Service/ExchangeRequestscopeTest.php
+++ b/zmsbackend/tests/Zmsbackend/Exchange/Service/ExchangeRequestscopeTest.php
@@ -25,6 +25,14 @@ class ExchangeRequestscopeTest extends \BO\Zmsbackend\Tests\Service\Base
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}$/', $entity->data[0][3]);
     }
 
+    public function testReadEntityWithEmptySubject()
+    {
+        $query = new Query();
+        $entity = $query->readEntity('', new DateTime('2016-04-01'), new DateTime('2016-04-30'));
+        $this->assertEntity("\\BO\\Zmsentities\\Exchange", $entity);
+        $this->assertEquals(0, count($entity->data));
+    }
+
     public function testSubject()
     {
         $query = new Query();

--- a/zmsbackend/tests/Zmsbackend/Exchange/Service/ExchangeRequestscopeTest.php
+++ b/zmsbackend/tests/Zmsbackend/Exchange/Service/ExchangeRequestscopeTest.php
@@ -16,6 +16,15 @@ class ExchangeRequestscopeTest extends \BO\Zmsbackend\Tests\Service\Base
         $this->assertEquals(17, count($entity->data));
     }
 
+    public function testReadEntityByMonth()
+    {
+        $query = new Query();
+        $entity = $query->readEntity(141, new DateTime('2016-01-01'), new DateTime('2016-12-31'), 'month');
+        $this->assertEntity("\\BO\\Zmsentities\\Exchange", $entity);
+        $this->assertGreaterThan(0, count($entity->data));
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}$/', $entity->data[0][3]);
+    }
+
     public function testSubject()
     {
         $query = new Query();

--- a/zmsstatistic/src/Zmsstatistic/Helper/ReportHelper.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/ReportHelper.php
@@ -193,6 +193,19 @@ class ReportHelper
     }
 
     /**
+     * Daily columns stay usable up to one month; longer ranges group by month
+     * so warehouse queries and HTML tables stay within gateway timeouts.
+     */
+    public function getGroupByForDateRange(string $fromDate, string $toDate): string
+    {
+        $from = new DateTimeImmutable($fromDate);
+        $to = new DateTimeImmutable($toDate);
+        $inclusiveDays = (int) $from->diff($to)->days + 1;
+
+        return $inclusiveDays > 31 ? 'month' : 'day';
+    }
+
+    /**
      * Get all years that need to be fetched for a date range
      */
     public function getYearsForDateRange(string $fromDate, string $toDate): array

--- a/zmsstatistic/src/Zmsstatistic/Service/ReportRequestService.php
+++ b/zmsstatistic/src/Zmsstatistic/Service/ReportRequestService.php
@@ -56,18 +56,19 @@ class ReportRequestService
 
         try {
             $reportHelper = new ReportHelper();
-            $years = $reportHelper->getYearsForDateRange($fromDate, $toDate);
-            $combinedData = $this->fetchAndCombineDataFromYears($reportHelper, $scopeId, $years, $fromDate, $toDate);
+            $groupby = $reportHelper->getGroupByForDateRange($fromDate, $toDate);
+            $exchangeRequest = $this->fetchExchangeRequest($scopeId, $fromDate, $toDate, $groupby);
 
-            if (empty($combinedData['data'])) {
+            if ($exchangeRequest === null || empty($exchangeRequest->data) || !is_array($exchangeRequest->data)) {
                 return null;
             }
 
             return $this->createFilteredExchangeRequest(
-                $combinedData['entity'],
-                $combinedData['data'],
+                $exchangeRequest,
+                $exchangeRequest->data,
                 $fromDate,
-                $toDate
+                $toDate,
+                $groupby
             );
         } catch (Exception $exception) {
             return null;
@@ -107,48 +108,26 @@ class ReportRequestService
     }
 
     /**
-     * Fetch and combine data from multiple years
+     * One warehouse call for the full from/to range (fromDate/toDate override the year in the path).
      */
-    private function fetchAndCombineDataFromYears(ReportHelper $reportHelper, string $scopeId, array $years, string $fromDate, string $toDate): array
-    {
-        $combinedData = [];
-        $baseEntity = null;
+    private function fetchExchangeRequest(
+        string $scopeId,
+        string $fromDate,
+        string $toDate,
+        string $groupby
+    ): mixed {
+        $fromYear = substr($fromDate, 0, 4);
 
-        foreach ($years as $year) {
-            $bounds = $reportHelper->getYearDateBounds($year, $fromDate, $toDate);
-            if ($bounds === null) {
-                continue;
-            }
-            try {
-                $exchangeRequest = \App::$http
-                    ->readGetResult(
-                        '/warehouse/requestscope/' . $scopeId . '/' . $year . '/',
-                        [
-                            'groupby' => 'day',
-                            'fromDate' => $bounds['from'],
-                            'toDate' => $bounds['to'],
-                        ]
-                    )
-                    ->getEntity();
-
-                // Use the first successfully fetched entity as the base
-                if ($baseEntity === null) {
-                    $baseEntity = $exchangeRequest;
-                }
-
-                // Combine data from all years
-                if (isset($exchangeRequest->data) && is_array($exchangeRequest->data)) {
-                    $combinedData = array_merge($combinedData, $exchangeRequest->data);
-                }
-            } catch (Exception $exception) {
-                // Continue with other years - don't fail completely if one year is missing
-            }
-        }
-
-        return [
-            'entity' => $baseEntity,
-            'data' => $combinedData
-        ];
+        return \App::$http
+            ->readGetResult(
+                '/warehouse/requestscope/' . $scopeId . '/' . $fromYear . '/',
+                [
+                    'groupby' => $groupby,
+                    'fromDate' => $fromDate,
+                    'toDate' => $toDate,
+                ]
+            )
+            ->getEntity();
     }
 
     /**
@@ -158,14 +137,12 @@ class ReportRequestService
         $exchangeRequestBasic,
         array $filteredData,
         string $fromDate,
-        string $toDate
+        string $toDate,
+        string $groupby = 'day'
     ): mixed {
         $exchangeRequest = $exchangeRequestBasic;
         $exchangeRequest->data = $filteredData;
-
-        if (!isset($exchangeRequest->period)) {
-            $exchangeRequest->period = 'day';
-        }
+        $exchangeRequest->period = $groupby;
 
         $exchangeRequest->firstDay = (new Day())->setDateTime(new DateTime($fromDate));
         $exchangeRequest->lastDay = (new Day())->setDateTime(new DateTime($toDate));

--- a/zmsstatistic/templates/page/reportRequestIndex.twig
+++ b/zmsstatistic/templates/page/reportRequestIndex.twig
@@ -37,11 +37,13 @@
                 {% set monthPattern = sameYear ? "LLL" : "LLL y" %}
                 {% set dateRange = [] %}
                 {% set cursor = startMonth %}
-                {% for i in 0..240 %}
-                    {% if cursor <= endMonth %}
-                        {% set dateRange = dateRange|merge([cursor|date('Y-m')]) %}
-                        {% set cursor = cursor|date_modify('+1 month') %}
-                    {% endif %}
+                {% set monthCount =
+                    (endMonth|date('Y') * 12 + endMonth|date('n'))
+                    - (startMonth|date('Y') * 12 + startMonth|date('n'))
+                %}
+                {% for i in range(0, monthCount) %}
+                    {% set dateRange = dateRange|merge([cursor|date('Y-m')]) %}
+                    {% set cursor = cursor|date_modify('+1 month') %}
                 {% endfor %}
             {% endif %}
             <div class="table-wrapper">

--- a/zmsstatistic/templates/page/reportRequestIndex.twig
+++ b/zmsstatistic/templates/page/reportRequestIndex.twig
@@ -31,9 +31,18 @@
                     {% set dateRange = dateRange|merge([fullDate]) %}
                 {% endfor %}
             {% elseif exchangeRequest.period == "month" %}
-                {% set startDate = "%s-%s"|format(exchangeRequest.firstDay.year, exchangeRequest.firstDay.month) %}
-                {% set endDate = "%s-%s"|format(exchangeRequest.lastDay.year, exchangeRequest.lastDay.month) %}
-                {% set dateRange = range(startDate|date('n'), endDate|date('n'), 1 ) %}
+                {% set startMonth = date("%s-%s-01"|format(exchangeRequest.firstDay.year, exchangeRequest.firstDay.month)) %}
+                {% set endMonth = date("%s-%s-01"|format(exchangeRequest.lastDay.year, exchangeRequest.lastDay.month)) %}
+                {% set sameYear = exchangeRequest.firstDay.year == exchangeRequest.lastDay.year %}
+                {% set monthPattern = sameYear ? "LLL" : "LLL y" %}
+                {% set dateRange = [] %}
+                {% set cursor = startMonth %}
+                {% for i in 0..240 %}
+                    {% if cursor <= endMonth %}
+                        {% set dateRange = dateRange|merge([cursor|date('Y-m')]) %}
+                        {% set cursor = cursor|date_modify('+1 month') %}
+                    {% endif %}
+                {% endfor %}
             {% endif %}
             <div class="table-wrapper">
             <table class="table--base">
@@ -48,13 +57,13 @@
                         <th class="statistik">Ø Bearbeitungsdauer</th>
                         <th class="statistik">Summe</th>
                     {% elseif exchangeRequest.period == "month" %}
-                        <th class="statistik">{{ startDate|date('Y') }}</th>
+                        <th class="statistik">{% if sameYear %}{{ exchangeRequest.firstDay.year }}{% else %}{% trans %}Summe{% endtrans %}{% endif %}</th>
                     {% endif %}
                     {% for date in dateRange %}
                         {% if exchangeRequest.period == "day" %}
                             <th class="statistik">{{ date|date('d.m.') }}</th>
                         {% elseif exchangeRequest.period == "month" %}
-                            <th class="statistik">&nbsp;{{ (startDate|date('Y') ~"-"~ "%02d"|format(date))|format_date(pattern="LLL") }}</th>
+                            <th class="statistik">&nbsp;{{ (date ~ "-01")|format_date(pattern=monthPattern) }}</th>
                         {% endif %}
                     {% endfor %}
                     </tr>
@@ -93,20 +102,11 @@
                             {% endif %}
 
                             {% for date in dateRange %}
-                                {% if exchangeRequest.period == "day" %}
-                                    <td>
-                                        <span class="{% if not entry[date].requestscount %}ausgegraut{% endif %}">
-                                            {{ entry[date].requestscount|default("-") }}
-                                        </span>
-                                    </td>
-                                {% elseif exchangeRequest.period == "month" %}
-                                    {% set formattedDate = startDate|date('Y') ~"-"~ "%02d"|format(date) %}
-                                    <td>
-                                        <span class="{% if not entry[formattedDate].requestscount %}ausgegraut{% endif %}">
-                                            {{ entry[formattedDate].requestscount|default("-") }}
-                                        </span>
-                                    </td>
-                                {% endif %}
+                                <td>
+                                    <span class="{% if not entry[date].requestscount %}ausgegraut{% endif %}">
+                                        {{ entry[date].requestscount|default("-") }}
+                                    </span>
+                                </td>
                             {% endfor %}
                         </tr>
                         {% endif %}
@@ -125,22 +125,12 @@
 
                         {% for date in dateRange %}
                             {% set dateSum = 0 %}
-                            {% if exchangeRequest.period == "day" %}
-                                {% for name, entry in exchangeRequest.data %}
-                                    {% if name != "average_processingtime" and name != "sum"
-                                        and name != uncategorizedRequestKey and name != serviceNotProvidedKey %}
-                                        {% set dateSum = dateSum + (entry[date].requestscount|default(0)) %}
-                                    {% endif %}
-                                {% endfor %}
-                            {% elseif exchangeRequest.period == "month" %}
-                                {% set formattedDate = startDate|date('Y') ~"-"~ "%02d"|format(date) %}
-                                {% for name, entry in exchangeRequest.data %}
-                                    {% if name != "average_processingtime" and name != "sum"
-                                        and name != uncategorizedRequestKey and name != serviceNotProvidedKey %}
-                                        {% set dateSum = dateSum + (entry[formattedDate].requestscount|default(0)) %}
-                                    {% endif %}
-                                {% endfor %}
-                            {% endif %}
+                            {% for name, entry in exchangeRequest.data %}
+                                {% if name != "average_processingtime" and name != "sum"
+                                    and name != uncategorizedRequestKey and name != serviceNotProvidedKey %}
+                                    {% set dateSum = dateSum + (entry[date].requestscount|default(0)) %}
+                                {% endif %}
+                            {% endfor %}
 
                             <td class="report-board--summary">
                                 {{ dateSum }}

--- a/zmsstatistic/tests/Zmsstatistic/ReportHelperTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportHelperTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BO\Zmsstatistic\Tests;
+
+use BO\Zmsstatistic\Helper\ReportHelper;
+
+class ReportHelperTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetGroupByForDateRangeUsesDayUpToOneMonth(): void
+    {
+        $helper = new ReportHelper();
+
+        $this->assertSame('day', $helper->getGroupByForDateRange('2016-04-01', '2016-04-30'));
+        $this->assertSame('day', $helper->getGroupByForDateRange('2016-04-01', '2016-05-01'));
+    }
+
+    public function testGetGroupByForDateRangeUsesMonthForLongerRanges(): void
+    {
+        $helper = new ReportHelper();
+
+        $this->assertSame('month', $helper->getGroupByForDateRange('2016-04-01', '2016-05-02'));
+        $this->assertSame('month', $helper->getGroupByForDateRange('2015-12-31', '2016-04-01'));
+        $this->assertSame('month', $helper->getGroupByForDateRange('2025-10-31', '2026-08-20'));
+    }
+}

--- a/zmsstatistic/tests/Zmsstatistic/ReportRequestScopeTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportRequestScopeTest.php
@@ -255,21 +255,11 @@ class ReportRequestScopeTest extends Base
                     'function' => 'readGetResult',
                     'url' => '/warehouse/requestscope/141/2015/',
                     'parameters' => [
-                        'groupby' => 'day',
+                        'groupby' => 'month',
                         'fromDate' => '2015-12-31',
-                        'toDate' => '2015-12-31'
-                    ],
-                    'response' => $this->readFixture("GET_requestscope_141_2015.json")
-                ],
-                [
-                    'function' => 'readGetResult',
-                    'url' => '/warehouse/requestscope/141/2016/',
-                    'parameters' => [
-                        'groupby' => 'day',
-                        'fromDate' => '2016-01-01',
                         'toDate' => '2016-04-01'
                     ],
-                    'response' => $this->readFixture("GET_requestscope_141_042016.json")
+                    'response' => $this->readFixture("GET_requestscope_141_2015.json")
                 ]
             ]
         );


### PR DESCRIPTION
## Summary
- Rewrite the `requestscope` warehouse SQL so `statistik` is aggregated by day/request before the `request` name join, and so the period-picker query filters by `standortid` instead of scanning the whole table.
- Fetch a custom date range in one warehouse call (instead of one call per year) and group ranges longer than 31 days by month, so city-wide reports like 122 locations over 10 months stay under the gateway timeout.
- Update the Dienstleistungsstatistik table to render month columns across year boundaries.

## Test plan
- [ ] Open Standort Dienstleistungsstatistik for a single location and a range of ≤ 31 days; daily columns still appear.
- [ ] Open the same report for 122 locations from 2025-10-31 to 2026-08-20 (the URL that returned 504); page loads with monthly columns instead of timing out.
- [ ] Open a calendar-year report (`/report/request/scope/2016/`); month headers and sums still look correct.
- [ ] Download XLSX for both a short daily range and a long monthly range.
- [ ] Confirm the period sidebar still lists available months for the workstation location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reports automatically use daily grouping for ranges up to one month and monthly grouping for longer periods.
  - Multi-year date ranges display clearer month and year labels.
  - Comma-separated subject selections handle invalid or empty entries more reliably.

- **Bug Fixes**
  - Improved report totals and processing-time calculations.
  - Simplified period retrieval and improved empty-report handling.

- **Tests**
  - Added coverage for date-range grouping and monthly report retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->