### PR TITLE
feat(GH-2899): introduce zmscitizenbackend parallel to zmscitizenapi

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -63,6 +63,7 @@ body:
         - zmsbase
         - zmscalldisplay
         - zmscitizenapi
+        - zmscitizenbackend
         - zmscitizenview
         - zmsclient
         - zmsdldb

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -26,6 +26,7 @@ body:
         - zmsbase
         - zmscalldisplay
         - zmscitizenapi
+        - zmscitizenbackend
         - zmscitizenview
         - zmsclient
         - zmsdldb

--- a/.github/ISSUE_TEMPLATE/3-maintenance-work.yml
+++ b/.github/ISSUE_TEMPLATE/3-maintenance-work.yml
@@ -26,6 +26,7 @@ body:
         - zmsbase
         - zmscalldisplay
         - zmscitizenapi
+        - zmscitizenbackend
         - zmscitizenview
         - zmsclient
         - zmsdldb

--- a/.github/ISSUE_TEMPLATE/4-documentation-change.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation-change.yml
@@ -26,6 +26,7 @@ body:
         - zmsbase
         - zmscalldisplay
         - zmscitizenapi
+        - zmscitizenbackend
         - zmscitizenview
         - zmsclient
         - zmsdldb

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,14 @@ updates:
     target-branch: "next"
 
   - package-ecosystem: "composer"
+    directory: "/zmscitizenbackend"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+      timezone: "Europe/Berlin"
+    target-branch: "next"
+
+  - package-ecosystem: "composer"
     directory: "/zmsclient"
     schedule:
       interval: "daily"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -95,6 +95,10 @@
   - changed-files:
     - any-glob-to-any-file: ['zmscitizenapi/**']
 
+"Module: zmscitizenbackend":
+  - changed-files:
+    - any-glob-to-any-file: ['zmscitizenbackend/**']
+
 "Module: zmscitizenview":
   - changed-files:
     - any-glob-to-any-file: ['zmscitizenview/**']

--- a/.github/workflows/combined-workflow-with-docs.yaml
+++ b/.github/workflows/combined-workflow-with-docs.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Fix directory structure
         run: |
-          MODULES="zmsadmin zmscalldisplay zmscitizenapi zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter zmsbackend zmsclient zmscitizenview"
+          MODULES="zmsadmin zmscalldisplay zmscitizenapi zmscitizenbackend zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter zmsbackend zmsclient zmscitizenview"
           # Fix coverage reports
           for module in $MODULES; do
             if [ -d "public/coverage-temp/coverage-$module" ]; then

--- a/.github/workflows/generate-api-class-diagrams-from-zmsentities-schema.yaml
+++ b/.github/workflows/generate-api-class-diagrams-from-zmsentities-schema.yaml
@@ -64,8 +64,10 @@ jobs:
                       with open(file) as f:
                           schemas.append((file.stem, json.load(f), ''))
               
-              # Load citizen schemas
-              citizen_dir = Path('zmsentities/schema/citizenapi')
+              # Load citizen schemas (owned by zmscitizenbackend; fall back to zmsentities for older trees)
+              citizen_dir = Path('zmscitizenbackend/schema/citizenapi')
+              if not citizen_dir.exists():
+                  citizen_dir = Path('zmsentities/schema/citizenapi')
               if citizen_dir.exists():
                   for file in citizen_dir.glob('*.json'):
                       with open(file) as f:

--- a/.github/workflows/php-code-quality.yaml
+++ b/.github/workflows/php-code-quality.yaml
@@ -49,6 +49,8 @@ jobs:
             php_version: "8.3"
           - module: zmscitizenapi
             php_version: "8.3"
+          - module: zmscitizenbackend
+            php_version: "8.3"
           - module: zmsclient
             php_version: "8.3"
           - module: zmsdldb

--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -97,6 +97,8 @@ jobs:
             php_version: "8.3"
           - module: zmscitizenapi
             php_version: "8.3"
+          - module: zmscitizenbackend
+            php_version: "8.3"
           - module: zmsdldb
             php_version: "8.3"
           - module: zmsentities

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -38,6 +38,7 @@ jobs:
           - zmsbackend
           - zmscalldisplay
           - zmscitizenapi
+          - zmscitizenbackend
           - zmsclient
           - zmsdldb
           - zmsentities
