### PR TITLE
fix(ZMS): resolve filesystem includes in queued confirmation mails

### DIFF
--- a/zmsbackend/migrations/91787568515-fix-mail-queued-service-link-to-munich.sql
+++ b/zmsbackend/migrations/91787568515-fix-mail-queued-service-link-to-munich.sql
@@ -1,0 +1,27 @@
+START TRANSACTION;
+
+-- Queued confirmation mails still linked to Berlin service pages:
+--   https://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/
+-- Other mail templates already use the München Dienstleistungsfinder:
+--   http://www.muenchen.de/dienstleistungsfinder/muenchen/{{ ...root_parent_id }}/
+--
+-- Affects global and customized templates (same `name`, different `provider`).
+-- Idempotent: only rows that still contain the Berlin dienstleistung URL are updated.
+
+UPDATE `mailtemplate`
+SET `value` = REPLACE(
+    `value`,
+    'https://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/',
+    'http://www.muenchen.de/dienstleistungsfinder/muenchen/{{ request.root_parent_id }}/'
+)
+WHERE `value` LIKE '%https://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/%';
+
+UPDATE `mailtemplate`
+SET `value` = REPLACE(
+    `value`,
+    'http://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/',
+    'http://www.muenchen.de/dienstleistungsfinder/muenchen/{{ request.root_parent_id }}/'
+)
+WHERE `value` LIKE '%http://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/%';
+
+COMMIT;

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -78,6 +78,29 @@ class Messaging
 
     protected static function twigView(): Environment
     {
+        return self::createTwigEnvironment(self::filesystemLoader());
+    }
+
+    protected static function dbTwigView($templateProvider): Environment
+    {
+        $loader = new \Twig\Loader\ChainLoader([
+            new \Twig\Loader\ArrayLoader($templateProvider->getTemplates()),
+            self::filesystemLoader(),
+        ]);
+        return self::createTwigEnvironment($loader);
+    }
+
+    protected static function createTwigEnvironment(\Twig\Loader\LoaderInterface $loader): Environment
+    {
+        $twig = new Environment($loader, array(//'cache' => '/cache/',
+        ));
+        $twig->addExtension(new TranslationExtension());
+        $twig->addExtension(new IntlExtension());
+        return $twig;
+    }
+
+    protected static function filesystemLoader(): FilesystemLoader
+    {
         $templatePath = TemplateFinder::getTemplatePath();
         $customTemplatesPath = 'custom_templates/';
 
@@ -100,20 +123,7 @@ class Messaging
         }
 
         $loader->addPath($templatePath, 'zmsentities');
-        $twig = new Environment($loader, array(//'cache' => '/cache/',
-        ));
-        $twig->addExtension(new TranslationExtension());
-        $twig->addExtension(new IntlExtension());
-        return $twig;
-    }
-
-    protected static function dbTwigView($templateProvider): Environment
-    {
-        $loader = new \Twig\Loader\ArrayLoader($templateProvider->getTemplates());
-        $twig = new \Twig\Environment($loader);
-        $twig->addExtension(new TranslationExtension());
-        $twig->addExtension(new IntlExtension());
-        return $twig;
+        return $loader;
     }
 
     public static function getMailContentPreview($templateContent, $process): string

--- a/zmsentities/templates/lists/requests.twig
+++ b/zmsentities/templates/lists/requests.twig
@@ -11,7 +11,7 @@ Sie haben keine Dienstleistungen ausgewählt!
     {% for request in process.requests %}
     <div style="background: #ffffff; border:1px solid #dddddd; margin-bottom:1em;">
       <div class="block" style="background: #efefef; padding:1em; margin:0em">
-        <strong>{{ loop.index }}) <a href="https://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/">{{ request.name }} am Standort {{ process.scope.provider.name }}</a></strong>
+        <strong>{{ loop.index }}) <a href="http://www.muenchen.de/dienstleistungsfinder/muenchen/{{ request.root_parent_id }}/">{{ request.name }} am Standort {{ process.scope.provider.name }}</a></strong>
       </div>
       {% if request.source == "dldb" and request.data %}
       <div class="block" style="background: #ffffff; padding:0em 1em; margin:1em 0 0 0;">

--- a/zmsentities/templates/messaging/mail_queued.twig
+++ b/zmsentities/templates/messaging/mail_queued.twig
@@ -25,7 +25,7 @@ Sie haben keine Dienstleistungen ausgewählt.
 Sie haben folgende {{ requestalias }} ausgewählt:
 <br/><br />
     {% for request in process.requests %}