@@ -183,13 +184,13 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ steps.composer-cache-monorepo.outputs.dir }}
-          key: ${{ runner.os }}-composer-psalm-monorepo-${{ hashFiles('mellon/composer.lock', 'zmsadmin/composer.lock', 'zmsbackend/composer.lock', 'zmscalldisplay/composer.lock', 'zmscitizenapi/composer.lock', 'zmsclient/composer.lock', 'zmsdldb/composer.lock', 'zmsentities/composer.lock', 'zmsmessaging/composer.lock', 'zmsslim/composer.lock', 'zmsstatistic/composer.lock', 'zmsticketprinter/composer.lock') }}
+          key: ${{ runner.os }}-composer-psalm-monorepo-${{ hashFiles('mellon/composer.lock', 'zmsadmin/composer.lock', 'zmsbackend/composer.lock', 'zmscalldisplay/composer.lock', 'zmscitizenapi/composer.lock', 'zmscitizenbackend/composer.lock', 'zmsclient/composer.lock', 'zmsdldb/composer.lock', 'zmsentities/composer.lock', 'zmsmessaging/composer.lock', 'zmsslim/composer.lock', 'zmsstatistic/composer.lock', 'zmsticketprinter/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-psalm-monorepo-
 
       - name: Install dependencies (all monorepo modules)
         run: |
-          for project in mellon zmsadmin zmsbackend zmscalldisplay zmscitizenapi zmsclient zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter; do
+          for project in mellon zmsadmin zmsbackend zmscalldisplay zmscitizenapi zmscitizenbackend zmsclient zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter; do
             echo "Installing ${project}..."
             composer install --no-progress --prefer-dist --no-interaction --working-dir="${project}"
           done

--- a/cli_base.py
+++ b/cli_base.py
@@ -32,6 +32,7 @@ class EappointmentCli:
     "zmsmessaging",
     "zmsstatistic",
     "zmscitizenapi",
+    "zmscitizenbackend",
     "zmsticketprinter",
   ]
 

--- a/docs/de/on-the-future/refarch-roadmap/product-oriented-refarch-roadmap.md
+++ b/docs/de/on-the-future/refarch-roadmap/product-oriented-refarch-roadmap.md
@@ -235,7 +235,7 @@ graph TD;
 - **Frontend-Modernisierung**: Alle Frontend-Module werden zu Vue.js-Anwendungen; `zmsadmin` und `zmsstatistic` hängen nicht mehr von `zmslayout` ab
 - **API-Gateway-Muster**: Getrennte Gateways für interne und bürgerorientierte Anwendungen
 - **Backend-Refactoring (PHP, erledigt — [GH-2604](https://github.com/it-at-m/eappointment/issues/2604))**: `zmsapi`, `zmsdb` und verwandte Schichten in **`zmsbackend`** (PHP/Slim) konsolidiert. **Ziel (Spring):** weitere Konsolidierung in einen Spring-Boot-**`zmsbackend`**-Service.
-- **Citizen-Backend**: `zmscitizenapi` → **`zmscitizenbackend`**; entfällt HTTP zu der Admin-REST-API zugunsten direkter JPA/SQL-Queries auf dem gemeinsamen Schema
+- **Citizen-Backend (PHP, in Arbeit — [GH-2899](https://github.com/it-at-m/eappointment/issues/2899))**: **`zmscitizenbackend`** existiert parallel zur live **`zmscitizenapi`**. Schema-, DB- und Repository-Arbeit läuft im neuen Modul bis zum Cutover. **Ziel (Spring):** der Name `zmscitizenbackend` bleibt.
 - **zmsmessaging**: Dedizierter EAI-Dienst für Benachrichtigungen
 - **zmsdldb**: EAI-Dienst für Stadt-München-Datenintegration mit `zmsdldbmapper`; weitere Mapper für andere Städte möglich
 - **Microservices-Architektur**: Klare Zuständigkeit durch dedizierte Dienste

--- a/docs/de/setup-and-development/development-rules/dependency-graph.md
+++ b/docs/de/setup-and-development/development-rules/dependency-graph.md
@@ -33,6 +33,7 @@ graph TD;
     zmsslim --> mellon;
 
     zmscitizenapi --> mellon & zmsslim & zmsclient & zmsentities;
+    zmscitizenbackend --> opis_json_schema["opis/json-schema"];
 
     %% npm-file:-Abhängigkeiten (gestrichelt)
     zmsadmin -.-> zmslayout;
@@ -141,7 +142,7 @@ Hinweise zu Gateway-Verhalten sowie Sicherheits-/Routing-Details siehe RefArch-A
 ### Backend-APIs und Kerndienste
 
 - `zmscitizenapi`: API-Schicht für Bürgerbuchungs-Flows; bildet Backend-Entitäten auf schlanke Frontend-DTOs ab.
-- `zmscitizenbackend`: Citizen-API-Backend unter dem RefArch-Namen, parallel zur live `zmscitizenapi` ([#2899](https://github.com/it-at-m/eappointment/issues/2899)). Traffic bleibt bis zum Cutover auf `zmscitizenapi`.
+- `zmscitizenbackend`: Citizen-API-Backend unter dem RefArch-Namen, parallel zur live `zmscitizenapi` ([#2899](https://github.com/it-at-m/eappointment/issues/2899)). Besitzt die Citizen-JSON-Schemas und die Modellvalidierung. Traffic bleibt bis zum Cutover auf `zmscitizenapi`.
 - `zmsbackend`: einheitliche Kern-Backend-REST-API und Datenbankzugriff für Vorgangs-, Warteschlangen-, Termin- und Verwaltungs-Flows.
 - `zmsdldb`: Importer/Transformer für externe DLDB-/SADB-Quellen.
 - `zmsclient`: HTTP-/API-Client-Abstraktionen, modulübergreifend genutzt.

--- a/docs/de/setup-and-development/development-rules/dependency-graph.md
+++ b/docs/de/setup-and-development/development-rules/dependency-graph.md
@@ -73,6 +73,7 @@ graph TD;
         zmsdldb
         mellon
         zmscitizenapi
+        zmscitizenbackend
     end
 
     subgraph runtime [Laufzeit / externe Dienste]
@@ -107,6 +108,7 @@ graph TD;
     classDef layout fill:#fff8e1,stroke:#f9a825,stroke-width:2px;
 
     class zmscitizenapi citizenapi;
+    class zmscitizenbackend citizenapi;
     class refarch-gateway gateway;
     class zmscitizenview citizenview;
     class dbs runtimeSvc;
@@ -139,6 +141,7 @@ Hinweise zu Gateway-Verhalten sowie Sicherheits-/Routing-Details siehe RefArch-A
 ### Backend-APIs und Kerndienste
 
 - `zmscitizenapi`: API-Schicht für Bürgerbuchungs-Flows; bildet Backend-Entitäten auf schlanke Frontend-DTOs ab.
+- `zmscitizenbackend`: Citizen-API-Backend unter dem RefArch-Namen, parallel zur live `zmscitizenapi` ([#2899](https://github.com/it-at-m/eappointment/issues/2899)). Traffic bleibt bis zum Cutover auf `zmscitizenapi`.
 - `zmsbackend`: einheitliche Kern-Backend-REST-API und Datenbankzugriff für Vorgangs-, Warteschlangen-, Termin- und Verwaltungs-Flows.
 - `zmsdldb`: Importer/Transformer für externe DLDB-/SADB-Quellen.
 - `zmsclient`: HTTP-/API-Client-Abstraktionen, modulübergreifend genutzt.

--- a/docs/de/setup-and-development/php-base-images.md
+++ b/docs/de/setup-and-development/php-base-images.md
@@ -106,6 +106,7 @@ graph TD
     PHPBASE -->|stellt Laufzeit bereit für| zmsdldb
     PHPBASE -->|stellt Laufzeit bereit für| mellon
     PHPBASE -->|stellt Laufzeit bereit für| zmscitizenapi
+    PHPBASE -->|stellt Laufzeit bereit für| zmscitizenbackend
 
     subgraph refarch["refarch"]
         style refarch stroke-dasharray:5
@@ -126,6 +127,7 @@ graph TD
         zmsdldb
         mellon
         zmscitizenapi
+        zmscitizenbackend
     end
 
     classDef foundation fill:#e3f2fd,stroke:#0277bd,stroke-width:3px
@@ -135,6 +137,7 @@ graph TD
 
     class PHPBASE foundation
     class zmscitizenapi citizenapi
+    class zmscitizenbackend citizenapi
     class refarch_gateway gateway
     class zmscitizenview citizenview
 ```

--- a/docs/de/setup-and-development/php-base-images.md
+++ b/docs/de/setup-and-development/php-base-images.md
@@ -90,6 +90,7 @@ graph TD
     zmscitizenapi --> zmsslim
     zmscitizenapi --> zmsclient
     zmscitizenapi --> zmsentities
+    zmscitizenbackend --> opis_json_schema["opis/json-schema"]
 
     zmscitizenapi -.-> zmsbackend
     refarch_gateway -.-> zmscitizenapi

--- a/docs/en/on-the-future/refarch-roadmap/product-oriented-refarch-roadmap.md
+++ b/docs/en/on-the-future/refarch-roadmap/product-oriented-refarch-roadmap.md
@@ -235,7 +235,7 @@ graph TD;
 - **Frontend Modernization**: All frontend modules converted to Vue.js applications; `zmsadmin` and `zmsstatistic` no longer depend on `zmslayout`
 - **API Gateway Pattern**: Separate gateways for internal and citizen-facing applications
 - **Backend Refactoring (PHP, done — [GH-2604](https://github.com/it-at-m/eappointment/issues/2604))**: `zmsapi`, `zmsdb`, and related layers consolidated into **`zmsbackend`** (PHP/Slim). **Target (Spring):** further consolidation into a Spring Boot **`zmsbackend`** service.
-- **Citizen backend**: `zmscitizenapi` → **`zmscitizenbackend`**; drops HTTP calls to the admin REST API in favour of direct JPA/SQL against the shared schema
+- **Citizen backend (PHP, in progress — [GH-2899](https://github.com/it-at-m/eappointment/issues/2899))**: **`zmscitizenbackend`** exists side-by-side with live **`zmscitizenapi`**. Schema, DB, and repository work proceeds in the new module until cutover. **Target (Spring):** keep the `zmscitizenbackend` name.
 - **zmsmessaging**: Dedicated EAI service for notifications
 - **zmsdldb**: EAI service for Stadt München data integration with `zmsdldbmapper`. Even possible to add other mappers for other cities.
 - **Microservices Architecture**: Clear separation of concerns with dedicated services

--- a/docs/en/setup-and-development/development-rules/dependency-graph.md
+++ b/docs/en/setup-and-development/development-rules/dependency-graph.md
@@ -33,6 +33,7 @@ graph TD;
     zmsslim --> mellon;
 
     zmscitizenapi --> mellon & zmsslim & zmsclient & zmsentities;
+    zmscitizenbackend --> opis_json_schema["opis/json-schema"];
 
     %% npm file: dependencies (dashed)
     zmsadmin -.-> zmslayout;
@@ -141,7 +142,7 @@ For gateway behavior and security/routing details, see the RefArch API Gateway d
 ### Backend APIs and Core Services
 
 - `zmscitizenapi`: API layer for citizen booking flows, mapping backend entities into thinned frontend DTOs.
-- `zmscitizenbackend`: RefArch-named Citizen API backend, introduced side-by-side with live `zmscitizenapi` ([#2899](https://github.com/it-at-m/eappointment/issues/2899)). Traffic stays on `zmscitizenapi` until cutover.
+- `zmscitizenbackend`: RefArch-named Citizen API backend, introduced side-by-side with live `zmscitizenapi` ([#2899](https://github.com/it-at-m/eappointment/issues/2899)). Owns Citizen JSON schemas and model validation. Traffic stays on `zmscitizenapi` until cutover.
 - `zmsbackend`: unified core backend REST API and database access for process, queue, appointment, and administration flows.
 - `zmsdldb`: importer/transformer for external DLDB/SADB sources.
 - `zmsclient`: HTTP/API client abstractions used between modules.

--- a/docs/en/setup-and-development/development-rules/dependency-graph.md
+++ b/docs/en/setup-and-development/development-rules/dependency-graph.md
@@ -73,6 +73,7 @@ graph TD;
         zmsdldb
         mellon
         zmscitizenapi
+        zmscitizenbackend
     end
 
     subgraph runtime [Runtime / external services]
@@ -107,6 +108,7 @@ graph TD;
     classDef layout fill:#fff8e1,stroke:#f9a825,stroke-width:2px;
 
     class zmscitizenapi citizenapi;
+    class zmscitizenbackend citizenapi;
     class refarch-gateway gateway;
     class zmscitizenview citizenview;
     class dbs runtimeSvc;
@@ -139,6 +141,7 @@ For gateway behavior and security/routing details, see the RefArch API Gateway d
 ### Backend APIs and Core Services
 
 - `zmscitizenapi`: API layer for citizen booking flows, mapping backend entities into thinned frontend DTOs.
+- `zmscitizenbackend`: RefArch-named Citizen API backend, introduced side-by-side with live `zmscitizenapi` ([#2899](https://github.com/it-at-m/eappointment/issues/2899)). Traffic stays on `zmscitizenapi` until cutover.
 - `zmsbackend`: unified core backend REST API and database access for process, queue, appointment, and administration flows.
 - `zmsdldb`: importer/transformer for external DLDB/SADB sources.
 - `zmsclient`: HTTP/API client abstractions used between modules.

--- a/docs/en/setup-and-development/php-base-images.md
+++ b/docs/en/setup-and-development/php-base-images.md
@@ -106,6 +106,7 @@ graph TD
     PHPBASE -->|provides runtime for| zmsdldb
     PHPBASE -->|provides runtime for| mellon
     PHPBASE -->|provides runtime for| zmscitizenapi
+    PHPBASE -->|provides runtime for| zmscitizenbackend
 
     subgraph refarch["refarch"]
         style refarch stroke-dasharray:5
@@ -126,6 +127,7 @@ graph TD
         zmsdldb
         mellon
         zmscitizenapi
+        zmscitizenbackend
     end
 
     classDef foundation fill:#e3f2fd,stroke:#0277bd,stroke-width:3px
@@ -135,6 +137,7 @@ graph TD
 
     class PHPBASE foundation
     class zmscitizenapi citizenapi
+    class zmscitizenbackend citizenapi
     class refarch_gateway gateway
     class zmscitizenview citizenview
 ```

--- a/docs/en/setup-and-development/php-base-images.md
+++ b/docs/en/setup-and-development/php-base-images.md
@@ -90,6 +90,7 @@ graph TD
     zmscitizenapi --> zmsslim
     zmscitizenapi --> zmsclient
     zmscitizenapi --> zmsentities
+    zmscitizenbackend --> opis_json_schema["opis/json-schema"]
 
     zmscitizenapi -.-> zmsbackend
     refarch_gateway -.-> zmscitizenapi

--- a/psalm.monorepo.xml
+++ b/psalm.monorepo.xml
@@ -71,6 +71,10 @@
         <file name="zmscitizenapi/bootstrap.php" />
         <file name="zmscitizenapi/routing.php" />
         <file name="zmscitizenapi/tests/Zmscitizenapi/bootstrap.php" />
+        <directory name="zmscitizenbackend/src" />
+        <directory name="zmscitizenbackend/tests" />
+        <file name="zmscitizenbackend/config.example.php" />
+        <file name="zmscitizenbackend/tests/Zmscitizenbackend/bootstrap.php" />
         <directory name="zmsclient/src" />
         <directory name="zmsclient/bin" />
         <directory name="zmsclient/tests" />
@@ -117,6 +121,7 @@
             <directory name="zmsbackend/vendor" />
             <directory name="zmscalldisplay/vendor" />
             <directory name="zmscitizenapi/vendor" />
+            <directory name="zmscitizenbackend/vendor" />
             <directory name="zmsclient/vendor" />
             <directory name="zmsdldb/vendor" />
             <directory name="zmsentities/vendor" />
@@ -135,6 +140,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -151,6 +157,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -167,6 +174,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -183,6 +191,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -199,6 +208,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -215,6 +225,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -231,6 +242,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -247,6 +259,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -263,6 +276,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -280,6 +294,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -296,6 +311,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -312,6 +328,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -328,6 +345,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -345,6 +363,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -361,6 +380,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -377,6 +397,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -393,6 +414,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -409,6 +431,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -425,6 +448,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -441,6 +465,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -457,6 +482,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -473,6 +499,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -489,6 +516,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -505,6 +533,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -521,6 +550,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -537,6 +567,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -553,6 +584,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -588,6 +620,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -604,6 +637,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -620,6 +654,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -636,6 +671,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -652,6 +688,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -668,6 +705,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -684,6 +722,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -700,6 +739,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -716,6 +756,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -732,6 +773,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -758,6 +800,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -774,6 +817,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -790,6 +834,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -806,6 +851,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -822,6 +868,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />
@@ -838,6 +885,7 @@
                 <directory name="zmsbackend/tests" />
                 <directory name="zmscalldisplay/tests" />
                 <directory name="zmscitizenapi/tests" />
+                <directory name="zmscitizenbackend/tests" />
                 <directory name="zmsclient/tests" />
                 <directory name="zmsdldb/tests" />
                 <directory name="zmsentities/tests" />

--- a/zmscitizenbackend/.gitignore
+++ b/zmscitizenbackend/.gitignore
@@ -1,0 +1,11 @@
+vendor
+vendor.zmsbase
+config.php
+tags
+.DS_*
+cache
+VERSION
+.phpunit.result.cache
+coverage
+.phpunit.cache
+.phpunit.cache/test-results

--- a/zmscitizenbackend/README.md
+++ b/zmscitizenbackend/README.md
@@ -1,0 +1,23 @@
+# zmscitizenbackend
+
+Standalone Citizen API backend (RefArch name). Introduced **side-by-side** with live [`zmscitizenapi`](../zmscitizenapi) so schemas, database access, and repositories can move here without churning the serving module.
+
+Tracked in [it-at-m/eappointment#2899](https://github.com/it-at-m/eappointment/issues/2899).
+
+## Status
+
+`zmscitizenapi` still serves traffic. This package is the parallel refactor target: public JSON contract stays compatible until an intentional cutover (gateway / `zmscitizenview` / deploy). After cutover, `zmscitizenapi` is retired. The Spring Boot phase keeps the `zmscitizenbackend` name.
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `src/Zmscitizenbackend/` | PSR-4 namespace `BO\Zmscitizenbackend\` |
+| `tests/Zmscitizenbackend/` | PHPUnit suite |
+
+## Tests
+
+```bash
+composer install
+./vendor/bin/phpunit -c phpunit.xml
+```

--- a/zmscitizenbackend/README.md
+++ b/zmscitizenbackend/README.md
@@ -8,11 +8,16 @@ Tracked in [it-at-m/eappointment#2899](https://github.com/it-at-m/eappointment/i
 
 `zmscitizenapi` still serves traffic. This package is the parallel refactor target: public JSON contract stays compatible until an intentional cutover (gateway / `zmscitizenview` / deploy). After cutover, `zmscitizenapi` is retired. The Spring Boot phase keeps the `zmscitizenbackend` name.
 
+Citizen JSON schemas and model validation live in this module (`schema/citizenapi` + `BO\Zmscitizenbackend\Schema\Entity`). They do not load from `zmsentities` schema paths.
+
 ## Layout
 
 | Path | Role |
 |------|------|
 | `src/Zmscitizenbackend/` | PSR-4 namespace `BO\Zmscitizenbackend\` |
+| `src/Zmscitizenbackend/Schema/` | JSON Schema loader, Entity base, and opis-based validator |
+| `src/Zmscitizenbackend/Models/` | Citizen models hydrated against local schemas |
+| `schema/citizenapi/` | Citizen JSON schemas (owned here; `zmsentities/schema/citizenapi` remains for live `zmscitizenapi` until cutover) |
 | `tests/Zmscitizenbackend/` | PHPUnit suite |
 
 ## Tests

--- a/zmscitizenbackend/composer.json
+++ b/zmscitizenbackend/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "eappointment/zmscitizenbackend",
+    "description": "Standalone Citizen API backend (RefArch name). Parallel to zmscitizenapi until cutover.",
+    "license": "EUPL-1.2",
+    "authors": [],
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../*",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        },
+        "platform": {
+            "php": "8.3.99"
+        }
+    },
+    "require-dev": {
+        "vimeo/psalm": "6.5.0",
+        "phpmd/phpmd": "@stable",
+        "squizlabs/php_codesniffer": "^4.0",
+        "phpunit/phpunit": "^11",
+        "roave/security-advisories": "dev-latest"
+    },
+    "require": {
+        "php": ">=8.3",
+        "roave/security-advisories": "dev-latest"
+    },
+    "autoload": {
+        "psr-4": {
+            "BO\\Zmscitizenbackend\\": "src/Zmscitizenbackend/",
+            "BO\\Zmscitizenbackend\\Tests\\": "tests/Zmscitizenbackend/"
+        }
+    }
+}

--- a/zmscitizenbackend/composer.json
+++ b/zmscitizenbackend/composer.json
@@ -29,6 +29,7 @@
     },
     "require": {
         "php": ">=8.3",
+        "opis/json-schema": "^2.4",
         "roave/security-advisories": "dev-latest"
     },
     "autoload": {

--- a/zmscitizenbackend/composer.lock
+++ b/zmscitizenbackend/composer.lock
@@ -1,0 +1,6521 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "97dd79234917f09dafa536722e285e9c",
+    "packages": [
+        {
+            "name": "roave/security-advisories",
+            "version": "dev-latest",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "6c0be3a74b4e70c18693ae5dc183132b4d17603a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6c0be3a74b4e70c18693ae5dc183132b4d17603a",
+                "reference": "6c0be3a74b4e70c18693ae5dc183132b4d17603a",
+                "shasum": ""
+            },
+            "conflict": {
+                "3f/pygmentize": "<1.2",
+                "adaptcms/adaptcms": "<=1.3",
+                "adawolfa/isdoc": "<1.4.3|>=1.5,<1.5.1|>=1.6,<1.6.1",
+                "admidio/admidio": "<=5.0.11",
+                "adodb/adodb-php": "<=5.22.9",
+                "aheinze/cockpit": "<2.2",
+                "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
+                "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
+                "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
+                "aimeos/ai-cms-grapesjs": ">=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.9|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.10.8|>=2025.04.1,<2025.10.2",
+                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9|==2024.04.1",
+                "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
+                "aimeos/aimeos-laravel": "==2021.10",
+                "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
+                "aimeos/pagible": "<0.10.4",
+                "airesvsg/acf-to-rest-api": "<=3.1",
+                "akaunting/akaunting": "<2.1.13",
+                "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
+                "alextselegidis/easyappointments": "<=1.5.2",
+                "alexusmai/laravel-file-manager": "<=3.3.1",
+                "algolia/algoliasearch-magento-2": "<=3.16.1|>=3.17.0.0-beta1,<=3.17.1",
+                "almirhodzic/nova-toggle-5": "<1.3",
+                "alt-design/alt-redirect": "<1.6.4",
+                "altcha-org/altcha": "<1.3.1",
+                "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+                "amazing/media2click": ">=1,<1.3.3",
+                "ameos/ameos_tarteaucitron": "<1.2.23",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<=1.7.2|>=2,<=2.1",
+                "amphp/http-client": ">=4,<4.4",
+                "amphp/http-server": ">=2.0.0.0-RC1-dev,<2.1.10|>=3.0.0.0-beta1,<3.4.4",
+                "anchorcms/anchor-cms": "<=0.12.7",
+                "andreapollastri/cipi": "<=3.1.15",
+                "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<1.0.2|>=2,<2.2.5",
+                "aoe/restler": "<1.7.1",
+                "apache-solr-for-typo3/solr": "<2.8.3",
+                "apereo/phpcas": "<1.6",
+                "api-platform/core": "<4.1.30|>=4.2,<4.2.26|>=4.3,<4.3.12",
+                "api-platform/graphql": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/hal": ">=4,<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
+                "api-platform/json-api": ">=4,<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
+                "appwrite/server-ce": "<=1.2.1",
+                "arc/web": "<3",
+                "area17/twill": "<1.2.5|>=2,<2.5.3",
+                "artesaos/seotools": "<0.17.2",
+                "asymmetricrypt/asymmetricrypt": "<9.9.99",
+                "athlon1600/php-proxy": "<=5.1",
+                "athlon1600/php-proxy-app": "<=3",
+                "athlon1600/youtube-downloader": "<=4",
+                "aureuserp/aureuserp": "<1.3.0.0-beta1",
+                "austintoddj/canvas": "<=3.4.2",
+                "auth0/auth0-php": ">=3.3,<=8.18",
+                "auth0/login": "<=7.20",
+                "auth0/symfony": "<=5.8",
+                "auth0/wordpress": "<=5.5",
+                "automad/automad": "<=2.0.0.0-beta27",
+                "automattic/jetpack": "<9.8",
+                "awesome-support/awesome-support": "<=6.0.7",
+                "aws/aws-sdk-php": "<=3.371.3",
+                "ayacoo/redirect-tab": "<2.1.2|>=3,<3.1.7|>=4,<4.0.5",
+                "azuracast/azuracast": "<=0.23.5",
+                "b13/seo_basics": "<0.8.2",
+                "backdrop/backdrop": "<=1.32",
+                "backpack/crud": "<6.8.15|>=7,<7.0.47",
+                "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
+                "bacula-web/bacula-web": "<9.7.1",
+                "badaso/core": "<=2.9.11",
+                "bagisto/bagisto": "<=2.3.15",
+                "barrelstrength/sprout-base-email": "<1.2.7",
+                "barrelstrength/sprout-forms": "<3.9",
+                "barryvdh/laravel-translation-manager": "<0.6.8",
+                "barzahlen/barzahlen-php": "<2.0.1",
+                "baserproject/basercms": "<=5.2.2",
+                "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
+                "bbpress/bbpress": "<2.6.5",
+                "bcit-ci/codeigniter": "<3.1.3",
+                "bcosca/fatfree": "<3.7.2",
+                "bedita/bedita": "<4",
+                "bednee/cooluri": "<1.0.30",
+                "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
+                "billabear/billabear": "<=2025.01.03",
+                "billz/raspap-webgui": "<3.3.6",
+                "binarytorch/larecipe": "<2.8.1",
+                "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
+                "blueimp/jquery-file-upload": "==6.4.4",
+                "bmarshall511/wordpress_zero_spam": "<5.2.13",
+                "bolt/bolt": "<3.7.2",
+                "bolt/core": "<=4.2",
+                "born05/craft-twofactorauthentication": "<3.3.4",
+                "bottelet/flarepoint": "<2.2.1",
+                "bref/bref": "<2.1.17",
+                "brightlocal/phpwhois": "<=4.2.5",
+                "brotkrueml/codehighlight": "<2.7",
+                "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
+                "brotkrueml/typo3-matomo-integration": "<1.3.2",
+                "buddypress/buddypress": "<14.5",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "bvbmedia/multishop": "<2.0.39",
+                "bytefury/crater": "<6.0.2",
+                "cachethq/cachet": "<2.5.1",
+                "cadmium-org/cadmium-cms": "<=0.4.9",
+                "cakephp/authentication": "<2.11.1|>=3,<3.3.6|>=4,<4.1.1",
+                "cakephp/cakephp": "<4.5.11|>=4.6,<4.6.4|>=5,<5.1.7|>=5.2,<5.2.13|>=5.3,<5.3.6",
+                "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
+                "cardgate/magento2": "<2.0.33",
+                "cardgate/woocommerce": "<=3.1.15",
+                "cart2quote/module-quotation": ">=4.1.6,<4.4.6|>=5,<5.4.4",
+                "cart2quote/module-quotation-encoded": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<2.1.7",
+                "catfan/medoo": "<1.7.5",
+                "causal/oidc": "<4",
+                "cecil/cecil": "<7.47.1",
+                "centreon/centreon": "<22.10.15",
+                "cesargb/laravel-magiclink": ">=2,<2.25.1",
+                "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+                "chriskacerguis/codeigniter-restserver": "<=2.7.1",
+                "chrome-php/chrome": "<1.14",
+                "ci4-cms-erp/ci4ms": "<=0.31.8",
+                "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
+                "ckeditor/ckeditor": "<4.25",
+                "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
+                "co-stack/fal_sftp": "<0.2.6",
+                "cockpit-hq/cockpit": "<=2.14",
+                "code16/sharp": "<9.22.3",
+                "codeception/codeception": "<3.1.3|>=4,<4.1.22",
+                "codeigniter/framework": "<3.1.10",
+                "codeigniter4/framework": "<4.7.4",
+                "codeigniter4/shield": "<1.0.0.0-beta8",
+                "codiad/codiad": "<=2.8.4",
+                "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
+                "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
+                "commerceteam/commerce": ">=0.9.6,<0.9.9",
+                "components/jquery": ">=1.0.3,<3.5",
+                "composer/composer": "<2.2.29|>=2.3,<2.10.2",
+                "concrete5/concrete5": "<9.5.2",
+                "concrete5/core": "<8.5.8|>=9,<9.1",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
+                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<5.3.48|>=5.4,<5.7.9",
+                "contao/core": "<3.5.39",
+                "contao/core-bundle": "<5.3.48|>=5.4,<5.7.9",
+                "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
+                "contao/managed-edition": "<=1.5",
+                "coreshop/core-shop": "<4.1.9|==5",
+                "corveda/phpsandbox": "<1.3.5",
+                "cosenary/instagram": "<=2.3",
+                "cotonti/cotonti": "<=1",
+                "couleurcitron/tarteaucitron-wp": "<0.3",
+                "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
+                "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
+                "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
+                "craftcms/cms": "<4.18.3|>=5,<5.10.8",
+                "craftcms/commerce": ">=4,<=4.11.1|>=5,<=5.6.4",
+                "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
+                "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
+                "craftcms/google-cloud": ">=2.0.0.0-beta1,<=2.2",
+                "craftcms/webhooks": ">=3,<3.2",
+                "croogo/croogo": "<=4.0.7",
+                "cuyz/valinor": "<0.12",
+                "czim/file-handling": "<1.5|>=2,<2.3",
+                "czproject/git-php": "<4.0.3",
+                "damienharper/auditor-bundle": "<5.2.6",
+                "dapphp/securimage": "<3.6.6",
+                "darylldoyle/safe-svg": "<1.9.10",
+                "datadog/dd-trace": ">=0.30,<0.30.2",
+                "datahihi1/tiny-env": "<1.0.3|>=1.0.9,<1.0.11",
+                "datatables/datatables": "<1.10.10",
+                "david-garcia/phpwhois": "<=4.3.1",
+                "dbrisinajumi/d2files": "<1",
+                "dcat/laravel-admin": "<=2.1.3|==2.2.0.0-beta|==2.2.2.0-beta",
+                "dedoc/scramble": ">=0.13.2,<0.13.22",
+                "derhansen/fe_change_pwd": "<2.0.5|>=3,<3.0.3",
+                "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1|>=7,<7.4",
+                "desperado/xml-bundle": "<=0.1.7",
+                "dev-lancer/minecraft-motd-parser": "<=1.0.5",
+                "devcode-it/openstamanager": "<=2.10.1",
+                "devgroup/dotplant": "<2020.09.14-dev",
+                "digimix/wp-svg-upload": "<=1",
+                "directmailteam/direct-mail": "<6.0.3|>=7,<7.0.3|>=8,<9.5.2",
+                "directorytree/imapengine": "<1.22.3",
+                "dl/yag": "<3.0.1",
+                "dmk/webkitpdf": "<1.1.4",
+                "dnadesign/silverstripe-elemental": "<5.3.12",
+                "doctrine/annotations": "<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": "<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2|>=3,<3.1.4",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<0.7.2",
+                "doctrine/mongodb-odm": "<1.0.2",
+                "doctrine/mongodb-odm-bundle": "<3.0.1",
+                "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
+                "dolibarr/dolibarr": "<=23.0.2",
+                "dompdf/dompdf": "<3.1.6",
+                "doublethreedigital/guest-entries": "<3.1.2",
+                "dreamfactory/df-core": "<1.0.4",
+                "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
+                "drupal/access_code": "<2.0.5",
+                "drupal/acquia_dam": "<1.1.5",
+                "drupal/admin_audit_trail": "<1.0.5",
+                "drupal/ai": "<1.0.5",
+                "drupal/alogin": "<2.0.6",
+                "drupal/cache_utility": "<1.2.1",
+                "drupal/civictheme": "<1.12",
+                "drupal/commerce_alphabank_redirect": "<1.0.3",
+                "drupal/commerce_eurobank_redirect": "<2.1.1",
+                "drupal/config_split": "<1.10|>=2,<2.0.2",
+                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.5.10|>=10.6,<10.6.9|>=11,<11.2.12|>=11.3,<11.3.10",
+                "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
+                "drupal/currency": "<3.5",
+                "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
+                "drupal/email_tfa": "<2.0.6",
+                "drupal/formatter_suite": "<2.1",
+                "drupal/gdpr": "<3.0.1|>=3.1,<3.1.2",
+                "drupal/google_tag": "<1.8|>=2,<2.0.8",
+                "drupal/ignition": "<1.0.4",
+                "drupal/json_field": "<1.5",
+                "drupal/lightgallery": "<1.6",
+                "drupal/link_field_display_mode_formatter": "<1.6",
+                "drupal/matomo": "<1.24",
+                "drupal/oauth2_client": "<4.1.3",
+                "drupal/oauth2_server": "<2.1",
+                "drupal/obfuscate": "<2.0.1",
+                "drupal/plausible_tracking": "<1.0.2",
+                "drupal/quick_node_block": "<2",
+                "drupal/rapidoc_elements_field_formatter": "<1.0.1",
+                "drupal/reverse_proxy_header": "<1.1.2",
+                "drupal/simple_multistep": "<2",
+                "drupal/simple_oauth": ">=6,<6.0.7",
+                "drupal/spamspan": "<3.2.1",
+                "drupal/tfa": "<1.10",
+                "drupal/umami_analytics": "<1.0.1",
+                "duncanmcclean/guest-entries": "<3.1.2",
+                "dweeves/magmi": "<=0.7.24",
+                "easycorp/easyadmin-bundle": ">=4,<4.29.16|>=5,<5.5.1",
+                "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
+                "ecodev/newsletter": "<=4",
+                "ectouch/ectouch": "<=2.7.2",
+                "egroupware/egroupware": "<23.1.20260601|>=26.0.20251208,<26.5.20260507",
+                "elefant/cms": "<2.0.7",
+                "elgg/elgg": "<3.3.24|>=4,<4.0.5",
+                "elijaa/phpmemcacheadmin": "<=1.3",
+                "elmsln/haxcms": "<11.0.14",
+                "encore/laravel-admin": "<=1.8.19",
+                "endroid/qr-code-bundle": "<3.4.2",
+                "enhavo/enhavo-app": "<=0.13.1",
+                "enshrined/svg-sanitize": "<0.22",
+                "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
+                "evolutioncms/evolution": "<=3.2.3",
+                "evoweb/sf-register": "<13.2.4|>=14,<14.0.2",
+                "exceedone/exment": "<4.4.3|>=5,<5.0.3",
+                "exceedone/laravel-admin": "<2.2.3|==3",
+                "ezsystems/demobundle": ">=5.4,<5.4.6.1-dev",
+                "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
+                "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1-dev",
+                "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1-dev|>=5.4,<5.4.11.1-dev|>=2017.12,<2017.12.0.1-dev",
+                "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.39|>=3.3,<3.3.39",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1|>=5.3.0.0-beta1,<5.3.5",
+                "ezsystems/ezplatform-graphql": ">=1.0.0.0-RC1-dev,<1.0.13|>=2.0.0.0-beta1,<2.3.12",
+                "ezsystems/ezplatform-http-cache": "<2.3.16",
+                "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<1.3.35",
+                "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
+                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.26|>=3.3,<3.3.40",
+                "ezsystems/ezplatform-solr-search-engine": ">=1.7,<1.7.12|>=2,<2.0.2|>=3.3,<3.3.15",
+                "ezsystems/ezplatform-user": ">=1,<1.0.1",
+                "ezsystems/ezpublish-kernel": "<=6.13.8.1|>=7,<7.5.31",
+                "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.03.5.1",
+                "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
+                "ezsystems/repository-forms": ">=2.3,<2.3.2.1-dev|>=2.5,<2.5.15",
+                "ezyang/htmlpurifier": "<=4.2",
+                "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
+                "facturascripts/facturascripts": "<=2026.2",
+                "fastly/magento2": "<1.2.26",
+                "feehi/cms": "<=2.1.1",
+                "feehi/feehicms": "<=2.1.1",
+                "fenom/fenom": "<=2.12.1",
+                "filament/actions": ">=3.2,<3.2.123|>=4,<=4.11.3|>=5,<=5.6.3",
+                "filament/filament": ">=3,<=3.3.51|>=4,<4.11.5|>=5,<5.6.5",
+                "filament/forms": ">=3,<=3.3.52",
+                "filament/infolists": ">=3,<3.2.115|>=4,<=4.11.4|>=5,<=5.6.4",
+                "filament/tables": ">=3,<=3.3.50|>=4,<=4.11.4|>=5,<=5.6.4",
+                "filegator/filegator": "<7.8",
+                "filp/whoops": "<2.1.13",
+                "fineuploader/php-traditional-server": "<=1.2.2",
+                "firebase/php-jwt": "<7",
+                "fisharebest/webtrees": "<=2.1.18",
+                "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
+                "fixpunkt/fp-newsletter": "<1.1.1|>=1.2,<2.1.2|>=2.2,<3.2.6",
+                "flarum/core": "<=1.8.15|>=2.0.0.0-beta1,<=2.0.0.0-beta8",
+                "flarum/flarum": "<0.1.0.0-beta8",
+                "flarum/framework": "<1.8.10",
+                "flarum/mentions": "<1.6.3",
+                "flarum/nicknames": "<1.8.3",
+                "flarum/sticky": ">=0.1.0.0-beta14,<=0.1.0.0-beta15",
+                "flarum/tags": "<=0.1.0.0-beta13",
+                "flightphp/core": "<3.18.1",
+                "floriangaerber/magnesium": "<0.3.1",
+                "fluidtypo3/vhs": "<5.1.1",
+                "fof/byobu": ">=0.3.0.0-beta2,<1.1.7",
+                "fof/pretty-mail": "<=1.1.2",
+                "fof/upload": "<1.2.3",
+                "foodcoopshop/foodcoopshop": ">=3.2,<3.6.1",
+                "fooman/tcpdf": "<6.2.22",
+                "forkcms/forkcms": "<5.11.1",
+                "fossar/tcpdf-parser": "<6.2.22",
+                "francoisjacquet/rosariosis": "<=11.5.1",
+                "frappant/frp-form-answers": "<3.1.2|>=4,<4.0.2",
+                "friendsofsymfony/oauth2-php": "<1.3",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1,<1.3.5",
+                "friendsofsymfony1/swiftmailer": ">=4,<5.4.13|>=6,<6.2.5",
+                "friendsofsymfony1/symfony1": ">=1.1,<1.5.19",
+                "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
+                "friendsoftypo3/tt-address": "<8.1.2|>=9,<9.1.1|>=10,<10.0.1",
+                "froala/wysiwyg-editor": "<=4.3",
+                "frosh/adminer-platform": "<2.2.1",
+                "froxlor/froxlor": "<2.3.8",
+                "frozennode/administrator": "<=5.0.12",
+                "fuel/core": "<1.8.1",
+                "funadmin/funadmin": "<=7.1.0.0-RC6",
+                "gaoming13/wechat-php-sdk": "<=1.10.2",
+                "genix/cms": "<=1.1.11",
+                "georgringer/news": "<10.0.4|>=11,<11.4.4|>=12,<12.3.2|>=13,<13.0.2|>=14,<14.0.3",
+                "geshi/geshi": "<=1.0.9.1",
+                "getformwork/formwork": "<=2.3.3",
+                "getgrav/grav": "<=2.0.19",
+                "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
+                "getgrav/grav-plugin-form": "<9.1",
+                "getkirby/cms": "<=4.9.3|>=5,<=5.4.3",
+                "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
+                "getkirby/panel": "<2.5.14",
+                "getkirby/starterkit": "<=3.7.0.2",
+                "gilacms/gila": "<=1.15.4",
+                "gleez/cms": "<=1.3|==2",
+                "globalpayments/php-sdk": "<2",
+                "goalgorilla/open_social": "<12.3.11|>=12.4,<12.4.10|>=13.0.0.0-alpha1,<13.0.0.0-alpha11",
+                "gogentooss/samlbase": "<1.2.7",
+                "goodoneuz/pay-uz": "<=2.2.24",
+                "google/protobuf": "<4.33.6",
+                "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
+                "gp247/core": "<1.1.24",
+                "gree/jose": "<2.2.1",
+                "gregwar/rst": "<1.0.3",
+                "grumpydictator/firefly-iii": "<=6.6.2",
+                "gugoan/economizzer": "<=0.9.0.0-beta1",
+                "guzzlehttp/guzzle": "<7.15.2|>=8,<8.0.1",
+                "guzzlehttp/guzzle-services": "<1.5.4",
+                "guzzlehttp/oauth-subscriber": "<0.8.1",
+                "guzzlehttp/psr7": "<2.12.3",
+                "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
+                "handcraftedinthealps/goodby-csv": "<1.4.3",
+                "harvesthq/chosen": "<1.8.7",
+                "helloxz/imgurl": "<=2.31",
+                "hhxsv5/laravel-s": "<3.7.36",
+                "hillelcoren/invoice-ninja": "<5.3.35",
+                "himiklab/yii2-jqgrid-widget": "<1.0.8",
+                "hjue/justwriting": "<=1",
+                "hov/jobfair": "<1.0.13|>=2,<2.0.2",
+                "httpsoft/http-message": "<1.0.12",
+                "hybridauth/hybridauth": "<=3.12.2",
+                "hyn/multi-tenant": ">=5.6,<5.7.2",
+                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.25|>=5,<5.0.3",
+                "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
+                "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3|>=4.5,<4.5.6|>=4.6,<4.6.2",
+                "ibexa/fieldtype-richtext": ">=4.6,<4.6.25|>=5,<5.0.3",
+                "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
+                "ibexa/http-cache": ">=4.6,<4.6.14",
+                "ibexa/post-install": "<1.0.16|>=4.6,<4.6.14",
+                "ibexa/solr": ">=4.5,<4.5.4",
+                "ibexa/user": ">=4,<4.4.3|>=5,<5.0.4",
+                "icecoder/icecoder": "<=8.1",
+                "idno/known": "<1.6.4",
+                "ilicmiljan/secure-props": ">=1.2,<1.2.2",
+                "illuminate/auth": "<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<6.18.31|>=7,<7.22.4",
+                "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/mail": ">=9,<12.60|>=13,<13.10",
+                "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
+                "imdbphp/imdbphp": "<=5.1.1",
+                "impresscms/impresscms": "<=1.4.5",
+                "impresspages/impresspages": "<1.0.13",
+                "in2code/femanager": "<6.4.2|>=7,<7.5.3|>=8,<8.3.1",
+                "in2code/ipandlanguageredirect": "<5.1.2",
+                "in2code/lux": "<17.6.1|>=18,<24.0.2",
+                "in2code/powermail": "<7.5.1|>=8,<8.5.1|>=9,<10.9.1|>=11,<12.5.3|==13",
+                "innologi/typo3-appointments": "<2.0.6",
+                "intelliants/subrion": "<4.2.2",
+                "inter-mediator/inter-mediator": "==5.5",
+                "intercom/intercom-php": "==5.0.2",
+                "invoiceninja/invoiceninja": "<5.13.4",
+                "ipl/web": "<=0.10.2|>=0.11,<=0.13",
+                "islandora/crayfish": "<4.1",
+                "islandora/islandora": ">=2,<2.4.1",
+                "ivankristianto/phpwhois": "<=4.3",
+                "j0k3r/graby": "<=2.5",
+                "jackalope/jackalope-doctrine-dbal": "<1.7.4",
+                "jambagecom/div2007": "<0.10.2",
+                "james-heinrich/getid3": "<1.9.21",
+                "james-heinrich/phpthumb": "<=1.7.23",
+                "jasig/phpcas": "<1.3.3",
+                "jbartels/wec-map": "<3.0.3",
+                "jcbrand/converse.js": "<3.3.3",
+                "jleehr/canto-saas-api": "<=2",
+                "joedolson/my-calendar": "<3.7.7",
+                "joelbutcher/socialstream": "<5.6|>=6,<6.2",
+                "johnbillion/query-monitor": "<3.20.4",
+                "johnbillion/wp-crontrol": "<1.16.2|>=1.17,<1.19.2",
+                "joomla/application": "<1.0.13",
+                "joomla/archive": "<1.1.12|>=2,<2.0.1",
+                "joomla/database": ">=1,<2.2|>=3,<3.4",
+                "joomla/filesystem": "<1.6.2|>=2,<2.0.1",
+                "joomla/filter": "<2.0.6|>=3,<3.0.5|==4",
+                "joomla/framework": "<1.5.7|>=2.5.4,<=3.8.12",
+                "joomla/input": ">=2,<2.0.2",
+                "joomla/joomla-cms": "<3.9.12|>=4,<4.4.13|>=5,<5.2.6",
+                "joomla/joomla-platform": "<1.5.4",
+                "joomla/session": "<1.3.1",
+                "joyqi/hyper-down": "<=2.4.27",
+                "jsdecena/laracom": "<2.0.9",
+                "jsmitty12/phpwhois": "<5.1",
+                "juzaweb/cms": "<=3.4.2",
+                "jweiland/events2": "<8.3.8|>=9,<9.0.6",
+                "jweiland/kk-downloader": "<1.2.2",
+                "kantorge/yaffa": "<=2",
+                "kazist/phpwhois": "<=4.2.6",
+                "kelvinmo/simplejwt": "<=1.1",
+                "kelvinmo/simplexrd": "<3.1.1",
+                "kevinpapst/kimai2": "<1.16.7",
+                "khodakhah/nodcms": "<=3.4.1",
+                "kimai/kimai": "<2.59",
+                "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
+                "klaviyo/magento2-extension": ">=1,<3",
+                "knplabs/knp-snappy": "<=1.7",
+                "kohana/core": "<3.3.3",
+                "koillection/koillection": "<1.6.12",
+                "krayin/laravel-crm": "<=2.2",
+                "kreait/firebase-php": ">=3.2,<3.8.1",
+                "kumbiaphp/kumbiapp": "<=1.1.1",
+                "la-haute-societe/tcpdf": "<6.2.22",
+                "laktak/hjson": "<2.3",
+                "laminas/laminas-diactoros": "<2.18.1|==2.19|==2.20|==2.21|==2.22|==2.23|>=2.24,<2.24.2|>=2.25,<2.25.2",
+                "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
+                "laminas/laminas-http": "<2.14.2",
+                "lara-zeus/artemis": ">=1,<=1.0.6",
+                "lara-zeus/dynamic-dashboard": ">=3,<=3.0.1",
+                "laravel/fortify": "<1.11.1",
+                "laravel/framework": "<12.61.1|>=13,<13.12",
+                "laravel/laravel": ">=5.4,<5.4.22",
+                "laravel/passport": ">=13,<13.7.1",
+                "laravel/pulse": "<1.3.1",
+                "laravel/reverb": "<1.7",
+                "laravel/socialite": ">=1,<2.0.10",
+                "latte/latte": "<2.10.8",
+                "lavalite/cms": "<=10.1",
+                "lavitto/typo3-form-to-database": "<2.2.5|>=3,<3.2.2|>=4,<4.2.3|>=5,<5.0.2",
+                "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
+                "league/commonmark": "<2.9",
+                "league/flysystem": "<1.1.4|>=2,<2.1.1",
+                "league/oauth2-server": ">=8.3.2,<8.4.2|>=8.5,<8.5.3",
+                "leantime/leantime": "<3.3",
+                "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
+                "libreform/libreform": ">=2,<=2.0.8",
+                "librenms/librenms": "<26.7",
+                "liftkit/database": "<2.13.2",
+                "lightsaml/lightsaml": "<1.3.5",
+                "limesurvey/limesurvey": "<=7.0.0.0-beta1",
+                "livehelperchat/livehelperchat": "<=3.91",
+                "livewire-filemanager/filemanager": "<=1.0.4",
+                "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.6.4",
+                "livewire/volt": "<1.7",
+                "lms/routes": "<2.1.1",
+                "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
+                "lomkit/laravel-rest-api": "<2.13",
+                "luracast/restler": "<3.1",
+                "luyadev/yii-helpers": "<1.2.1",
+                "macropay-solutions/laravel-crud-wizard-free": "<3.4.17",
+                "maestroerror/php-heic-to-jpg": "<1.0.5",
+                "magento/community-edition": "<2.4.6.0-patch13|>=2.4.7.0-beta1,<2.4.7.0-patch8|>=2.4.8.0-beta1,<2.4.8.0-patch3|>=2.4.9.0-alpha1,<2.4.9.0-alpha3|==2.4.9",
+                "magento/core": "<=1.9.4.5",
+                "magento/magento1ce": "<1.9.4.3-dev",
+                "magento/magento1ee": ">=1,<1.14.4.3-dev",
+                "magento/product-community-edition": "<2.4.4.0-patch9|>=2.4.5,<2.4.5.0-patch8|>=2.4.6,<2.4.6.0-patch6|>=2.4.7,<2.4.7.0-patch1",
+                "magento/project-community-edition": "<=2.0.2",
+                "magneto/core": "<1.9.4.4-dev",
+                "mahocommerce/maho": "<25.9",
+                "maikuolan/phpmussel": ">=1,<1.6",
+                "mainwp/mainwp": "<=4.4.3.3",
+                "manogi/nova-tiptap": "<=3.2.6",
+                "mantisbt/mantisbt": "<=2.28.3",
+                "marcwillmann/turn": "<0.3.3",
+                "markhuot/craftql": "<=1.3.7",
+                "marshmallow/nova-tiptap": "<5.7",
+                "matomo/matomo": "<1.11",
+                "matyhtf/framework": "<3.0.6",
+                "mautic/core": "<5.2.11|>=6,<6.0.9|>=7,<7.1.2",
+                "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
+                "mautic/grapes-js-builder-bundle": ">=4,<4.4.18|>=5,<5.2.9|>=6,<6.0.7",
+                "maximebf/debugbar": "<1.19",
+                "mckenziearts/livewire-markdown-editor": "<1.3",
+                "mcp/sdk": ">=0.5,<0.7.1",
+                "mdanter/ecc": "<2",
+                "mediawiki/abuse-filter": "<1.39.9|>=1.40,<1.41.3|>=1.42,<1.42.2",
+                "mediawiki/cargo": "<3.8.3",
+                "mediawiki/core": "<1.39.5|==1.40",
+                "mediawiki/data-transfer": ">=1.39,<1.39.11|>=1.41,<1.41.3|>=1.42,<1.42.2",
+                "mediawiki/maps": "<12.1.3",
+                "mediawiki/matomo": "<2.4.3",
+                "mediawiki/semantic-media-wiki": "<4.0.2",
+                "mehrwert/phpmyadmin": "<3.2",
+                "melisplatform/melis-asset-manager": "<5.0.1",
+                "melisplatform/melis-cms": "<5.3.4",
+                "melisplatform/melis-cms-slider": "<5.3.1",
+                "melisplatform/melis-core": "<5.3.11",
+                "melisplatform/melis-front": "<5.0.1",
+                "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
+                "mgallegos/laravel-jqgrid": "<=1.3",
+                "microsoft/microsoft-graph": ">=1.16,<1.109.1|>=2,<2.0.1",
+                "microsoft/microsoft-graph-beta": "<2.0.1",
+                "microsoft/microsoft-graph-core": "<2.0.2",
+                "microweber/microweber": "<2.0.20",
+                "mikehaertl/php-shellcommand": "<1.6.1",
+                "mineadmin/mineadmin": "<3.2.0.0-alpha2",
+                "miniorange/miniorange-saml": "<1.4.3",
+                "miraheze/ts-portal": "<=33",
+                "mittwald/typo3_forum": "<1.2.1",
+                "mix/mix": ">=2,<=2.2.17",
+                "mmc/ceselector": "<3.0.3|>=4,<4.0.2|>=5,<5.0.1|>=6,<6.0.1",
+                "mobiledetect/mobiledetectlib": "<2.8.32",
+                "modx/revolution": "<=3.1",
+                "mojo42/jirafeau": "<4.4",
+                "mongodb/mongodb": ">=1,<1.9.2",
+                "mongodb/mongodb-extension": "<1.21.2",
+                "monolog/monolog": ">=1.8,<1.12",
+                "moodle/moodle": "<4.5.9|>=5.0.0.0-beta,<5.0.5|>=5.1.0.0-beta,<5.1.2",
+                "moonshine/moonshine": "<=3.12.5",
+                "mos/cimage": "<0.7.19",
+                "movim/moxl": ">=0.8,<=0.10",
+                "movingbytes/social-network": "<=1.2.1",
+                "mpdf/mpdf": "<=7.1.7",
+                "mtdowling/jmespath.php": "<2.9.1",
+                "munkireport/comment": "<4",
+                "munkireport/managedinstalls": "<2.6",
+                "munkireport/munki_facts": "<1.5",
+                "munkireport/reportdata": "<3.5",
+                "munkireport/softwareupdate": "<1.6",
+                "mustache/mustache": ">=2,<2.14.1",
+                "mwdelaney/wp-enable-svg": "<=0.2",
+                "nabeel/phpvms": "<7.0.6",
+                "namshi/jose": "<2.2",
+                "nasirkhan/laravel-starter": "<11.11",
+                "nategood/httpful": "<1",
+                "neoan3-apps/template": "<1.1.1",
+                "neorazorx/facturascripts": "<2022.04",
+                "neos/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "neos/form": ">=1.2,<4.3.3|>=5,<5.0.9|>=5.1,<5.1.3",
+                "neos/media-browser": "<7.3.19|>=8,<8.0.16|>=8.1,<8.1.11|>=8.2,<8.2.11|>=8.3,<8.3.9",
+                "neos/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<5.3.10|>=7,<7.0.9|>=7.1,<7.1.7|>=7.2,<7.2.6|>=7.3,<7.3.4|>=8,<8.0.2",
+                "neos/swiftmailer": "<5.4.5",
+                "nesbot/carbon": "<2.72.6|>=3,<3.8.4",
+                "netcarver/textile": "<=4.1.2",
+                "netgen/tagsbundle": ">=3.4,<3.4.11|>=4,<4.0.15",
+                "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
+                "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+                "neuron-core/neuron-ai": "<=2.8.11",
+                "nilsteampassnet/teampass": "<3.1.3.1-dev",
+                "nitsan/ns-backup": "<13.0.1",
+                "nonfiction/nterchange": "<4.1.1",
+                "notrinos/notrinos-erp": "<=1",
+                "noumo/easyii": "<=0.9",
+                "novaksolutions/infusionsoft-php-sdk": "<1",
+                "novosga/novosga": "<=2.2.12",
+                "nukeviet/nukeviet": "<4.6.00",
+                "nyholm/psr7": "<1.6.1",
+                "nystudio107/craft-seomatic": "<3.4.12",
+                "nzedb/nzedb": "<0.8",
+                "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+                "october/backend": "<1.1.2",
+                "october/cms": "<1.0.469|==1.0.469|==1.0.471|==1.1.1",
+                "october/october": "<3.7.14|>=4,<4.1.10",
+                "october/rain": "<=3.7.13|>=4,<=4.1.9",
+                "october/system": "<3.7.16|>=4,<4.1.16",
+                "oliverklee/phpunit": "<3.5.15",
+                "omeka/omeka-s": "<4.0.3",
+                "onelogin/php-saml": "<2.21.1|>=3,<3.8.1|>=4,<4.3.1",
+                "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
+                "open-web-analytics/open-web-analytics": "<1.8.1",
+                "opencart/opencart": ">=0",
+                "openid/php-openid": "<2.3",
+                "openmage/magento-lts": "<=20.17",
+                "opensolutions/vimbadmin": "<=3.0.15",
+                "opensource-workshop/connect-cms": "<1.41.1|>=2,<2.41.1",
+                "orchid/platform": ">=8,<14.43",
+                "oro/calendar-bundle": ">=4.2,<=4.2.6|>=5,<=5.0.6|>=5.1,<5.1.1",
+                "oro/commerce": ">=4.1,<5.0.11|>=5.1,<5.1.1",
+                "oro/crm": ">=1.7,<1.7.4|>=3.1,<4.1.17|>=4.2,<4.2.7",
+                "oro/crm-call-bundle": ">=4.2,<=4.2.5|>=5,<5.0.4|>=5.1,<5.1.1",
+                "oro/customer-portal": ">=4.1,<=4.1.13|>=4.2,<=4.2.10|>=5,<=5.0.11|>=5.1,<=5.1.3",
+                "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<=4.2.10|>=5,<=5.0.12|>=5.1,<=5.1.3",
+                "oveleon/contao-cookiebar": "<1.16.3|>=2,<2.1.3",
+                "oxid-esales/oxideshop-ce": "<4.5|>=6,<6.14.4",
+                "oxid-esales/oxideshop-metapackage-ce": ">=6,<6.5.5",
+                "oxid-esales/paymorrow-module": ">=1,<1.0.2|>=2,<2.0.1",
+                "oxid-esales/smarty-component": "<1.0.1",
+                "packbackbooks/lti-1-3-php-library": "<5",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": "<3",
+                "pagekit/pagekit": "<=1.0.18",
+                "paragonie/ecc": "<2.0.1",
+                "paragonie/random_compat": "<2",
+                "paragonie/sodium_compat": "<1.24.1|>=2,<2.5.1",
+                "passbolt/passbolt_api": "<4.6.2",
+                "paymenter/paymenter": "<=1.5.4",
+                "paypal/adaptivepayments-sdk-php": "<=3.9.2",
+                "paypal/invoice-sdk-php": "<=3.9",
+                "paypal/merchant-sdk-php": "<3.12",
+                "paypal/permissions-sdk-php": "<=3.9.1",
+                "pear/archive_tar": "<1.4.14",
+                "pear/auth": "<1.2.4",
+                "pear/crypt_gpg": "<1.6.7",
+                "pear/http_request2": "<2.7",
+                "pear/pear": "<=1.10.1",
+                "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
+                "personnummer/personnummer": "<3.0.2",
+                "ph7software/ph7builder": "<=17.9.1",
+                "phalcon/cphalcon": "<=5.15",
+                "phanan/koel": "<=9.7",
+                "pheditor/pheditor": "<2.0.8",
+                "phenx/php-svg-lib": "<0.5.2",
+                "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
+                "php-mod/curl": "<2.3.2",
+                "php-standard-library/h2": ">=6.1,<6.1.2|>=6.2,<6.2.1",
+                "php-standard-library/php-standard-library": ">=6.1,<6.1.2|>=6.2,<6.2.1",
+                "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
+                "phpcsstandards/phpcsutils": ">=1.0.0.0-alpha1,<1.2.3",
+                "phpems/phpems": ">=6,<=6.1.3",
+                "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
+                "phpmailer/phpmailer": "<6.5",
+                "phpmussel/phpmussel": ">=1,<1.6",
+                "phpmyadmin/phpmyadmin": "<5.2.2",
+                "phpmyfaq/phpmyfaq": "<4.1.4",
+                "phpoffice/common": "<0.2.9",
+                "phpoffice/math": "<=0.2",
+                "phpoffice/phpexcel": "<=1.8.2",
+                "phpoffice/phpspreadsheet": "<=1.30.5|>=2,<=2.1.17|>=2.2,<=2.4.6|>=3,<=3.10.6|>=4,<=5.8",
+                "phppgadmin/phppgadmin": "<=7.13",
+                "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
+                "phpservermon/phpservermon": "<3.6",
+                "phpsysinfo/phpsysinfo": "<3.4.3",
+                "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8|>=12.5.21,<12.5.22|>=13.1.5,<13.1.6",
+                "phpwhois/phpwhois": "<=4.2.5",
+                "phpxmlrpc/extras": "<0.6.1",
+                "phpxmlrpc/phpxmlrpc": "<4.9.2",
+                "phraseanet/phraseanet": "==4.0.3",
+                "pi/pi": "<=2.5",
+                "pimcore/admin-ui-classic-bundle": "<1.7.18|>=2.0.0.0-RC1-dev,<=2.3.5",
+                "pimcore/customer-management-framework-bundle": "<4.2.1",
+                "pimcore/data-hub": "<1.2.4",
+                "pimcore/data-importer": "<1.8.9|>=1.9,<1.9.3",
+                "pimcore/demo": "<10.3",
+                "pimcore/ecommerce-framework-bundle": "<1.0.10",
+                "pimcore/perspective-editor": "<1.5.1",
+                "pimcore/pimcore": "<12.3.9|>=2026.1,<=2026.1.4",
+                "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
+                "piwik/piwik": "<1.11",
+                "pixelfed/pixelfed": "<0.12.5",
+                "plank/laravel-mediable": "<7",
+                "plotly/plotly.js": "<2.25.2",
+                "pocketmine/bedrock-protocol": "<8.0.2",
+                "pocketmine/pocketmine-mp": "<5.42.1",
+                "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
+                "pontedilana/php-weasyprint": "<=2.5.1",
+                "poweradmin/poweradmin": "<4.2.5|>=4.3,<4.3.4",
+                "pressbooks/pressbooks": "<5.18",
+                "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/blockreassurance": "<=5.1.3",
+                "prestashop/blockwishlist": ">=2,<2.1.1",
+                "prestashop/contactform": ">=1.0.1,<4.3",
+                "prestashop/gamification": "<2.3.2",
+                "prestashop/prestashop": "<8.2.6|>=9,<9.1.1",
+                "prestashop/productcomments": "<5.0.2",
+                "prestashop/ps_checkout": "<5.3",
+                "prestashop/ps_contactinfo": "<=3.3.2",
+                "prestashop/ps_emailsubscription": "<2.6.1",
+                "prestashop/ps_facetedsearch": "<4.0.4",
+                "prestashop/ps_linklist": "<3.1",
+                "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
+                "processwire/processwire": "<=3.0.255",
+                "propel/propel": ">=2.0.0.0-alpha1,<2.0.0.0-alpha8",
+                "propel/propel1": ">=1,<1.7.2",
+                "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
+                "pterodactyl/panel": "<=1.12.4",
+                "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
+                "ptrofimov/beanstalk_console": "<1.7.14",
+                "pubnub/pubnub": "<6.1",
+                "punktde/pt_extbase": "<1.5.1",
+                "pusher/pusher-php-server": "<2.2.1",
+                "putyourlightson/craft-sprig": ">=2,<2.15.2|>=3,<3.7.2",
+                "pwweb/laravel-core": "<=0.3.6.0-beta",
+                "pxlrbt/filament-excel": "<1.1.14|>=2.0.0.0-alpha,<2.3.3",
+                "pyrocms/pyrocms": "<=3.9.1",
+                "qcubed/qcubed": "<=3.1.1",
+                "quickapps/cms": "<=2.0.0.0-beta2",
+                "rainlab/blog-plugin": "<1.4.1",
+                "rainlab/debugbar-plugin": "<3.1",
+                "rainlab/user-plugin": "<=1.4.5",
+                "ralffreit/mfa-email": "<1.0.7|==2",
+                "rankmath/seo-by-rank-math": "<=1.0.95",
+                "rap2hpoutre/laravel-log-viewer": "<0.13",
+                "react/http": ">=0.7,<1.9",
+                "really-simple-plugins/complianz-gdpr": "<6.4.2",
+                "redaxo/source": "<5.21.1",
+                "remdex/livehelperchat": "<4.29",
+                "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
+                "reportico-web/reportico": "<=8.1",
+                "rhukster/dom-sanitizer": "<1.0.10",
+                "rmccue/requests": ">=1.6,<1.8",
+                "roadiz/documents": "<2.3.42|>=2.4,<2.5.44|>=2.6,<2.6.28|>=2.7,<2.7.9",
+                "roadiz/openid": "<2.3.43|>=2.5,<2.5.45|>=2.6,<2.6.31|>=2.7,<2.7.18",
+                "robrichards/xmlseclibs": "<3.1.5",
+                "roots/soil": "<4.1",
+                "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11|>=1.7.0.0-beta,<1.7.0.0-RC5-dev",
+                "rudloff/alltube": "<3.0.3",
+                "rudloff/rtmpdump-bin": "<=2.3.1",
+                "s-cart/core": "<=9.0.5",
+                "s-cart/s-cart": "<6.9",
+                "s9y/serendipity": "<2.6",
+                "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
+                "sabre/dav": ">=1.6,<1.7.11|>=1.8,<1.8.9",
+                "saloonphp/saloon": "<4",
+                "samwilson/unlinked-wikibase": "<1.42",
+                "scheb/two-factor-bundle": "<3.26|>=4,<4.11",
+                "sensiolabs/connect": "<4.2.3",
+                "serluck/phpwhois": "<=4.2.6",
+                "setasign/fpdi": "<2.6.7",
+                "sfroemken/url_redirect": "<=1.2.1",
+                "sheng/yiicms": "<1.2.1",
+                "shopper/cart": "<2.8",
+                "shopper/framework": "<2.8",
+                "shopware/core": "<6.6.10.18-dev|>=6.7,<6.7.10.1-dev",
+                "shopware/platform": "<6.6.10.18-dev|>=6.7,<6.7.10.1-dev",
+                "shopware/production": "<=6.3.5.2",
+                "shopware/shopware": "<=6.3.5.2|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
+                "shopware/storefront": "<6.6.10.10-dev|>=6.7,<6.7.5.1-dev",
+                "shopxo/shopxo": "<=6.4",
+                "showdoc/showdoc": "<3.8.1",
+                "shuchkin/simplexlsx": ">=1.0.12,<1.1.13",
+                "silverstripe-australia/advancedreports": ">=1,<=2",
+                "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
+                "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
+                "silverstripe/cms": "<6.2.1",
+                "silverstripe/comments": ">=1.3,<3.1.1",
+                "silverstripe/forum": "<0.6.2|>=0.7,<0.7.4",
+                "silverstripe/framework": "<6.2.2",
+                "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
+                "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
+                "silverstripe/recipe-cms": ">=4.5,<4.5.3",
+                "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+                "silverstripe/reports": "<5.2.3",
+                "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4|>=2.1,<2.1.2",
+                "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
+                "silverstripe/subsites": ">=2,<2.6.1",
+                "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+                "silverstripe/userforms": "<6.4.9|>=7,<7.0.7|>=7.1,<7.1.1",
+                "silverstripe/versioned": "<3.2.1",
+                "silverstripe/versioned-admin": ">=1,<1.11.1",
+                "simogeo/filemanager": "<=2.5",
+                "simple-updates/phpwhois": "<=1",
+                "simplesamlphp/saml2": "<4.19.3|>=4.20,<=4.20.2|>=5,<5.0.6|>=6,<6.2.1",
+                "simplesamlphp/saml2-legacy": "<4.19.3|>=4.20,<=4.20.2",
+                "simplesamlphp/simplesamlphp": "<=2.4.6|>=2.5,<=2.5.1",
+                "simplesamlphp/simplesamlphp-module-casserver": "<=7.0.2",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "simplesamlphp/simplesamlphp-module-openid": "<1",
+                "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
+                "simplesamlphp/xml-common": "<1.20",
+                "simplesamlphp/xml-security": "<1.13.9|>=2,<2.3.1",
+                "simplito/elliptic-php": "<1.0.6",
+                "sitegeist/fluid-components": "<3.5",
+                "sjbr/sr-feuser-register": "<2.6.2|>=5.1,<12.5",
+                "sjbr/sr-freecap": "<2.4.6|>=2.5,<2.5.3",
+                "sjbr/static-info-tables": "<2.3.1",
+                "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
+                "slim/slim": "<2.6|>=4.4,<=4.15.1",
+                "slub/slub-events": "<3.0.3",
+                "smarty/smarty": "<4.5.7|>=5,<5.8.4",
+                "snipe/snipe-it": "<8.6.3",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "socialiteproviders/steam": "<1.1",
+                "solidinvoice/solidinvoice": "<=2.3.15",
+                "solspace/craft-freeform": "<4.1.29|>=5,<=5.14.6",
+                "soosyze/soosyze": "<=2",
+                "spatie/browsershot": "<5.0.5",
+                "spatie/image-optimizer": "<1.7.3",
+                "spatie/laravel-medialibrary": "<11.23",
+                "spatie/schema-org": ">=3.23.1,<3.23.2|>=4,<4.0.2",
+                "spencer14420/sp-php-email-handler": "<1",
+                "spipu/html2pdf": "<5.2.8",
+                "spiral/roadrunner": "<2025.1",
+                "spomky-labs/otphp": "<11.4.3",
+                "spoon/library": "<1.4.1",
+                "spoonity/tcpdf": "<6.2.22",
+                "squizlabs/php_codesniffer": "<3.13.6|>=4,<4.0.2",
+                "ssddanbrown/bookstack": "<24.05.1",
+                "starcitizentools/citizen-skin": ">=1.9.4,<3.9",
+                "starcitizentools/short-description": ">=4,<4.0.1",
+                "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
+                "starcitizenwiki/embedvideo": "<=4",
+                "statamic/cms": "<5.74.3|>=6,<6.24.2",
+                "stormpath/sdk": "<9.9.99",
+                "studio-42/elfinder": "<=2.1.67",
+                "studiomitte/friendlycaptcha": "<0.1.4",
+                "subhh/libconnect": "<7.0.8|>=8,<8.1",
+                "sukohi/surpass": "<1",
+                "sulu/form-bundle": ">=2,<2.5.3",
+                "sulu/sulu": "<=2.6.22|>=3,<=3.0.5",
+                "sumocoders/framework-user-bundle": "<1.4",
+                "superbig/craft-audit": "<3.0.2",
+                "svewap/a21glossary": "<=0.4.10",
+                "swag/paypal": "<5.4.4",
+                "swiftmailer/swiftmailer": "<6.2.5",
+                "swiftyedit/swiftyedit": "<1.2",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/grid-bundle": "<1.10.1",
+                "sylius/mollie-plugin": "<2.2.8|>=3,<3.2.4|>=3.3,<3.3.1",
+                "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
+                "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
+                "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<2.0.18|>=2.1,<2.1.15|>=2.2,<2.2.6",
+                "symbiote/silverstripe-advancedworkflow": "<6.4.5|>=7,<7.1.3|>=7.2,<7.2.1",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
+                "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
+                "symbiote/silverstripe-seed": "<6.0.3",
+                "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+                "symfont/process": ">=0",
+                "symfony/cache": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/dom-crawler": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<5.3.15|>=5.4.3,<5.4.4|>=6.0.3,<6.0.4",
+                "symfony/html-sanitizer": ">=6.1,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/http-client": ">=4.3,<5.4.53|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/http-foundation": "<5.4.50|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6|>=7.4,<7.4.12|>=8,<8.0.12",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/json-path": ">=7.3,<7.4.12|>=8,<8.0.12",
+                "symfony/lox24-notifier": ">=7.1,<7.4.12|>=8,<8.0.12",
+                "symfony/mailer": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailjet-mailer": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailomat-mailer": ">=7.2,<7.4.13|>=8,<8.0.13",
+                "symfony/mailtrap-mailer": ">=7.2,<7.4.12|>=8,<8.0.12",
+                "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
+                "symfony/mime": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/monolog-bridge": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/polyfill": ">=1,<1.10|>=1.17.1,<1.38.1",
+                "symfony/polyfill-intl-idn": ">=1.17.1,<1.38.1",
+                "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/process": "<5.4.51|>=6,<6.4.33|>=7,<7.1.7|>=7.3,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/routing": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/runtime": ">=5.3,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
+                "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.4.10|>=7,<7.0.10|>=7.1,<7.1.3",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
+                "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
+                "symfony/security-http": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
+                "symfony/symfony": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8|>=6.4.24,<6.4.40",
+                "symfony/twilio-notifier": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/ux-autocomplete": "<2.36|>=3,<3.1",
+                "symfony/ux-icons": ">=2.17,<2.36.1|>=3,<3.2",
+                "symfony/ux-live-component": "<2.36|>=3,<3.1",
+                "symfony/ux-toolkit": ">=2.32,<2.36.1|>=3,<3.2",
+                "symfony/ux-twig-component": "<2.25.1",
+                "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
+                "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4|>=7.2.9,<7.4.12|>=8,<8.0.12",
+                "symfony/webhook": ">=6.3,<6.3.8",
+                "symfony/yaml": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symphonycms/symphony-2": "<2.6.4",
+                "t3/dce": "<0.11.5|>=2.2,<2.6.2",
+                "t3g/svg-sanitizer": "<1.0.3",
+                "t3s/content-consent": "<1.0.3|>=2,<2.0.2",
+                "tastyigniter/tastyigniter": "<4",
+                "tcg/voyager": "<=1.8",
+                "tecnickcom/tc-lib-pdf-font": "<2.6.4",
+                "tecnickcom/tcpdf": "<6.8",
+                "terminal42/contao-tablelookupwizard": "<3.3.5",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.0.0.0-beta1,<2.1.3",
+                "theonedemon/phpwhois": "<=4.2.5",
+                "thinkcmf/thinkcmf": "<6.0.8",
+                "thorsten/phpmyfaq": "<4.2.0.0-alpha",
+                "tikiwiki/tiki-manager": "<=17.1",
+                "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
+                "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
+                "tinymighty/wiki-seo": "<1.2.2",
+                "titon/framework": "<9.9.99",
+                "tltneon/lgsl": "<7",
+                "tobiasbg/tablepress": "<=2.0.0.0-RC1",
+                "tomasnorre/crawler": "<11.0.13|>=12,<12.0.11",
+                "topthink/framework": "<6.0.17|>=6.1,<=8.0.4",
+                "topthink/think": "<=6.1.1",
+                "topthink/thinkphp": "<=3.2.3|>=6.1.3,<=8.0.4",
+                "torrentpier/torrentpier": "<=2.8.8",
+                "tpwd/ke_search": "<5.6.2|>=6,<6.6.1|>=7,<7.0.1",
+                "tribalsystems/zenario": "<=9.7.61188",
+                "truckersmp/phpwhois": "<=4.3.1",
+                "ttskch/pagination-service-provider": "<1",
+                "twbs/bootstrap": "<3.4.1|>=4,<4.3.1",
+                "twig/cssinliner-extra": "<3.26",
+                "twig/intl-extra": "<3.26",
+                "twig/markdown-extra": "<3.26",
+                "twig/twig": "<3.27",
+                "typicms/core": "<12.0.5|>=13,<13.0.9|>=14,<14.0.27|>=15,<15.0.29|>=16,<16.1.7",
+                "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
+                "typo3/cms-backend": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
+                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.34|>=14,<14.3.6",
+                "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
+                "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
+                "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-felogin": ">=4.2,<4.2.3",
+                "typo3/cms-filelist": ">=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1|>=8,<8.7.23|>=9,<9.5.4",
+                "typo3/cms-form": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.5",
+                "typo3/cms-frontend": "<4.3.9|>=4.4,<4.4.5",
+                "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-install": "<4.1.14|>=4.2,<4.2.16|>=4.3,<4.3.9|>=4.4,<4.4.5|>=12.2,<12.4.8|==13.4.2",
+                "typo3/cms-lowlevel": ">=11,<=11.5.41",
+                "typo3/cms-recordlist": ">=11,<11.5.48",
+                "typo3/cms-recycler": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-redirects": ">=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-rte-ckeditor": ">=9.5,<9.5.42|>=10,<10.4.39|>=11,<11.5.30",
+                "typo3/cms-scheduler": ">=11,<=11.5.41",
+                "typo3/cms-setup": ">=9,<=9.5.50|>=10,<=10.4.49|>=11,<=11.5.43|>=12,<=12.4.30|>=13,<=13.4.11",
+                "typo3/cms-webhooks": ">=12,<=12.4.30|>=13,<=13.4.11",
+                "typo3/cms-workspaces": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "typo3/html-sanitizer": "<2.3.2",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
+                "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+                "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
+                "ua-parser/uap-php": "<3.8",
+                "uasoft-indonesia/badaso": "<=2.9.7",
+                "unisharp/laravel-filemanager": "<2.9.1",
+                "universal-omega/dynamic-page-list3": "<3.6.4",
+                "unopim/unopim": "<=0.3",
+                "userfrosting/userfrosting": ">=0.3.1,<4.6.3",
+                "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+                "uvdesk/community-skeleton": "<=1.1.1",
+                "uvdesk/core-framework": "<=1.1.1",
+                "vanilla/safecurl": "<0.9.2",
+                "verbb/comments": "<1.5.5",
+                "verbb/formie": "<3.1.28",
+                "verbb/image-resizer": "<2.0.9",
+                "verbb/knock-knock": "<1.2.8",
+                "verot/class.upload.php": "<=2.1.6",
+                "vertexvaar/falsftp": "<0.2.6",
+                "villagedefrance/opencart-overclocked": "<=1.11.1",
+                "vova07/yii2-fileapi-widget": "<0.1.9",
+                "vrana/adminer": "<5.4.2",
+                "vufind/vufind": ">=2,<9.1.1",
+                "waldhacker/hcaptcha": "<2.1.2",
+                "wallabag/tcpdf": "<6.2.22",
+                "wallabag/wallabag": "<2.6.11",
+                "wanglelecc/laracms": "<=1.0.3",
+                "wapplersystems/a21glossary": "<=0.4.10",
+                "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4|>=5.3,<5.3.1",
+                "web-auth/webauthn-lib": ">=4.5,<5.3.5",
+                "web-auth/webauthn-symfony-bundle": "<5.3.4",
+                "web-feet/coastercms": "==5.5",
+                "web-token/jwt-bundle": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
+                "web-token/jwt-experimental": "<4.1.7",
+                "web-token/jwt-framework": "<4.1.7",
+                "web-token/jwt-library": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
+                "web-tp3/wec_map": "<3.0.3",
+                "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
+                "webcoast/deferred-image-processing": "<1.0.2",
+                "webklex/laravel-imap": "<5.3",
+                "webklex/php-imap": "<5.3",
+                "webonyx/graphql-php": "<=15.32.2",
+                "webpa/webpa": "<3.1.2",
+                "webreinvent/vaahcms": "<=2.3.1",
+                "wikibase/wikibase": "<=1.39.3",
+                "wikimedia/parsoid": "<0.12.2",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "winter/wn-backend-module": "<1.2.14",
+                "winter/wn-cms-module": "<=1.2.12",
+                "winter/wn-dusk-plugin": "<2.1",
+                "winter/wn-system-module": "<1.2.13",
+                "wintercms/winter": "<=1.2.3",
+                "wireui/wireui": "<1.19.3|>=2,<2.1.3",
+                "wnx/laravel-backup-restore": "<=1.9.3",
+                "woocommerce/woocommerce": "<6.6|>=8.8,<8.8.5|>=8.9,<8.9.3",
+                "wp-cli/wp-cli": ">=0.12,<2.5",
+                "wp-coding-standards/wpcs": ">=0.14.1,<3.4.1",
+                "wp-graphql/wp-graphql": "<=2.6",
+                "wp-premium/gravityforms": "<2.4.21",
+                "wpanel/wpanel4-cms": "<=4.3.1",
+                "wpcloud/wp-stateless": "<3.2",
+                "wpglobus/wpglobus": "<=1.9.6",
+                "wpmetabox/meta-box": "<5.11.2",
+                "wwbn/avideo": "<=29",
+                "xataface/xataface": "<3",
+                "xpressengine/xpressengine": "<3.0.15",
+                "yab/quarx": "<2.4.5",
+                "yansongda/pay": "<=3.7.19",
+                "yeswiki/yeswiki": "<4.6.6",
+                "yetiforce/yetiforce-crm": "<6.5",
+                "yidashi/yii2cmf": "<=2",
+                "yii2mod/yii2-cms": "<1.9.2",
+                "yiisoft/yii": "<1.1.31",
+                "yiisoft/yii2": "<2.0.55",
+                "yiisoft/yii2-authclient": "<2.2.15",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<=2.0.45",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
+                "yiisoft/yii2-gii": "<=2.2.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.20",
+                "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
+                "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
+                "yoast/duplicate-post": "<=4.5",
+                "yourls/yourls": "<=1.10.3",
+                "yuan1994/tpadmin": "<=1.3.12",
+                "yungifez/skuul": "<=2.6.5",
+                "z-push/z-push-dev": "<2.7.6",
+                "zencart/zencart": "<=1.5.7.0-beta",
+                "zendesk/zendesk_api_client_php": "<2.2.11",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": "<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+                "zendframework/zend-diactoros": "<1.8.4",
+                "zendframework/zend-feed": "<2.10.3",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": "<2.8.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": "<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": "<=3",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": "<2.0.2",
+                "zendframework/zendrest": "<2.0.2",
+                "zendframework/zendservice-amazon": "<2.0.3",
+                "zendframework/zendservice-api": "<1",
+                "zendframework/zendservice-audioscrobbler": "<2.0.2",
+                "zendframework/zendservice-nirvanix": "<2.0.2",
+                "zendframework/zendservice-slideshare": "<2.0.2",
+                "zendframework/zendservice-technorati": "<2.0.2",
+                "zendframework/zendservice-windowsazure": "<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zenstruck/collection": "<0.2.1",
+                "zetacomponents/mail": "<1.8.2",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2",
+                "zoujingli/thinkadmin": "<=6.1.53",
+                "zumba/json-serializer": "<3.2.3"
+            },
+            "default-branch": true,
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
+                },
+                {
+                    "name": "Ilya Tribusean",
+                    "email": "slash3b@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "keywords": [
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/Roave/SecurityAdvisories/issues",
+                "source": "https://github.com/Roave/SecurityAdvisories/tree/latest"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T21:23:53+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-19T17:59:20+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/cache",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/parallel",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parallel.git",
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/37f5b2754fadc229c00f9416bd68fb8d04529a81",
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/process": "^2",
+                "amphp/serialization": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Context/functions.php",
+                    "src/Context/Internal/functions.php",
+                    "src/Ipc/functions.php",
+                    "src/Worker/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Parallel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Parallel processing component for Amp.",
+            "homepage": "https://github.com/amphp/parallel",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrent",
+                "multi-processing",
+                "multi-threading"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parallel/issues",
+                "source": "https://github.com/amphp/parallel/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-16T16:54:01+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-26T14:50:43+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "583959df17d00304ad7b0b32285373f985935643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/583959df17d00304ad7b0b32285373f985935643",
+                "reference": "583959df17d00304ad7b0b32285373f985935643",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-31T15:11:55+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-19T15:09:56+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<2.2.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-07T11:47:49+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
+            },
+            "time": "2024-04-30T00:40:11+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-11T10:17:44+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0 || ~10.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
+            },
+            "time": "2024-09-08T10:13:13+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "pdepend/pdepend",
+            "version": "2.16.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
+                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.7",
+                "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/polyfill-mbstring": "^1.19"
+            },
+            "require-dev": {
+                "easy-doc/easy-doc": "0.0.0|^1.2.3",
+                "gregwar/rst": "^1.0",
+                "squizlabs/php_codesniffer": "^2.0.0"
+            },
+            "bin": [
+                "src/bin/pdepend"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PDepend\\": "src/main/php/PDepend"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "keywords": [
+                "PHP Depend",
+                "PHP_Depend",
+                "dev",
+                "pdepend"
+            ],
+            "support": {
+                "issues": "https://github.com/pdepend/pdepend/issues",
+                "source": "https://github.com/pdepend/pdepend/tree/2.16.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-17T18:09:59+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
+            },
+            "time": "2026-03-18T20:47:46+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpmd/phpmd",
+            "version": "2.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/74a1f56e33afad4128b886e334093e98e1b5e7c0",
+                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
+                "ext-xml": "*",
+                "pdepend/pdepend": "^2.16.1",
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "gregwar/rst": "^1.0",
+                "mikey179/vfsstream": "^1.6.8",
+                "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2"
+            },
+            "bin": [
+                "src/bin/phpmd"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPMD\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Manuel Pichler",
+                    "email": "github@manuel-pichler.de",
+                    "homepage": "https://github.com/manuelpichler",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Marc Würth",
+                    "email": "ravage@bluewin.ch",
+                    "homepage": "https://github.com/ravage84",
+                    "role": "Project Maintainer"
+                },
+                {
+                    "name": "Other contributors",
+                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
+            "homepage": "https://phpmd.org/",
+            "keywords": [
+                "dev",
+                "mess detection",
+                "mess detector",
+                "pdepend",
+                "phpmd",
+                "pmd"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/phpmd",
+                "issues": "https://github.com/phpmd/phpmd/issues",
+                "source": "https://github.com/phpmd/phpmd/tree/2.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-11T08:22:20+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.56",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:52:39+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
+            },
+            "time": "2026-05-16T17:55:38+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "spatie/array-to-xml",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-15T09:00:41+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/bbdc3d0532623e21838b7041a4364383a8126f96",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96",
+                "shasum": ""
+            },
+            "require": {
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "suggest": {
+                "ext-iconv": "For accurate character length calculation when the checked files contain multi-byte characters.",
+                "ext-pcntl": "For parallel processing support via the --parallel CLI option."
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-08-06T02:45:27+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "e896f5e874e6983d0a098f554ca82a08a924c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e896f5e874e6983d0a098f554ca82a08a924c298",
+                "reference": "e896f5e874e6983d0a098f554ca82a08a924c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1|^8.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-30T15:04:16+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.2|^8.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-31T12:37:14+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "7f59a843c1fbcceafecdf6863d3e38ea6ecd5061"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7f59a843c1fbcceafecdf6863d3e38ea6ecd5061",
+                "reference": "7f59a843c1fbcceafecdf6863d3e38ea6ecd5061",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^3.6",
+                "symfony/var-exporter": "^6.4.20|^7.2.5|^8.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.4",
+                "symfony/finder": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-06T09:45:22+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-22T07:36:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T08:25:59+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-16T09:55:08+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e394af32256bf9e7bf80849d95e589167c10097b",
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T07:33:02+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "ca31404415670aa3834809005b529df1b84f0790"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/ca31404415670aa3834809005b529df1b84f0790",
+                "reference": "ca31404415670aa3834809005b529df1b84f0790",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-30T12:37:26+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "38fc8444edf0cebc9205296ee6e30e906ade783b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/38fc8444edf0cebc9205296ee6e30e906ade783b",
+                "reference": "38fc8444edf0cebc9205296ee6e30e906ade783b",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parallel": "^2.3",
+                "composer-runtime-api": "^2",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.1",
+                "felixfbecker/language-server-protocol": "^1.5.3",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^5.0.0",
+                "php": "~8.1.17 || ~8.2.4 || ~8.3.0 || ~8.4.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
+                "symfony/console": "^6.0 || ^7.0",
+                "symfony/filesystem": "^6.0 || ^7.0"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "amphp/phpunit-util": "^3",
+                "bamarni/composer-bin-plugin": "^1.4",
+                "brianium/paratest": "^6.9",
+                "dg/bypass-finals": "^1.5",
+                "ext-curl": "*",
+                "mockery/mockery": "^1.5",
+                "nunomaduro/mock-final-classes": "^1.1",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpdoc-parser": "^1.6",
+                "phpunit/phpunit": "^9.6",
+                "psalm/plugin-mockery": "^1.1",
+                "psalm/plugin-phpunit": "^0.19",
+                "slevomat/coding-standard": "^8.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/process": "^6.0 || ^7.0"
+            },
+            "suggest": {
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalm-review",
+                "psalter"
+            ],
+            "type": "project",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev",
+                    "dev-6.x": "6.x-dev",
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://psalm.dev/docs",
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm"
+            },
+            "time": "2025-02-07T20:42:25+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
+            },
+            "time": "2026-06-15T15:31:57+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "phpmd/phpmd": 0,
+        "roave/security-advisories": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.3"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.99"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/zmscitizenbackend/composer.lock
+++ b/zmscitizenbackend/composer.lock
@@ -4,8 +4,198 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97dd79234917f09dafa536722e285e9c",
+    "content-hash": "2c370f1649178eb3b66fac0c90b9067c",
     "packages": [
+        {
+            "name": "opis/json-schema",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.1",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.6.0"
+            },
+            "time": "2025-10-17T12:46:48+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.1.0"
+            },
+            "time": "2025-10-17T12:38:41+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
+        },
         {
             "name": "roave/security-advisories",
             "version": "dev-latest",

--- a/zmscitizenbackend/config.example.php
+++ b/zmscitizenbackend/config.example.php
@@ -1,0 +1,17 @@
+<?php
+
+define('ZMS_IDENTIFIER', getenv('ZMS_IDENTIFIER') ? getenv('ZMS_IDENTIFIER') : 'zms');
+define('ZMS_MODULE_NAME', 'zmscitizenbackend');
+
+class App extends \BO\Zmscitizenbackend\Application
+{
+    /**
+     * Name of the application
+     */
+    public const string IDENTIFIER = ZMS_IDENTIFIER;
+
+    /**
+     * Name of the module
+     */
+    public const string MODULE_NAME = ZMS_MODULE_NAME;
+}

--- a/zmscitizenbackend/phpunit.xml
+++ b/zmscitizenbackend/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false"
+         bootstrap="tests/Zmscitizenbackend/bootstrap.php" colors="true" stopOnFailure="false" processIsolation="false"
+         cacheDirectory=".phpunit.cache" backupStaticProperties="false" requireCoverageMetadata="false">
+    <testsuites>
+        <testsuite name="Zmscitizenbackend Test Suite">
+            <directory>./tests/Zmscitizenbackend/</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <report>
+            <html outputDirectory="./coverage/html"/>
+            <clover outputFile="./coverage/clover.xml"/>
+        </report>
+    </coverage>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <directory>./vendor</directory>
+            <directory>./tests</directory>
+        </exclude>
+    </source>
+</phpunit>

--- a/zmscitizenbackend/psalm.xml
+++ b/zmscitizenbackend/psalm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="7"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+>
+    <projectFiles>
+        <directory name="src" />
+        <file name="config.example.php" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/zmscitizenbackend/schema/citizenapi/appointmentCancel.json
+++ b/zmscitizenbackend/schema/citizenapi/appointmentCancel.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "description": "Includes a message indicating the result of a canceled appointment request.",
+  "properties": {
+    "message": {
+      "type": "string",
+      "description": "A human-readable message describing the cancellation result",
+      "minLength": 1,
+      "maxLength": 1000,
+      "pattern": "^[\\p{L}\\p{N}\\s.,!?()-]+$"
+    }
+  },
+  "required": [
+    "message"
+  ]
+}

--- a/zmscitizenbackend/schema/citizenapi/appointmentConfirm.json
+++ b/zmscitizenbackend/schema/citizenapi/appointmentConfirm.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "description": "Contains a message confirming the successful confirmation of an appointment.",
+    "properties": {
+      "message": {
+        "type": "string"
+      }
+    },
+    "required": ["message"]
+}

--- a/zmscitizenbackend/schema/citizenapi/appointmentPreconfirm.json
+++ b/zmscitizenbackend/schema/citizenapi/appointmentPreconfirm.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "description": "Provides a message indicating the successful pre-confirmation of an appointment.",
+    "properties": {
+      "message": {
+        "type": "string"
+      }
+    },
+    "required": ["message"]
+}

--- a/zmscitizenbackend/schema/citizenapi/appointmentReserve.json
+++ b/zmscitizenbackend/schema/citizenapi/appointmentReserve.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "description": "Includes a message confirming that an appointment has been successfully reserved.",
+    "properties": {
+      "message": {
+        "type": "string",
+        "description": "Confirmation message for the appointment reservation",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
+    "required": ["message"]
+}

--- a/zmscitizenbackend/schema/citizenapi/appointmentUpdate.json
+++ b/zmscitizenbackend/schema/citizenapi/appointmentUpdate.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "description": "Provides a message indicating the result of an appointment update operation.",
+    "properties": {
+      "message": {
+        "type": "string"
+      }
+    },
+    "required": ["message"]
+}

--- a/zmscitizenbackend/schema/citizenapi/availableCalendar.json
+++ b/zmscitizenbackend/schema/citizenapi/availableCalendar.json
@@ -1,0 +1,75 @@
+{
+  "title": "AvailableCalendar",
+  "type": ["array", "object", "null"],
+  "properties": {
+    "startDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Start date of the requested day-status range in YYYY-MM-DD format"
+    },
+    "endDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "End date of the requested day-status range in YYYY-MM-DD format"
+    },
+    "slotsStartDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Start date of the appointment slots window in YYYY-MM-DD format"
+    },
+    "slotsEndDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "End date of the appointment slots window in YYYY-MM-DD format"
+    },
+    "prevBookableDate": {
+      "type": ["string", "null"],
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Nearest bookable day before the slots window (may skip empty months)"
+    },
+    "nextBookableDate": {
+      "type": ["string", "null"],
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Nearest bookable day after the slots window (may skip empty months)"
+    },
+    "availableDays": {
+      "type": "array",
+      "description": "Bookable days with appointment slots grouped by office",
+      "items": {
+        "type": ["array", "object", "null"],
+        "properties": {
+          "date": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "Day in YYYY-MM-DD format"
+          },
+          "providerIDs": {
+            "type": "string",
+            "description": "Comma-separated office IDs"
+          },
+          "offices": {
+            "type": ["array", "null"],
+            "items": {
+              "type": ["array", "object", "null"],
+              "properties": {
+                "officeId": {
+                  "type": "string",
+                  "description": "Office ID"
+                },
+                "appointments": {
+                  "type": ["array", "null"],
+                  "items": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["startDate", "endDate", "availableDays"],
+  "description": "Schema defining available days and appointment slots for offices and services"
+}

--- a/zmscitizenbackend/schema/citizenapi/captcha/altchaCaptcha.json
+++ b/zmscitizenbackend/schema/citizenapi/captcha/altchaCaptcha.json
@@ -1,0 +1,30 @@
+{
+    "title": "AltchaCaptchaConfig",
+    "type": ["array", "object"],
+    "properties": {
+        "siteKey": {
+            "type": "string",
+            "description": "Site key for AltchaCaptcha integration"
+        },
+        "captchaChallenge": {
+            "type": "string",
+            "description": "Challenge endpoint URL for AltchaCaptcha"
+        },
+        "captchaVerify": {
+            "type": "string",
+            "description": "Endpoint for captcha verification"
+        },
+        "captchaEnabled": {
+            "type": "boolean",
+            "description": "Indicates if captcha is enabled"
+        }
+    },
+    "required": [
+        "siteKey",
+        "captchaChallenge",
+        "captchaVerify",
+        "captchaEnabled"
+    ],
+    "description": "Schema definition for AltchaCaptcha configuration"
+}
+  

--- a/zmscitizenbackend/schema/citizenapi/captcha/altchaVerifyPayload.json
+++ b/zmscitizenbackend/schema/citizenapi/captcha/altchaVerifyPayload.json
@@ -1,0 +1,35 @@
+{
+    "title": "AltchaVerifyPayload",
+    "type": "object",
+    "properties": {
+        "challenge": {
+            "$ref": "createChallengeResponse.json"
+        },
+        "solution": {
+            "type": "object",
+            "properties": {
+                "counter": {
+                    "type": "number",
+                    "description": "Brute-forced integer that satisfies the proof of work"
+                },
+                "derivedKey": {
+                    "type": "string",
+                    "description": "Lowercase hex of the derived key for counter"
+                },
+                "time": {
+                    "type": "number",
+                    "description": "Time of challenge completion in milliseconds"
+                }
+            },
+            "required": [
+                "counter",
+                "derivedKey"
+            ]
+        }
+    },
+    "required": [
+        "challenge",
+        "solution"
+    ],
+    "description": "Decoded JSON structure inside the base64-encoded payload field of POST /captcha-verify/"
+}

--- a/zmscitizenbackend/schema/citizenapi/captcha/createChallengeResponse.json
+++ b/zmscitizenbackend/schema/citizenapi/captcha/createChallengeResponse.json
@@ -1,0 +1,73 @@
+{
+    "title": "AltchaCaptchaChallenge",
+    "type": "object",
+    "properties": {
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "algorithm": {
+                    "type": "string",
+                    "description": "Key-derivation algorithm used for the proof of work"
+                },
+                "nonce": {
+                    "type": "string",
+                    "description": "Random server-issued nonce used as part of the proof-of-work input"
+                },
+                "salt": {
+                    "type": "string",
+                    "minLength": 10,
+                    "description": "Random salt for key derivation"
+                },
+                "cost": {
+                    "type": "integer",
+                    "description": "Work factor (KDF iterations). Larger values are harder to solve"
+                },
+                "keyLength": {
+                    "type": "integer",
+                    "description": "Length of the derived key in bytes"
+                },
+                "keyPrefix": {
+                    "type": "string",
+                    "description": "Hex prefix the derived key must start with"
+                },
+                "keySignature": {
+                    "type": ["string", "null"],
+                    "description": "Optional HMAC of the expected derived key"
+                },
+                "memoryCost": {
+                    "type": ["integer", "null"],
+                    "description": "Memory cost for memory-hard algorithms"
+                },
+                "parallelism": {
+                    "type": ["integer", "null"],
+                    "description": "Parallelism for memory-hard algorithms"
+                },
+                "expiresAt": {
+                    "type": ["integer", "null"],
+                    "description": "Unix timestamp (seconds) after which verification fails"
+                },
+                "data": {
+                    "type": ["object", "null"],
+                    "description": "Optional custom metadata attached to the challenge"
+                }
+            },
+            "required": [
+                "algorithm",
+                "nonce",
+                "salt",
+                "cost",
+                "keyLength",
+                "keyPrefix"
+            ]
+        },
+        "signature": {
+            "type": "string",
+            "description": "HMAC signature over the challenge parameters"
+        }
+    },
+    "required": [
+        "parameters",
+        "signature"
+    ],
+    "description": "Schema definition for an AltchaCaptcha v2 challenge response"
+}

--- a/zmscitizenbackend/schema/citizenapi/captcha/verifySolutionRequest.json
+++ b/zmscitizenbackend/schema/citizenapi/captcha/verifySolutionRequest.json
@@ -1,0 +1,14 @@
+{
+    "title": "CaptchaVerifyRequest",
+    "type": "object",
+    "properties": {
+        "payload": {
+            "type": "string",
+            "description": "Base64-encoded JSON (URL-safe alphabet) containing the Altcha challenge and solution. After decoding, the JSON conforms to altchaVerifyPayload.json."
+        }
+    },
+    "required": [
+        "payload"
+    ],
+    "description": "Request body for POST /captcha-verify/. The server adds siteKey, siteSecret, and clientAddress when forwarding verification to the Altcha service."
+}

--- a/zmscitizenbackend/schema/citizenapi/captcha/verifySolutionResponse.json
+++ b/zmscitizenbackend/schema/citizenapi/captcha/verifySolutionResponse.json
@@ -1,0 +1,15 @@
+{
+    "title": "AltchaCaptchaSolutionResponse",
+    "type": "object",
+    "properties": {
+        "valid": {
+            "type": "boolean",
+            "description": "Indicates whether the solution is valid"
+        }
+    },
+    "required": [
+        "valid"
+    ],
+    "description": "Schema definition for an AltchaCaptcha solution response"
+}
+    

--- a/zmscitizenbackend/schema/citizenapi/collections/officeList.json
+++ b/zmscitizenbackend/schema/citizenapi/collections/officeList.json
@@ -1,0 +1,18 @@
+{
+  "type": [
+    "array",
+    "object",
+    "null"
+  ],
+  "properties": {
+    "offices": {
+      "type": "array",
+      "items": {
+        "$ref": "../office.json"
+      }
+    }
+  },
+  "required": [
+    "offices"
+  ]
+}

--- a/zmscitizenbackend/schema/citizenapi/collections/officeServiceAndRelationList.json
+++ b/zmscitizenbackend/schema/citizenapi/collections/officeServiceAndRelationList.json
@@ -1,0 +1,33 @@
+{
+  "type": [
+    "array",
+    "object",
+    "null"
+  ],
+  "description": "Contains information about offices, services, and their relations. Includes details about each office, available services, and how they are related.",
+  "properties": {
+    "offices": {
+      "type": "array",
+      "items": {
+        "$ref": "../office.json"
+      }
+    },
+    "services": {
+      "type": "array",
+      "items": {
+        "$ref": "../service.json"
+      }
+    },
+    "relations": {
+      "type": "array",
+      "items": {
+        "$ref": "../officeServiceRelation.json"
+      }
+    }
+  },
+  "required": [
+    "offices",
+    "services",
+    "relations"
+  ]
+}

--- a/zmscitizenbackend/schema/citizenapi/collections/officeServiceRelationList.json
+++ b/zmscitizenbackend/schema/citizenapi/collections/officeServiceRelationList.json
@@ -1,0 +1,14 @@
+{
+    "type": ["array", "object", "null"],
+    "properties": {
+        "relations": {
+            "type": "array",
+            "items": {
+              "$ref": "../officeServiceRelation.json"
+            }
+        }
+    },
+    "required": [
+        "relations"
+    ]
+}

--- a/zmscitizenbackend/schema/citizenapi/collections/serviceList.json
+++ b/zmscitizenbackend/schema/citizenapi/collections/serviceList.json
@@ -1,0 +1,14 @@
+{
+  "type": ["array", "object", "null"],
+  "properties": {
+    "services": {
+      "type": "array",
+      "items": {
+        "$ref": "../service.json"
+      }
+    }
+  },
+  "required": [
+    "services"
+  ]
+}

--- a/zmscitizenbackend/schema/citizenapi/collections/thinnedScopeList.json
+++ b/zmscitizenbackend/schema/citizenapi/collections/thinnedScopeList.json
@@ -1,0 +1,18 @@
+{
+  "type": [
+    "array",
+    "object",
+    "null"
+  ],
+  "properties": {
+    "scopes": {
+      "type": "array",
+      "items": {
+        "$ref": "../thinnedScope.json"
+      }
+    }
+  },
+  "required": [
+    "scopes"
+  ]
+}

--- a/zmscitizenbackend/schema/citizenapi/combinable.json
+++ b/zmscitizenbackend/schema/citizenapi/combinable.json
@@ -1,0 +1,19 @@
+{
+  "type": ["object", "array"],
+  "patternProperties": {
+    "^[0-9]+$": {
+      "type": ["object", "array"],
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1
+    }
+  }
+}

--- a/zmscitizenbackend/schema/citizenapi/office.json
+++ b/zmscitizenbackend/schema/citizenapi/office.json
@@ -1,0 +1,165 @@
+{
+    "title": "Office",
+    "type": [
+        "array",
+        "object"
+    ],
+    "properties": {
+        "id": {
+            "type": "integer",
+            "description": "Unique identifier for the office"
+        },
+        "name": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The name of the office"
+        },
+        "showAlternativeLocations": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "description": "Show alternative office locations in the citizen calendar"
+        },
+        "address": {
+            "type": [
+                "array",
+                "object",
+                "null"
+            ],
+            "description": "The address of the office",
+            "items": {
+                "type": [
+                    "array",
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "house_number": {
+                        "type": "string",
+                        "description": "House number of the address"
+                    },
+                    "city": {
+                        "type": "string",
+                        "description": "City of the address"
+                    },
+                    "postal_code": {
+                        "type": "string",
+                        "description": "Postal code of the address"
+                    },
+                    "street": {
+                        "type": "string",
+                        "description": "Street name of the address"
+                    },
+                    "hint": {
+                        "type": "boolean",
+                        "description": "Additional hint about the address"
+                    }
+                }
+            }
+        },
+        "displayNameAlternatives": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "description": "Alternative names of the office"
+        },
+        "organization": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The name of the Organization"
+        },
+        "organizationUnit": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The name of the organization"
+        },
+        "slotTimeInMinutes": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "Slot time in minutes"
+        },
+        "version": {
+            "type": ["number", "null"],
+            "default": 1,
+            "description": "Numeric version of the availability"
+        },
+        "geo": {
+            "type": [
+                "array",
+                "object",
+                "null"
+            ],
+            "description": "Geographical coordinates of the office",
+            "properties": {
+                "lat": {
+                    "type": "number",
+                    "description": "Latitude of a geo coordinate as wgs84 or etrs89",
+                    "minimum": -90,
+                    "maximum": 90
+                },
+                "lon": {
+                    "type": "number",
+                    "description": "Longitude of a geo coordinate as wgs84 or etrs89",
+                    "minimum": -180,
+                    "maximum": 180
+                }
+            }
+        },
+        "parentId": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "description": "Parent provider ID (when this is a child provider)"
+        },
+        "scope": {
+            "$ref": "./thinnedScope.json"
+        },
+        "disabledByServices": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "description": "Array of service-IDs for which a provider is unavailable"
+        },
+        "allowDisabledServicesMix": {
+            "type": [
+                "boolean",
+                "array",
+                "null"
+            ],
+            "description": "If array of office IDs: JumpIn with one auto-selects equivalent in group. Legacy boolean=true treated as participates in mix."
+        },
+        "sharedBookingOfficeIds": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "integer"
+            },
+            "description": "Peer office IDs that share one Ort checkbox but pool calendar capacity (all IDs queried; backend round-robins across the group)."
+        },
+        "slotsPerAppointment": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Number of slots that can be booked per appointment at this office"
+        }
+    },
+    "required": [
+        "id"
+    ],
+    "description": "Schema definition for the Office entity"
+}

--- a/zmscitizenbackend/schema/citizenapi/officeServiceRelation.json
+++ b/zmscitizenbackend/schema/citizenapi/officeServiceRelation.json
@@ -1,0 +1,21 @@
+{
+    "title": "OfficeServiceRelation",
+    "type": ["array", "object", "null"],
+    "properties": {
+      "officeId": {
+        "type": ["integer", "null"],
+        "description": "Unique identifier for the office"
+      },
+      "serviceId": {
+        "type": ["integer", "null"],
+        "description": "Unique identifier for the service"
+      },
+      "slots": {
+        "type": ["integer", "null"],
+        "description": "Number of slots available for the relation"
+      }
+    },
+    "required": ["officeId", "serviceId", "slots"],
+    "description": "Schema definition for the Office-Service relation"
+  }
+  

--- a/zmscitizenbackend/schema/citizenapi/service.json
+++ b/zmscitizenbackend/schema/citizenapi/service.json
@@ -1,0 +1,74 @@
+{
+  "title": "Service",
+  "type": [
+    "array",
+    "object",
+    "null"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Unique identifier for the service"
+    },
+    "name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Name of the service"
+    },
+    "maxQuantity": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Maximum quantity of the service"
+    },
+    "combinable": {
+      "$ref": "./combinable.json"
+    },
+    "public": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicates whether the service is publicly visible"
+    },
+    "parentId": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Parent-Service ID (falls diese Service-Variante zu einem Parent gehört)"
+    },
+    "variantId": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Variant-ID (z.B. ZMS-Variantenkennung)"
+    },
+    "rootParentId": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Root service ID for service info links; equals id for root services"
+    },
+    "showOnStartPage": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicates whether the service is visible on the start page (ServiceFinder)"
+    }
+  },
+  "required": [
+    "id",
+    "name"
+  ],
+  "description": "Schema definition for the Service entity"
+}

--- a/zmscitizenbackend/schema/citizenapi/thinnedContact.json
+++ b/zmscitizenbackend/schema/citizenapi/thinnedContact.json
@@ -1,0 +1,35 @@
+{
+    "title": "ThinnedContact",
+    "description": "Represents a simplified contact object for the citizen API.",
+    "type": ["array", "object", "null"],
+    "properties": {
+      "city": {
+        "type": ["string", "null"],
+        "description": "The city name."
+      },
+      "country": {
+        "type": ["string", "null"],
+        "description": "The country name."
+      },
+      "name": {
+        "type": ["string", "null"],
+        "description": "Optional name field displayed for contact."
+      },
+      "postalCode": {
+        "type": ["string", "null"],
+        "description": "The postal (ZIP) code."
+      },
+      "region": {
+        "type": ["string", "null"],
+        "description": "The region or state name."
+      },
+      "street": {
+        "type": ["string", "null"],
+        "description": "The street name."
+      },
+      "streetNumber": {
+        "type": ["string", "null"],
+        "description": "The house/street number."
+      }
+    }
+  }

--- a/zmscitizenbackend/schema/citizenapi/thinnedProcess.json
+++ b/zmscitizenbackend/schema/citizenapi/thinnedProcess.json
@@ -1,0 +1,175 @@
+{
+  "title": "ThinnedProcess",
+  "type": [
+    "array",
+    "object",
+    "null"
+  ],
+  "properties": {
+    "processId": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Unique identifier for the process"
+    },
+    "authKey": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Authentication key for the process"
+    },
+    "captchaToken": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Token used for captcha validation"
+    },
+    "timestamp": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Timestamp of the process in seconds since epoch"
+    },
+    "familyName": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Family name associated with the process"
+    },
+    "customTextfield": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Custom text field for the process"
+    },
+    "customTextfield2": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Custom text field for the process"
+    },
+    "email": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Email associated with the process"
+    },
+    "telephone": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Telephone number associated with the process"
+    },
+    "officeName": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Name of the office handling the process"
+    },
+    "officeId": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Unique identifier for the office"
+    },
+    "scope": {
+      "$ref": "./thinnedScope.json"
+    },
+    "status": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "free",
+        "reserved",
+        "preconfirmed",
+        "confirmed",
+        "queued",
+        "called",
+        "processing",
+        "pending",
+        "finished",
+        "missed",
+        "parked",
+        "archived",
+        "deleted",
+        "anonymized",
+        "blocked",
+        "conflict"
+      ],
+      "description": "Status of the process"
+    },
+    "subRequestCounts": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "description": "Counts of sub-requests in the process",
+      "items": {
+        "type": [
+          "integer",
+          "null"
+        ]
+      }
+    },
+    "serviceId": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Service ID associated with the process"
+    },
+    "serviceName": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Service name associated with the process"
+    },
+    "serviceCount": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Count of services in the process"
+    },
+    "slotCount": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Count of slots in the process"
+    },
+    "displayNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Appointment number that should be displayed"
+    },
+    "icsContent": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "ICS calendar file content for the appointment"
+    }
+  },
+  "required": [
+    "processId",
+    "authKey"
+  ],
+  "description": "Schema definition for the process entity"
+}

--- a/zmscitizenbackend/schema/citizenapi/thinnedProvider.json
+++ b/zmscitizenbackend/schema/citizenapi/thinnedProvider.json
@@ -1,0 +1,49 @@
+{
+    "title": "ThinnedProvider",
+    "type": [
+        "array",
+        "object",
+        "null"
+    ],
+    "properties": {
+        "id": {
+            "type": "string",
+            "description": "Provider ID"
+        },
+        "name": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Provider name"
+        },
+        "displayName": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Display provider name"
+        },
+        "lat": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "description": "Latitude in decimal degrees."
+        },
+        "lon": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "description": "Longitude in decimal degrees."
+        },
+        "source": {
+            "type": "string",
+            "description": "Data source"
+        },
+        "contact": {
+            "$ref": "./thinnedContact.json"
+        }
+    }
+}

--- a/zmscitizenbackend/schema/citizenapi/thinnedScope.json
+++ b/zmscitizenbackend/schema/citizenapi/thinnedScope.json
@@ -1,0 +1,147 @@
+{
+    "title": "thinnedScope",
+    "type": [
+        "array",
+        "object",
+        "null"
+    ],
+    "description": "The scope of the office's operations",
+    "properties": {
+        "id": {
+            "type": [
+                "string",
+                "integer"
+            ],
+            "description": "Unique identifier of the scope"
+        },
+        "provider": {
+            "$ref": "./thinnedProvider.json"
+        },
+        "shortName": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Short name of the scope"
+        },
+        "emailFrom": {
+            "type": "string",
+            "description": "Mail address for sending mails to clients",
+            "default": "",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]{2,}@[a-zA-Z0-9_\\-\\.]{2,}\\.[a-z]{2,}$|^$",
+            "x-locale": {
+                "de_DE": {
+                    "pointer": "Absender E-Mail",
+                    "messages": {
+                        "pattern": "Die E-Mail Adresse muss eine valide E-Mail im Format max@mustermann.de sein"
+                    }
+                }
+            }
+        },
+        "emailRequired": {
+            "type": "boolean",
+            "description": "Whether email is required"
+        },
+        "telephoneActivated": {
+            "type": "boolean",
+            "description": "Whether telephone is activated"
+        },
+        "telephoneRequired": {
+            "type": "boolean",
+            "description": "Whether telephone is required"
+        },
+        "customTextfieldActivated": {
+            "type": "boolean",
+            "description": "Whether a custom textfield is activated"
+        },
+        "customTextfieldRequired": {
+            "type": "boolean",
+            "description": "Whether a custom textfield is required"
+        },
+        "customTextfieldLabel": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Label for the custom textfield"
+        },
+        "customTextfield2Activated": {
+            "type": "boolean",
+            "description": "Whether a custom textfield is activated"
+        },
+        "customTextfield2Required": {
+            "type": "boolean",
+            "description": "Whether a custom textfield is required"
+        },
+        "customTextfield2Label": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Label for the second custom textfield"
+        },
+        "captchaActivatedRequired": {
+            "type": "boolean",
+            "description": "Whether captcha is activated and required"
+        },
+        "infoForAppointment": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Additional display information"
+        },
+        "infoForAllAppointments": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Additional display information for no appointments"
+        },
+        "slotsPerAppointment": {
+            "type": [
+                "string",
+                "null",
+                "integer"
+            ],
+            "description": "Number of slots that can be booked per appointment"
+        },
+        "appointmentsPerMail": {
+            "type": [
+                "string",
+                "null",
+                "integer"
+            ],
+            "description": "Number of allowed appointments per e-mail address"
+        },
+        "whitelistedMails": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "E-mail addresses that have no limitation on appointments count"
+        },
+        "reservationDuration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Duration of the reservation in minutes"
+        },
+        "activationDuration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Duration of the activation time in minutes"
+
+        },
+        "hint": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Additional hint information for the scope"
+        }
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Application.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Application.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend;
+
+class Application
+{
+    public const string IDENTIFIER = 'zms';
+    public const string MODULE_NAME = 'zmscitizenbackend';
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Application.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Application.php
@@ -8,4 +8,9 @@ class Application
 {
     public const string IDENTIFIER = 'zms';
     public const string MODULE_NAME = 'zmscitizenbackend';
+
+    /**
+     * Optional PSR-3 logger used by collection models when skipping invalid items.
+     */
+    public static mixed $log = null;
 }

--- a/zmscitizenbackend/src/Zmscitizenbackend/Exception/SchemaFailedParseJsonFile.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Exception/SchemaFailedParseJsonFile.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Exception;
+
+class SchemaFailedParseJsonFile extends \Exception
+{
+    protected $code = 500;
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Exception/SchemaMissingJsonFile.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Exception/SchemaMissingJsonFile.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Exception;
+
+class SchemaMissingJsonFile extends \Exception
+{
+    protected $code = 500;
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Exception/SchemaValidation.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Exception/SchemaValidation.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Exception;
+
+use Opis\JsonSchema\Errors\ValidationError as OpisValidationError;
+
+class SchemaValidation extends \Exception
+{
+    protected $code = 400;
+
+    public array $data = [];
+
+    protected string $schemaName = '';
+
+    public function setValidationError(array $validationErrorList): static
+    {
+        $this->setMessages($validationErrorList);
+        return $this;
+    }
+
+    public function setSchemaName(string $schemaName): static
+    {
+        $this->schemaName = $schemaName . '.json';
+        return $this;
+    }
+
+    /**
+     * @param OpisValidationError[] $validationErrorList
+     */
+    protected function setMessages(array $validationErrorList): static
+    {
+        foreach ($validationErrorList as $error) {
+            $pointer = is_array($error->data()->path())
+                ? "/" . implode("/", $error->data()->path())
+                : (string) ($error->data()->path() ?? "(root)");
+
+            $message = $error->message();
+            foreach ($error->args() as $key => $value) {
+                $message = str_replace("{" . $key . "}", json_encode($value, JSON_UNESCAPED_SLASHES), $message);
+            }
+
+            $this->data[$pointer]['messages'][$error->keyword()] = $message;
+            $this->data[$pointer]['headline'] = $pointer;
+            $this->data[$pointer]['failed'] = 1;
+            $this->data[$pointer]['data'] = $error->data() !== null ? $error->data()->value() : null;
+
+            $this->message .= ($this->message ? " | " : "")
+                . '[property ' . $pointer . '] '
+                . json_encode($this->data[$pointer]['messages'], JSON_UNESCAPED_SLASHES);
+        }
+        return $this;
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/AvailableCalendar.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/AvailableCalendar.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Schema\Entity;
+use JsonSerializable;
+
+class AvailableCalendar extends Entity implements JsonSerializable
+{
+    public static $schema = 'citizenapi/availableCalendar.json';
+    public string $startDate = '';
+    public string $endDate = '';
+    public string $slotsStartDate = '';
+    public string $slotsEndDate = '';
+    public ?string $prevBookableDate = null;
+    public ?string $nextBookableDate = null;
+    public array $availableDays = [];
+
+    public function __construct(
+        string $startDate,
+        string $endDate,
+        array $availableDays = [],
+        ?string $slotsStartDate = null,
+        ?string $slotsEndDate = null,
+        ?string $prevBookableDate = null,
+        ?string $nextBookableDate = null
+    ) {
+        $this->startDate = $startDate;
+        $this->endDate = $endDate;
+        $this->slotsStartDate = $slotsStartDate ?? $startDate;
+        $this->slotsEndDate = $slotsEndDate ?? $endDate;
+        $this->prevBookableDate = $prevBookableDate;
+        $this->nextBookableDate = $nextBookableDate;
+        $this->availableDays = $availableDays;
+        $this->ensureValid();
+    }
+
+    public function ensureValid(): void
+    {
+        $this->testValid();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'startDate' => $this->startDate,
+            'endDate' => $this->endDate,
+            'slotsStartDate' => $this->slotsStartDate,
+            'slotsEndDate' => $this->slotsEndDate,
+            'prevBookableDate' => $this->prevBookableDate,
+            'nextBookableDate' => $this->nextBookableDate,
+            'availableDays' => $this->availableDays,
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/OfficeList.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/OfficeList.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models\Collections;
+
+use BO\Zmscitizenbackend\Models\Office;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class OfficeList extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/collections/officeList.json";
+    public array $offices = [];
+    public function __construct(array $offices = [])
+    {
+        foreach ($offices as $office) {
+            try {
+                if (!$office instanceof Office) {
+                    throw new InvalidArgumentException("Element is not an instance of Office.");
+                }
+                $this->offices[] = $office;
+            } catch (\Exception $e) {
+                \App::$log->warning('Invalid Office skipped', ['exception' => $e->getMessage()]);
+            }
+        }
+
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'offices' => array_map(fn(Office $office) => $office->toArray(), $this->offices),
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/OfficeServiceAndRelationList.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/OfficeServiceAndRelationList.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models\Collections;
+
+use BO\Zmscitizenbackend\Models\Collections\OfficeList;
+use BO\Zmscitizenbackend\Models\Collections\OfficeServiceRelationList;
+use BO\Zmscitizenbackend\Models\Collections\ServiceList;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class OfficeServiceAndRelationList extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/collections/officeServiceAndRelationList.json";
+    protected OfficeList $offices;
+    protected ServiceList $services;
+    protected OfficeServiceRelationList $relations;
+    public function __construct(OfficeList $offices, ServiceList $services, OfficeServiceRelationList $relations)
+    {
+        $this->offices = $offices;
+        $this->services = $services;
+        $this->relations = $relations;
+        $this->ensureValid();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'offices' => $this->offices->toArray()['offices'],
+            'services' => $this->services->toArray()['services'],
+            'relations' => $this->relations->toArray()['relations']
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/OfficeServiceRelationList.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/OfficeServiceRelationList.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models\Collections;
+
+use BO\Zmscitizenbackend\Models\OfficeServiceRelation;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class OfficeServiceRelationList extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/collections/officeServiceRelationList.json";
+    public array $relations = [];
+    public function __construct(array $relations = [])
+    {
+
+        foreach ($relations as $relation) {
+            try {
+                if (!$relation instanceof OfficeServiceRelation) {
+                    throw new InvalidArgumentException("Element is not an instance of OfficeServiceRelation.");
+                }
+                $this->relations[] = $relation;
+            } catch (\Exception $e) {
+                \App::$log->warning('Invalid OfficeServiceRelation skipped', ['exception' => $e->getMessage()]);
+            }
+        }
+
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'relations' => array_map(fn(OfficeServiceRelation $relation) => $relation->toArray(), $this->relations),
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/ServiceList.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/ServiceList.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models\Collections;
+
+use BO\Zmscitizenbackend\Models\Service;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class ServiceList extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/collections/serviceList.json";
+    public array $services = [];
+    public function __construct(array $services = [])
+    {
+        foreach ($services as $service) {
+            try {
+                if (!$service instanceof Service) {
+                    throw new InvalidArgumentException("Element is not an instance of Service.");
+                }
+                $this->services[] = $service;
+            } catch (\Exception $e) {
+                \App::$log->warning('Invalid Service skipped', ['exception' => $e->getMessage()]);
+            }
+        }
+
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            "services" => array_map(fn(Service $service) => $service->toArray(), $this->services)
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/ThinnedScopeList.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Collections/ThinnedScopeList.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models\Collections;
+
+use BO\Zmscitizenbackend\Models\ThinnedScope;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class ThinnedScopeList extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/collections/thinnedScopeList.json";
+    public array $scopes = [];
+    public function __construct(array $scopes = [])
+    {
+        foreach ($scopes as $scope) {
+            try {
+                if (!$scope instanceof ThinnedScope) {
+                    throw new InvalidArgumentException("Element is not an instance of ThinnedScope.");
+                }
+                $this->scopes[] = $scope;
+            } catch (\Exception $e) {
+                \App::$log->warning('Invalid ThinnedScope skipped', ['exception' => $e->getMessage()]);
+            }
+        }
+
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'scopes' => array_map(fn(ThinnedScope $scope) => $scope->toArray(), $this->scopes),
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Combinable.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Combinable.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class Combinable extends Entity implements JsonSerializable
+{
+    public static $schema = 'citizenapi/combinable.json';
+    private array $combinations = [];
+    private array $order = [];
+
+    public function __construct(array $combinations = [])
+    {
+        $this->order = array_keys($combinations);
+        foreach ($combinations as $id => $providerIds) {
+            $this->combinations[(string)$id] = is_array($providerIds) ? array_map('intval', $providerIds) : [];
+        }
+
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function getCombinations(): array
+    {
+        return $this->combinations;
+    }
+
+    public function toArray(): array
+    {
+        $result = [];
+        foreach ($this->order as $index => $id) {
+            $orderKey = (string)($index + 1);
+            $result[$orderKey] = [$id => $this->combinations[$id]];
+        }
+        return $result;
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Office.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Office.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Schema\Entity;
+use BO\Zmscitizenbackend\Models\ThinnedScope;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class Office extends Entity implements JsonSerializable
+{
+    public static $schema = 'citizenapi/office.json';
+    public int $id;
+    public string $name;
+    public ?array $address = null;
+    public ?array $displayNameAlternatives = null;
+    public ?bool $showAlternativeLocations = null;
+    public ?string $organization = null;
+    public ?string $organizationUnit = null;
+    public ?int $slotTimeInMinutes = null;
+    public ?array $geo = null;
+    public ?array $disabledByServices = [];
+    public int $priority = 1;
+    public ?ThinnedScope $scope = null;
+    public ?string $slotsPerAppointment = null;
+    public ?int $parentId = null;
+    public ?array $allowDisabledServicesMix = null;
+    public ?array $sharedBookingOfficeIds = null;
+
+    public function __construct(
+        int $id,
+        string $name,
+        ?array $address = null,
+        ?bool $showAlternativeLocations = null,
+        ?array $displayNameAlternatives = null,
+        ?string $organization = null,
+        ?string $organizationUnit = null,
+        ?int $slotTimeInMinutes = null,
+        ?array $geo = null,
+        ?array $disabledByServices = [],
+        int $priority = 1,
+        ?ThinnedScope $scope = null,
+        ?string $slotsPerAppointment = null,
+        ?int $parentId = null,
+        ?array $allowDisabledServicesMix = null,
+        ?array $sharedBookingOfficeIds = null
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->address = $address;
+        $this->showAlternativeLocations = $showAlternativeLocations;
+        $this->displayNameAlternatives = $displayNameAlternatives;
+        $this->organization = $organization;
+        $this->organizationUnit = $organizationUnit;
+        $this->slotTimeInMinutes = $slotTimeInMinutes;
+        $this->geo = $geo;
+        $this->scope = $scope;
+        $this->priority = $priority;
+        $this->disabledByServices = $disabledByServices;
+        $this->slotsPerAppointment = $slotsPerAppointment;
+        $this->parentId = $parentId;
+        $this->allowDisabledServicesMix = $allowDisabledServicesMix;
+        $this->sharedBookingOfficeIds = $sharedBookingOfficeIds;
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'address' => $this->address,
+            'showAlternativeLocations' => $this->showAlternativeLocations,
+            'displayNameAlternatives' => $this->displayNameAlternatives,
+            'organization' => $this->organization,
+            'organizationUnit' => $this->organizationUnit,
+            'slotTimeInMinutes' => $this->slotTimeInMinutes,
+            'geo' => $this->geo,
+            'disabledByServices' => $this->disabledByServices,
+            'priority' => $this->priority,
+            'scope' => $this->scope?->toArray(),
+            'slotsPerAppointment' => $this->slotsPerAppointment,
+            'parentId' => $this->parentId,
+            'allowDisabledServicesMix' => $this->allowDisabledServicesMix,
+            'sharedBookingOfficeIds' => $this->sharedBookingOfficeIds,
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/OfficeServiceRelation.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/OfficeServiceRelation.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class OfficeServiceRelation extends Entity implements JsonSerializable
+{
+    public static $schema = 'citizenapi/officeServiceRelation.json';
+
+    public int $officeId;
+    public int $serviceId;
+    public int $slots;
+    public bool $public;
+    public ?int $maxQuantity;
+
+    public function __construct(int $officeId, int $serviceId, int $slots, bool $public, ?int $maxQuantity)
+    {
+        $this->officeId = $officeId;
+        $this->serviceId = $serviceId;
+        $this->slots = $slots;
+        $this->public = $public;
+        $this->maxQuantity = $maxQuantity;
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'officeId' => $this->officeId,
+            'serviceId' => $this->serviceId,
+            'slots' => $this->slots,
+            'public' => $this->public,
+            'maxQuantity' => $this->maxQuantity,
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/Service.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/Service.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Models\Combinable;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class Service extends Entity implements JsonSerializable
+{
+    public static $schema = 'citizenapi/service.json';
+    public int $id;
+    public string $name;
+    public ?int $maxQuantity = null;
+    public ?Combinable $combinable = null;
+    public ?int $parentId = null;
+    public ?int $variantId = null;
+    public ?int $rootParentId = null;
+    public ?bool $showOnStartPage = null;
+
+    public function __construct(
+        int $id,
+        string $name,
+        ?int $maxQuantity = null,
+        ?Combinable $combinable = null,
+        ?int $parentId = null,
+        ?int $variantId = null,
+        ?bool $showOnStartPage = null,
+        ?int $rootParentId = null
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->maxQuantity = $maxQuantity;
+        $this->combinable = $combinable;
+        $this->parentId = $parentId;
+        $this->variantId = $variantId;
+        $this->showOnStartPage = $showOnStartPage;
+        $this->rootParentId = $rootParentId ?? $id;
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'maxQuantity' => $this->maxQuantity,
+            'combinable' => $this->combinable,
+            'parentId' => $this->parentId,
+            'variantId' => $this->variantId,
+            'rootParentId' => $this->rootParentId,
+            'showOnStartPage' => $this->showOnStartPage
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedContact.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedContact.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+
+class ThinnedContact extends Entity implements \JsonSerializable
+{
+    public static $schema = 'citizenapi/thinnedContact.json';
+    public ?string $city;
+    public ?string $country;
+    public ?string $name;
+    public ?string $postalCode;
+    public ?string $region;
+    public ?string $street;
+    public ?string $streetNumber;
+    public function __construct(?string $city = null, ?string $country = null, ?string $name = null, ?string $postalCode = null, ?string $region = null, ?string $street = null, ?string $streetNumber = null)
+    {
+        $this->city         = $city     ?? '';
+        $this->country      = $country  ?? '';
+        $this->name         = $name     ?? '';
+        $this->postalCode   = $postalCode ?? '';
+        $this->region       = $region   ?? '';
+        $this->street       = $street   ?? '';
+        $this->streetNumber = $streetNumber ?? '';
+        $this->ensureValid();
+    }
+
+    private function ensureValid(): void
+    {
+        // testValid() is inherited from Entity; it checks $this against self::$schema.
+        $this->testValid();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'city'         => $this->city,
+            'country'      => $this->country,
+            'name'         => $this->name,
+            'postalCode'   => $this->postalCode,
+            'region'       => $this->region,
+            'street'       => $this->street,
+            'streetNumber' => $this->streetNumber,
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedProcess.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedProcess.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Models\ThinnedScope;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class ThinnedProcess extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/thinnedProcess.json";
+    public ?int $processId;
+    public ?string $timestamp;
+    public ?string $authKey;
+    public ?string $familyName;
+    public ?string $customTextfield;
+    public ?string $customTextfield2;
+    public ?string $email;
+    public ?string $telephone;
+    public ?string $officeName;
+    public ?int $officeId;
+    public ?ThinnedScope $scope;
+    public array $subRequestCounts;
+    public ?int $serviceId;
+    public ?string $serviceName;
+    public int $serviceCount;
+    public ?string $status;
+    public ?string $captchaToken;
+    public ?int $slotCount;
+    public ?string $displayNumber;
+    public ?string $icsContent;
+
+    public function __construct(?int $processId = null, ?string $timestamp = null, ?string $authKey = null, ?string $familyName = null, ?string $customTextfield = null, ?string $customTextfield2 = null, ?string $email = null, ?string $telephone = null, ?string $officeName = null, ?int $officeId = null, ?ThinnedScope $scope = null, array $subRequestCounts = [], ?int $serviceId = null, ?string $serviceName = null, int $serviceCount = 0, ?string $status = null, ?string $captchaToken = null, ?int $slotCount = null, ?string $displayNumber = null, ?string $icsContent = null)
+    {
+        $this->processId = $processId;
+        $this->timestamp = $timestamp;
+        $this->authKey = $authKey;
+        $this->familyName = $familyName;
+        $this->customTextfield = $customTextfield;
+        $this->customTextfield2 = $customTextfield2;
+        $this->email = $email;
+        $this->telephone = $telephone;
+        $this->officeName = $officeName;
+        $this->officeId = $officeId;
+        $this->scope = $scope;
+        $this->subRequestCounts = $subRequestCounts;
+        $this->serviceId = $serviceId;
+        $this->serviceName = $serviceName;
+        $this->serviceCount = $serviceCount;
+        $this->status = $status;
+        $this->captchaToken = $captchaToken;
+        $this->slotCount = $slotCount;
+        $this->displayNumber = $displayNumber;
+        $this->icsContent = $icsContent;
+        $this->ensureValid();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'processId' => $this->processId ?? null,
+            'timestamp' => $this->timestamp ?? null,
+            'authKey' => $this->authKey ?? null,
+            'familyName' => $this->familyName ?? null,
+            'customTextfield' => $this->customTextfield ?? null,
+            'customTextfield2' => $this->customTextfield2 ?? null,
+            'email' => $this->email ?? null,
+            'telephone' => $this->telephone ?? null,
+            'officeName' => $this->officeName ?? null,
+            'officeId' => $this->officeId ?? null,
+            'scope' => $this->scope ?? null,
+            'subRequestCounts' => $this->subRequestCounts,
+            'serviceId' => $this->serviceId ?? null,
+            'serviceName' => $this->serviceName ?? null,
+            'serviceCount' => $this->serviceCount,
+            'status' => $this->status ?? null,
+            'captchaToken' => $this->captchaToken ?? null,
+            'slotCount' => $this->slotCount ?? null,
+            'displayNumber' => $this->displayNumber ?? null,
+            'icsContent' => $this->icsContent ?? null
+        ];
+    }
+
+    public function setCaptchaToken(string $token): void
+    {
+        $this->captchaToken = $token;
+    }
+
+    /** @psalm-api */
+    public function getCaptchaToken(): ?string
+    {
+        return $this->captchaToken;
+    }
+
+    /** @psalm-api */
+    public function setIcsContent(string $icsContent): void
+    {
+        $this->icsContent = $icsContent;
+    }
+
+    /** @psalm-api */
+    public function getIcsContent(): ?string
+    {
+        return $this->icsContent;
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedProvider.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class ThinnedProvider extends Entity implements JsonSerializable
+{
+    public static $schema = "citizenapi/thinnedProvider.json";
+    public ?int $id;
+    public ?string $name;
+    public ?string $displayName;
+    public ?string $source;
+    public ?float $lat;
+    public ?float $lon;
+    public ?ThinnedContact $contact;
+    public function __construct(?int $id = null, ?string $name = null, ?string $displayName = null, ?float $lat = null, ?float $lon = null, ?string $source = null, ?ThinnedContact $contact = null,)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->displayName = $displayName;
+        $this->lat = $lat;
+        $this->lon = $lon;
+        $this->source = $source;
+        $this->contact = $contact;
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id ?? null,
+            'name' => $this->name ?? null,
+            'displayName' => $this->displayName ?? null,
+            'lat' => $this->lat ?? null,
+            'lon' => $this->lon ?? null,
+            'source' => $this->source ?? null,
+            'contact' => $this->contact ?? null,
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedScope.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Models/ThinnedScope.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Models;
+
+use BO\Zmscitizenbackend\Models\ThinnedProvider;
+use BO\Zmscitizenbackend\Schema\Entity;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class ThinnedScope extends Entity implements JsonSerializable
+{
+    public static $schema = 'citizenapi/thinnedScope.json';
+    public int $id;
+    public ?ThinnedProvider $provider;
+    public ?string $shortName;
+    public ?string $emailFrom;
+    public ?bool $emailRequired;
+    public ?bool $telephoneActivated;
+    public ?bool $telephoneRequired;
+    public ?bool $customTextfieldActivated;
+    public ?bool $customTextfieldRequired;
+    public ?string $customTextfieldLabel;
+    public ?bool $customTextfield2Activated;
+    public ?bool $customTextfield2Required;
+    public ?string $customTextfield2Label;
+    public ?bool $captchaActivatedRequired;
+    public ?string $infoForAppointment;
+    public ?string $infoForAllAppointments;
+    public ?string $slotsPerAppointment;
+    public ?string $appointmentsPerMail;
+    public ?string $whitelistedMails;
+    public ?int $reservationDuration;
+    public ?int $activationDuration;
+    public ?string $hint;
+
+    public function __construct(int $id = 0, ?ThinnedProvider $provider = null, ?string $shortName = null, ?string $emailFrom = null, ?bool $emailRequired = null, ?bool $telephoneActivated = null, ?bool $telephoneRequired = null, ?bool $customTextfieldActivated = null, ?bool $customTextfieldRequired = null, ?string $customTextfieldLabel = null, ?bool $customTextfield2Activated = null, ?bool $customTextfield2Required = null, ?string $customTextfield2Label = null, ?bool $captchaActivatedRequired = null, ?string $infoForAppointment = null, ?string $infoForAllAppointments = null, ?string $slotsPerAppointment = null, ?string $appointmentsPerMail = null, ?string $whitelistedMails = null, ?int $reservationDuration = null, ?int $activationDuration = null, ?string $hint = null)
+    {
+        $this->id = $id;
+        $this->provider = $provider;
+        $this->shortName = $shortName;
+        $this->emailFrom = $emailFrom;
+        $this->emailRequired = $emailRequired;
+        $this->telephoneActivated = $telephoneActivated;
+        $this->telephoneRequired = $telephoneRequired;
+        $this->customTextfieldActivated = $customTextfieldActivated;
+        $this->customTextfieldRequired = $customTextfieldRequired;
+        $this->customTextfieldLabel = $customTextfieldLabel;
+        $this->customTextfield2Activated = $customTextfield2Activated;
+        $this->customTextfield2Required = $customTextfield2Required;
+        $this->customTextfield2Label = $customTextfield2Label;
+        $this->captchaActivatedRequired = $captchaActivatedRequired;
+        $this->infoForAppointment = $infoForAppointment;
+        $this->infoForAllAppointments = $infoForAllAppointments;
+        $this->slotsPerAppointment = $slotsPerAppointment;
+        $this->appointmentsPerMail = $appointmentsPerMail;
+        $this->whitelistedMails = $whitelistedMails;
+        $this->reservationDuration = $reservationDuration;
+        $this->activationDuration = $activationDuration;
+        $this->hint = $hint;
+        $this->ensureValid();
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureValid()
+    {
+        if (!$this->testValid()) {
+            throw new InvalidArgumentException("The provided data is invalid according to the schema.");
+        }
+    }
+
+    /** @psalm-api */
+    public function getProvider(): ?ThinnedProvider
+    {
+        return $this->provider;
+    }
+
+    /** @psalm-api */
+    public function getShortName(): ?string
+    {
+        return $this->shortName;
+    }
+
+    public function getEmailFrom(): ?string
+    {
+        return $this->emailFrom;
+    }
+
+    public function getEmailRequired(): ?bool
+    {
+        return $this->emailRequired;
+    }
+
+    public function getTelephoneActivated(): ?bool
+    {
+        return $this->telephoneActivated;
+    }
+
+    public function getTelephoneRequired(): ?bool
+    {
+        return $this->telephoneRequired;
+    }
+
+    public function getCustomTextfieldActivated(): ?bool
+    {
+        return $this->customTextfieldActivated;
+    }
+
+    public function getCustomTextfieldRequired(): ?bool
+    {
+        return $this->customTextfieldRequired;
+    }
+
+    public function getCustomTextfieldLabel(): ?string
+    {
+        return $this->customTextfieldLabel;
+    }
+
+    public function getCustomTextfield2Activated(): ?bool
+    {
+        return $this->customTextfield2Activated;
+    }
+
+    public function getCustomTextfield2Required(): ?bool
+    {
+        return $this->customTextfield2Required;
+    }
+
+    public function getCustomTextfield2Label(): ?string
+    {
+        return $this->customTextfield2Label;
+    }
+
+    /** @psalm-api */
+    public function getCaptchaActivatedRequired(): ?bool
+    {
+        return $this->captchaActivatedRequired;
+    }
+
+    /** @psalm-api */
+    public function getInfoForAppointment(): ?string
+    {
+        return $this->infoForAppointment;
+    }
+
+    /** @psalm-api */
+    public function getInfoForAllAppointments(): ?string
+    {
+        return $this->infoForAllAppointments;
+    }
+
+    public function getSlotsPerAppointment(): ?string
+    {
+        return $this->slotsPerAppointment;
+    }
+
+    public function getAppointmentsPerMail(): ?string
+    {
+        return $this->appointmentsPerMail;
+    }
+
+    public function getWhitelistedMails(): ?string
+    {
+        return $this->whitelistedMails;
+    }
+
+    public function getReservationDuration(): ?int
+    {
+        return $this->reservationDuration;
+    }
+
+    public function getActivationDuration(): ?int
+    {
+        return $this->activationDuration;
+    }
+
+    /** @psalm-api */
+    public function getHint(): ?string
+    {
+        return $this->hint;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'provider' => $this->provider,
+            'shortName' => $this->shortName,
+            'emailFrom' => $this->emailFrom,
+            'emailRequired' => $this->emailRequired,
+            'telephoneActivated' => $this->telephoneActivated,
+            'telephoneRequired' => $this->telephoneRequired,
+            'customTextfieldActivated' => $this->customTextfieldActivated,
+            'customTextfieldRequired' => $this->customTextfieldRequired,
+            'customTextfieldLabel' => $this->customTextfieldLabel,
+            'customTextfield2Activated' => $this->customTextfield2Activated,
+            'customTextfield2Required' => $this->customTextfield2Required,
+            'customTextfield2Label' => $this->customTextfield2Label,
+            'captchaActivatedRequired' => $this->captchaActivatedRequired,
+            'infoForAppointment' => $this->infoForAppointment,
+            'infoForAllAppointments' => $this->infoForAllAppointments,
+            'slotsPerAppointment' => $this->slotsPerAppointment,
+            'appointmentsPerMail' => $this->appointmentsPerMail,
+            'whitelistedMails' => $this->whitelistedMails,
+            'reservationDuration' => $this->reservationDuration,
+            'activationDuration' => $this->activationDuration,
+            'hint' => $this->hint
+        ];
+    }
+
+    #[\Override]
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Schema/Entity.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Schema/Entity.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Schema;
+
+use BO\Zmscitizenbackend\Exception\SchemaValidation;
+
+abstract class Entity implements \JsonSerializable
+{
+    /**
+     * @var string|null Filename of JSON-Schema file relative to zmscitizenbackend/schema
+     */
+    public static $schema = null;
+
+    /**
+     * @var array<string, Schema>
+     */
+    protected static array $schemaCache = [];
+
+    public function getValidator(int $resolveLevel = 10): Validator
+    {
+        $jsonSchema = self::readJsonSchema()->withResolvedReferences($resolveLevel);
+        $data = self::stripNulls(json_decode(json_encode($this->jsonSerialize())));
+        return new Validator($data, $jsonSchema);
+    }
+
+    public function isValid(int $resolveLevel = 10): bool
+    {
+        return $this->getValidator($resolveLevel)->isValid();
+    }
+
+    /**
+     * @throws SchemaValidation
+     */
+    public function testValid(int $resolveLevel = 10): bool
+    {
+        $validator = $this->getValidator($resolveLevel);
+        if (!$validator->isValid()) {
+            $exception = new SchemaValidation();
+            $exception->setSchemaName($this->getEntityName());
+            $exception->setValidationError($validator->getErrors());
+            throw $exception;
+        }
+        return true;
+    }
+
+    public function getEntityName(): string
+    {
+        $entity = get_class($this);
+        $entity = preg_replace('#.*[\\\]#', '', $entity);
+        return strtolower($entity);
+    }
+
+    protected static function readJsonSchema(): Schema
+    {
+        $class = get_called_class();
+        if (!array_key_exists($class, self::$schemaCache)) {
+            self::$schemaCache[$class] = Loader::asArray($class::$schema);
+        }
+        return self::$schemaCache[$class];
+    }
+
+    protected static function stripNulls(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            $out = [];
+            foreach ($value as $key => $item) {
+                if ($item === null) {
+                    continue;
+                }
+                $out[$key] = self::stripNulls($item);
+            }
+            return $out;
+        }
+        if (is_object($value)) {
+            foreach ($value as $key => $item) {
+                if ($item === null) {
+                    unset($value->$key);
+                } else {
+                    $value->$key = self::stripNulls($item);
+                }
+            }
+        }
+        return $value;
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Schema/Loader.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Schema/Loader.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Schema;
+
+use BO\Zmscitizenbackend\Exception\SchemaFailedParseJsonFile;
+use BO\Zmscitizenbackend\Exception\SchemaMissingJsonFile;
+
+class Loader
+{
+    public static function asArray(string $schemaFilename): Schema
+    {
+        $path = self::resolvePath($schemaFilename);
+        $jsonString = file_get_contents($path);
+        if ($jsonString === false) {
+            throw new SchemaMissingJsonFile("Could not read JSON-Schema file $path");
+        }
+        $array = json_decode($jsonString, true);
+        if (null === $array && $jsonString !== '' && $jsonString !== 'null') {
+            throw new SchemaFailedParseJsonFile("Could not parse JSON File $path");
+        }
+        $schema = new Schema(is_array($array) ? $array : []);
+        $schema->setSourcePath($path);
+        return $schema;
+    }
+
+    public static function resolvePath(string $schemaFilename): string
+    {
+        if ($schemaFilename === '') {
+            throw new SchemaMissingJsonFile("Missing JSON-Schema file");
+        }
+        if ($schemaFilename[0] === '/') {
+            $filename = $schemaFilename;
+        } else {
+            $filename = self::getSchemaPath() . DIRECTORY_SEPARATOR . $schemaFilename;
+        }
+        $real = realpath($filename);
+        if ($real === false) {
+            throw new SchemaMissingJsonFile("Missing JSON-Schema file: $schemaFilename");
+        }
+        return $real;
+    }
+
+    public static function getSchemaPath(): string
+    {
+        $pathTrace = [
+            __DIR__,
+            '..',
+            '..',
+            '..',
+            'schema'
+        ];
+        $path = realpath(implode(DIRECTORY_SEPARATOR, $pathTrace));
+        if ($path === false) {
+            throw new SchemaMissingJsonFile("Could not resolve Citizen schema directory");
+        }
+        return $path;
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Schema/Schema.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Schema/Schema.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Schema;
+
+/**
+ * @extends \ArrayObject<array-key, mixed>
+ */
+class Schema extends \ArrayObject
+{
+    protected string $sourcePath = '';
+
+    public function __construct(
+        array $input = [],
+        int $flags = \ArrayObject::ARRAY_AS_PROPS,
+        string $iterator_class = "ArrayIterator"
+    ) {
+        parent::__construct($input, $flags, $iterator_class);
+    }
+
+    public function setSourcePath(string $sourcePath): static
+    {
+        $this->sourcePath = $sourcePath;
+        return $this;
+    }
+
+    public function getSourcePath(): string
+    {
+        return $this->sourcePath;
+    }
+
+    public function withResolvedReferences(int $resolveLevel): self
+    {
+        if ($resolveLevel <= 0) {
+            return $this;
+        }
+        $baseDir = $this->sourcePath !== '' ? dirname($this->sourcePath) : Loader::getSchemaPath();
+        $resolved = $this->resolveReferences($this->getArrayCopy(), $resolveLevel, $baseDir);
+        $schema = new self($resolved);
+        $schema->setSourcePath($this->sourcePath);
+        return $schema;
+    }
+
+    public function toJsonObject(): mixed
+    {
+        return json_decode(json_encode($this->getArrayCopy()));
+    }
+
+    protected function resolveKey(string|int $key, mixed $value, int $resolveLevel, string $baseDir): mixed
+    {
+        if (is_array($value)) {
+            return $this->resolveReferences($value, $resolveLevel, $baseDir);
+        }
+        if ($key === '$ref' && is_string($value) && $value !== '' && !str_starts_with($value, '#')) {
+            $refPath = $value;
+            if ($refPath[0] !== '/') {
+                $refPath = $baseDir . DIRECTORY_SEPARATOR . $refPath;
+            }
+            return Loader::asArray($refPath)->withResolvedReferences($resolveLevel - 1);
+        }
+        return $value;
+    }
+
+    protected function resolveReferences(array|self $hash, int $resolveLevel, string $baseDir): array
+    {
+        foreach ($hash as $key => $value) {
+            $hash[$key] = $this->resolveKey($key, $value, $resolveLevel, $baseDir);
+            if ($hash[$key] instanceof self) {
+                return $hash[$key]->getArrayCopy();
+            }
+        }
+        return $hash instanceof self ? $hash->getArrayCopy() : $hash;
+    }
+}

--- a/zmscitizenbackend/src/Zmscitizenbackend/Schema/Validator.php
+++ b/zmscitizenbackend/src/Zmscitizenbackend/Schema/Validator.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Schema;
+
+use Opis\JsonSchema\Errors\ValidationError as OpisValidationError;
+use Opis\JsonSchema\Validator as OpisValidator;
+
+class Validator
+{
+    protected \Opis\JsonSchema\ValidationResult $validationResult;
+
+    public function __construct(mixed $data, Schema $schemaObject)
+    {
+        $opis = new OpisValidator();
+        $schemaJson = $schemaObject->toJsonObject();
+        $payload = json_decode(json_encode($data));
+        $this->validationResult = $opis->validate($payload, $schemaJson);
+    }
+
+    public function isValid(): bool
+    {
+        return $this->validationResult->isValid();
+    }
+
+    /**
+     * @return OpisValidationError[]
+     */
+    public function getErrors(): array
+    {
+        if ($this->validationResult->isValid()) {
+            return [];
+        }
+
+        $error = $this->validationResult->error();
+        if (!$error) {
+            return [];
+        }
+
+        return $this->extractErrors($error);
+    }
+
+    /**
+     * @return OpisValidationError[]
+     */
+    private function extractErrors(OpisValidationError $error): array
+    {
+        $errors = [$error];
+        foreach ($error->subErrors() as $subError) {
+            if ($subError instanceof OpisValidationError) {
+                $errors = array_merge($errors, $this->extractErrors($subError));
+            }
+        }
+        return $errors;
+    }
+}

--- a/zmscitizenbackend/tests/Zmscitizenbackend/ApplicationTest.php
+++ b/zmscitizenbackend/tests/Zmscitizenbackend/ApplicationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Tests;
+
+use BO\Zmscitizenbackend\Application;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationTest extends TestCase
+{
+    public function testModuleNameIsCitizenBackend(): void
+    {
+        $this->assertSame('zmscitizenbackend', Application::MODULE_NAME);
+        $this->assertSame('zms', Application::IDENTIFIER);
+    }
+}

--- a/zmscitizenbackend/tests/Zmscitizenbackend/SchemaAndModelTest.php
+++ b/zmscitizenbackend/tests/Zmscitizenbackend/SchemaAndModelTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BO\Zmscitizenbackend\Tests;
+
+use BO\Zmscitizenbackend\Exception\SchemaMissingJsonFile;
+use BO\Zmscitizenbackend\Exception\SchemaValidation;
+use BO\Zmscitizenbackend\Models\Collections\OfficeList;
+use BO\Zmscitizenbackend\Models\Office;
+use BO\Zmscitizenbackend\Models\ThinnedScope;
+use BO\Zmscitizenbackend\Schema\Loader;
+use PHPUnit\Framework\TestCase;
+
+class SchemaAndModelTest extends TestCase
+{
+    public function testSchemaPathPointsAtCitizenBackend(): void
+    {
+        $path = Loader::getSchemaPath();
+        $this->assertStringEndsWith('/zmscitizenbackend/schema', $path);
+        $this->assertFileExists($path . '/citizenapi/office.json');
+    }
+
+    public function testLoaderReadsOfficeSchema(): void
+    {
+        $schema = Loader::asArray('citizenapi/office.json');
+        $this->assertSame('Office', $schema['title']);
+        $this->assertContains('id', $schema['required']);
+    }
+
+    public function testLoaderResolvesRelativeRefs(): void
+    {
+        $schema = Loader::asArray('citizenapi/office.json')->withResolvedReferences(4);
+        $scope = $schema['properties']['scope'];
+        $this->assertIsArray($scope);
+        $this->assertArrayHasKey('properties', $scope);
+        $this->assertArrayHasKey('provider', $scope['properties']);
+        $this->assertArrayNotHasKey('$ref', $scope);
+    }
+
+    public function testMissingSchemaFileThrows(): void
+    {
+        $this->expectException(SchemaMissingJsonFile::class);
+        Loader::asArray('citizenapi/does-not-exist.json');
+    }
+
+    public function testOfficeModelValidatesAgainstOwnedSchema(): void
+    {
+        $office = new Office(1, 'Bürgerbüro');
+        $this->assertSame(1, $office->id);
+        $this->assertSame('Bürgerbüro', $office->toArray()['name']);
+    }
+
+    public function testThinnedScopeRejectsInvalidEmail(): void
+    {
+        $this->expectException(SchemaValidation::class);
+        new ThinnedScope(id: 1, emailFrom: 'not-an-email');
+    }
+
+    public function testOfficeListHydratesFromOwnedCollectionSchema(): void
+    {
+        $list = new OfficeList([new Office(10, 'Ruppertstraße')]);
+        $payload = $list->toArray();
+        $this->assertCount(1, $payload['offices']);
+        $this->assertSame(10, $payload['offices'][0]['id']);
+    }
+}

--- a/zmscitizenbackend/tests/Zmscitizenbackend/bootstrap.php
+++ b/zmscitizenbackend/tests/Zmscitizenbackend/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';

--- a/zmscitizenbackend/tests/Zmscitizenbackend/bootstrap.php
+++ b/zmscitizenbackend/tests/Zmscitizenbackend/bootstrap.php
@@ -3,3 +3,15 @@
 declare(strict_types=1);
 
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+if (!class_exists('App')) {
+    class App extends \BO\Zmscitizenbackend\Application
+    {
+    }
+}
+
+App::$log = new class {
+    public function warning(string $message, array $context = []): void
+    {
+    }
+};


### PR DESCRIPTION
## Summary
- Add `zmscitizenbackend` as a side-by-side Composer/PHP module (namespaces, PHPUnit/Psalm, CI matrix, docs) so refactor work can proceed without renaming live `zmscitizenapi`.
- Own Citizen JSON schemas and model validation in the new module (`schema/citizenapi` + local `Schema\Entity`); `zmscitizenapi` still serves traffic and still reads `zmsentities/schema/citizenapi` until cutover.

Related: https://github.com/it-at-m/eappointment/issues/2899 (phases 2 and 3). Does not switch gateway/`zmscitizenview`.

## Test plan
- [ ] CI unit tests and PHPCS/PHPMD pass for `zmscitizenbackend`
- [ ] `cd zmscitizenbackend && composer install && ./vendor/bin/phpunit -c phpunit.xml --no-coverage`
- [ ] Confirm `zmscitizenapi` is unchanged and local citizen view still hits `/terminvereinbarung/api/citizen`
- [ ] Optional: `vendor/bin/phpcs --standard=psr12 --warning-severity=0 src/` and `vendor/bin/phpmd src/ text ../phpmd.rules.xml` in `zmscitizenbackend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the standalone Citizen API backend module.
  - Added structured schemas and data models for appointments, offices, services, calendars, CAPTCHA, contacts, processes, and scopes.
  - Added validation and JSON serialization for consistent API data handling.
- **Documentation**
  - Documented the backend’s migration status, architecture, setup, and module relationships.
- **Quality Improvements**
  - Integrated the backend into automated testing, code-quality checks, static analysis, coverage reporting, and CLI processing.
  - Updated issue templates and automated module labeling to support the new backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->