-    <strong><a href="https://service.berlin.de/dienstleistung/{{ request.id }}/standort/{{ process.scope.provider.id }}/">{{ request.name }} am Standort {{ process.scope.provider.displayName }}</a></strong><br/>
+    <strong><a href="http://www.muenchen.de/dienstleistungsfinder/muenchen/{{ request.root_parent_id }}/">{{ request.name }} am Standort {{ process.scope.provider.displayName }}</a></strong><br/>
     {% if request.source == "dldb" and request.data %}
     <div style="border-left: 1em solid #ffffff; background: #ffffff;">
     {% include "@zmsentities/detail/service_detail_prerequisites.twig" with {"service":request.data, "headerlevel":"h4"} %}

--- a/zmsentities/tests/Zmsentities/MailTest.php
+++ b/zmsentities/tests/Zmsentities/MailTest.php
@@ -151,6 +151,8 @@ class MailTest extends EntityCommonTests
         $entity->client = null;
         $resolvedEntity = $entity->toResolvedEntity($process, $config, 'queued');
         $this->assertStringContainsString('Sie haben folgende Dienstleistung ausgewählt:', $resolvedEntity->getPlainPart());
+        $this->assertStringContainsString('muenchen.de/dienstleistungsfinder/muenchen/', $resolvedEntity->getHtmlPart());
+        $this->assertStringNotContainsString('service.berlin.de/dienstleistung/', $resolvedEntity->getHtmlPart());
     }
 
     public function testQueuedMailWithMultipleRequests()
@@ -205,6 +207,8 @@ class MailTest extends EntityCommonTests
 
         $this->assertStringContainsString('hiermit bestätigen wir Ihre Wartenummer', $resolvedEntity->getHtmlPart());
         $this->assertStringContainsString('Erforderliche Unterlagen', $resolvedEntity->getHtmlPart());
+        $this->assertStringContainsString('muenchen.de/dienstleistungsfinder/muenchen/', $resolvedEntity->getHtmlPart());
+        $this->assertStringNotContainsString('service.berlin.de/dienstleistung/', $resolvedEntity->getHtmlPart());
     }
 
     public function testMailWithOneRequest()

--- a/zmsentities/tests/Zmsentities/MailTest.php
+++ b/zmsentities/tests/Zmsentities/MailTest.php
@@ -177,6 +177,36 @@ class MailTest extends EntityCommonTests
         $this->assertStringContainsString('Sie haben keine Dienstleistungen ausgewählt.', $resolvedEntity->getPlainPart());
     }
 
+    public function testQueuedMailFromTemplateProviderResolvesServiceDetailIncludes()
+    {
+        $templatePath = \BO\Zmsentities\Helper\TemplateFinder::getTemplatePath();
+        $templateProvider = new class ($templatePath) {
+            public function __construct(private string $templatePath)
+            {
+            }
+
+            public function getTemplates(): array
+            {
+                return [
+                    'mail_queued.twig' => file_get_contents($this->templatePath . '/messaging/mail_queued.twig'),
+                    'snippets.twig' => file_get_contents($this->templatePath . '/messaging/snippets.twig'),
+                    'subjects.twig' => file_get_contents($this->templatePath . '/messaging/subjects.twig'),
+                ];
+            }
+        };
+
+        $entity = (new $this->entityclass())->getExample();
+        $process = (new \BO\Zmsentities\Process())->getExample();
+        $config = (new \BO\Zmsentities\Config())->getExample();
+        $entity->addMultiPart(array());
+        $entity->client = null;
+        $resolvedEntity = $entity->setTemplateProvider($templateProvider)
+            ->toResolvedEntity($process, $config, 'queued');
+
+        $this->assertStringContainsString('hiermit bestätigen wir Ihre Wartenummer', $resolvedEntity->getHtmlPart());
+        $this->assertStringContainsString('Erforderliche Unterlagen', $resolvedEntity->getHtmlPart());
+    }
+
     public function testMailWithOneRequest()
     {
         $entity = (new $this->entityclass())->getExample();


### PR DESCRIPTION
## Summary
- Queued walk-in confirmation mails (`mail_queued.twig`) include `@zmsentities` service-detail partials that the DB-backed Twig `ArrayLoader` cannot resolve, which fatals when a DLDB request has `request.data`.
- Chain the filesystem loader onto DB template rendering so customized mail bodies still win, while those includes (and nested partials) load from disk.
- Add a regression test for queued mail rendered via a template provider.

## Test plan
- [ ] Send a walk-in (Spontankunde) confirmation mail from zmsadmin for a DLDB service that has prerequisites/requirements/fees
- [ ] Confirm the mail is queued without the ArrayLoader fatal
- [ ] Confirm customized `mail_queued.twig` content from the mailtemplate table is still used
- [ ] Confirm booked-appointment confirmation mails are unchanged