### PR TITLE
fix(ZMSKVR-1571): keep office and form intact vue mount on back from Übersicht; first citizen-login zmsautomation coverage

### DIFF
--- a/zmsautomation/src/main/resources/db/migration/V25__ZMSKVR-1571_opening_hours_for_scheidplatz.sql
+++ b/zmsautomation/src/main/resources/db/migration/V25__ZMSKVR-1571_opening_hours_for_scheidplatz.sql
@@ -1,0 +1,111 @@
+-- Flyway migration: Opening hours for Scheidplatz test data (ZMSKVR-1571)
+--
+-- Mirrors V19__ZMSKVR-1124_opening_hours_for_ruppertstasse for Citizen View
+-- zmskvr-1571_scheidplatz_contact_location_back_login.feature:
+--  - Office 102524 (Bürgerbüro Scheidplatz)
+--
+-- Standorte involved (see V5__standort_test_data):
+--  - 157 -> officeId 102524 (alt / Belgradstraße; Termine_bis was 1)
+--  - 353 -> officeId 102524 (Riesenfeldstraße; Termine_bis 42)
+--
+-- Without oeffnungszeit rows, available-calendar returns no free days and ATAF
+-- cannot highlight a timeslot for provider 102524.
+
+-- Widen booking window on legacy scope 157 (was Termine_ab=1, Termine_bis=1)
+-- and give a real reservation hold (was reservierungsdauer/reservationDuration=0),
+-- otherwise Kontakt shows "Ihre Sitzung ist abgelaufen" immediately after reserve.
+UPDATE `standort`
+SET `Termine_ab` = 0,
+    `Termine_bis` = 42,
+    `reservierungsdauer` = 15
+WHERE `StandortID` = 157;
+
+UPDATE `preferences`
+SET `value` = '42',
+    `updateTimestamp` = NOW()
+WHERE `entity` = 'scope'
+  AND `id` = 157
+  AND `groupName` = 'appointment'
+  AND `name` = 'endInDaysDefault';
+
+UPDATE `preferences`
+SET `value` = '15',
+    `updateTimestamp` = NOW()
+WHERE `entity` = 'scope'
+  AND `id` = 157
+  AND `groupName` = 'appointment'
+  AND `name` = 'reservationDuration';
+
+-- round current time to next 5 minute slot
+SET @rounded_start :=
+  SEC_TO_TIME(CEILING(TIME_TO_SEC(CURTIME()) / 300) * 300);
+
+-- desired end = +6 hours
+SET @desired_end :=
+  ADDTIME(@rounded_start, '06:00:00');
+
+-- latest allowed end so slots still fit
+SET @rounded_end :=
+  LEAST(@desired_end, '23:55:00');
+
+-- If the capped end is not after the rounded start (e.g. late night / 24:00:00 start),
+-- use the next calendar day with appointment window 00:05–03:05 (still capped at 23:55).
+SET @start_sec := TIME_TO_SEC(@rounded_start);
+SET @end_sec := TIME_TO_SEC(@rounded_end);
+SET @use_next_day := (@end_sec <= @start_sec);
+
+SET @appt_start := IF(@use_next_day, '00:05:00', @rounded_start);
+SET @appt_end :=
+  IF(@use_next_day, LEAST(ADDTIME('00:05:00', '03:00:00'), '23:55:00'), @rounded_end);
+
+SET @range_start := IF(@use_next_day, DATE_ADD(CURDATE(), INTERVAL 1 DAY), CURDATE());
+SET @range_end :=
+  IF(@use_next_day, DATE_ADD(CURDATE(), INTERVAL 8 DAY), DATE_ADD(CURDATE(), INTERVAL 7 DAY));
+
+INSERT IGNORE INTO `oeffnungszeit`
+(
+  `OeffnungszeitID`,
+  `StandortID`,
+  `Startdatum`,
+  `Endedatum`,
+  `allexWochen`,
+  `jedexteWoche`,
+  `Wochentag`,
+  `Anfangszeit`,
+  `Terminanfangszeit`,
+  `Endzeit`,
+  `Terminendzeit`,
+  `Timeslot`,
+  `Anzahlarbeitsplaetze`,
+  `Anzahlterminarbeitsplaetze`,
+  `kommentar`,
+  `reduktionTermineImInternet`,
+  `erlaubemehrfachslots`,
+  `Offen_ab`,
+  `Offen_bis`,
+  `updateTimestamp`
+)
+VALUES
+  -- Bürgerbüro Scheidplatz (KVR-II/233) – Belgradstraße alt (officeId 102524)
+  (136207, 157, @range_start, @range_end,
+   1, 0, 127,
+   '00:00:00', @appt_start,
+   '00:00:00', @appt_end,
+   '00:05:00',
+   0, 5,
+   'ZMSKVR-1571 Scheidplatz Öffnungszeit',
+   0, 5,
+   0, 30,
+   NOW()),
+
+  -- Bürgerbüro Scheidplatz (KVR-II/233) – Riesenfeldstraße (officeId 102524)
+  (136208, 353, @range_start, @range_end,
+   1, 0, 127,
+   '00:00:00', @appt_start,
+   '00:00:00', @appt_end,
+   '00:05:00',
+   0, 5,
+   'ZMSKVR-1571 Scheidplatz Öffnungszeit',
+   0, 5,
+   0, 30,
+   NOW());

--- a/zmsautomation/src/test/java/zms/ataf/ui/pages/citizenview/CitizenViewPage.java
+++ b/zmsautomation/src/test/java/zms/ataf/ui/pages/citizenview/CitizenViewPage.java
@@ -8,9 +8,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 
@@ -18,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ataf.core.helpers.TestDataHelper;
+import ataf.core.helpers.TestPropertiesHelper;
 import ataf.core.logging.ScenarioLogManager;
 import ataf.web.model.LocatorType;
 import ataf.web.pages.BasePage;
@@ -561,22 +564,90 @@ public class CitizenViewPage extends BasePage {
      * Asserts that block is present so the appointment is tied to the correct calendar/office.
      */
     public void assertProviderSummaryVisible(int officeId) {
+        assertProviderSummaryVisible(officeId, "Bürgerbüro Ruppertstraße");
+    }
+
+    /**
+     * Text of the <em>visible</em> booking-summary Ort block {@code #provider-{officeId}}.
+     * Ignores hidden Ort-step checkboxes that reuse the same id while AppointmentSelection stays
+     * mounted under {@code v-show}.
+     */
+    public String deepVisibleProviderSummaryText(int officeId) {
+        CONTEXT.set();
+        String script =
+                "var want='provider-'+String(arguments[0]);"
+                        + "function visible(el){"
+                        + " if(!el||el.nodeType!==1)return false;"
+                        + " var n=el;"
+                        + " while(n){"
+                        + "  if(n.nodeType===1){"
+                        + "   try{var st=getComputedStyle(n);if(st.display==='none'||st.visibility==='hidden')return false;}catch(e0){}"
+                        + "  }"
+                        + "  if(n.parentElement){n=n.parentElement;continue;}"
+                        + "  var root=n.getRootNode&&n.getRootNode();"
+                        + "  if(root&&root.host){n=root.host;continue;}"
+                        + "  break;"
+                        + " }"
+                        + " try{return el.getClientRects().length>0;}catch(e1){return true;}"
+                        + "}"
+                        + "function collect(root,out){"
+                        + " if(!root)return;"
+                        + " if(root.nodeType===1&&root.id===want)out.push(root);"
+                        + " if(root.shadowRoot)collect(root.shadowRoot,out);"
+                        + " var c=root.children;if(c)for(var i=0;i<c.length;i++)collect(c[i],out);"
+                        + "}"
+                        + "var found=[];collect(document.body,found);"
+                        + "for(var i=0;i<found.length;i++){"
+                        + " var el=found[i];"
+                        + " if(!visible(el))continue;"
+                        + " var tag=(el.tagName||'').toLowerCase();"
+                        + " if(tag.indexOf('checkbox')>=0)continue;"
+                        + " if(tag==='input')continue;"
+                        + " var txt=(el.innerText||el.textContent||'').replace(/\\s+/g,' ').trim();"
+                        + " if(txt)return txt;"
+                        + "}"
+                        + "return null;";
+        Object o = ((JavascriptExecutor) DriverUtil.getDriver()).executeScript(script, officeId);
+        return o == null ? null : String.valueOf(o);
+    }
+
+    public boolean deepVisibleProviderSummaryExists(int officeId) {
+        String text = deepVisibleProviderSummaryText(officeId);
+        return text != null && !text.isBlank();
+    }
+
+    /**
+     * Reserve / preconfirm / confirm screens expose {@code <p id="provider-{officeId}">…</p>} (summary).
+     * Asserts that the <em>visible</em> summary block contains the standort label (not hidden Ort checkboxes).
+     */
+    public void assertProviderSummaryVisible(int officeId, String expectedStandortLabel) {
         CONTEXT.set();
         String sel = "#provider-" + officeId;
-        waitWithThreeWindows(() -> deepElementExists(sel), "Provider summary " + sel);
-        if (!deepElementExists(sel)) {
+        waitWithThreeWindows(
+                () -> deepVisibleProviderSummaryExists(officeId), "Provider summary " + sel);
+        if (!deepVisibleProviderSummaryExists(officeId)) {
             ScenarioLogManager.getLogger()
-                    .warn("Provider summary {} not visible after 60s; waiting up to 30s more after deep-link navigation", sel);
+                    .warn(
+                            "Visible provider summary {} not found after 60s; waiting up to 30s more after deep-link navigation",
+                            sel);
             try {
-                waitUntilDeepElementExists(sel, 30);
+                new WebDriverWait(DriverUtil.getDriver(), Duration.ofSeconds(30))
+                        .until(d -> deepVisibleProviderSummaryExists(officeId));
             } catch (TimeoutException e) {
-                ScenarioLogManager.getLogger().warn("Provider summary {} still not visible after extended wait", sel);
+                ScenarioLogManager.getLogger()
+                        .warn("Visible provider summary {} still not found after extended wait", sel);
             }
         }
-        Assert.assertTrue(deepElementExists(sel), "Expected booking summary provider block: " + sel);
+        String summaryText = deepVisibleProviderSummaryText(officeId);
+        Assert.assertNotNull(summaryText, "Expected visible booking summary provider block: " + sel);
         Assert.assertTrue(
-                shadowDomContainsText("Bürgerbüro Ruppertstraße"),
-                "Expected standort label near provider-" + officeId);
+                summaryText.contains(expectedStandortLabel),
+                "Expected standort label in visible summary "
+                        + sel
+                        + ": "
+                        + expectedStandortLabel
+                        + " actual="
+                        + summaryText);
     }
 
     /** On Passkalender jump-in, only Pass services should be combinable (names from API). */
@@ -601,7 +672,10 @@ public class CitizenViewPage extends BasePage {
         CONTEXT.set();
         String script =
                 "var want=arguments[0],v=arguments[1]==null?'':String(arguments[1]);"
-                        + "var ids=[];ids.push(want);if(want.indexOf('input-')===0)ids.push(want.slice(6));else ids.push('input-'+want);"
+                        // MucInput → input-{id}; MucTextArea → textarea-{id} (id prop is not on the host).
+                        + "var ids=[];ids.push(want);"
+                        + "if(want.indexOf('input-')===0)ids.push(want.slice(6));else ids.push('input-'+want);"
+                        + "if(want.indexOf('textarea-')===0)ids.push(want.slice(9));else ids.push('textarea-'+want);"
                         + "function byId(root,id){try{if(root.getElementById)return root.getElementById(id);}catch(e0){}"
                         + "try{return root.querySelector('#'+id.replace(/([^a-zA-Z0-9_-])/g,'\\\\$1'));}catch(e1){return root.querySelector('[id=\"'+id.replace(/\"/g,'')+'\"]');}}"
                         + "function resolve(el){if(!el)return null;if(el.tagName==='INPUT'||el.tagName==='TEXTAREA')return el;"
@@ -620,10 +694,17 @@ public class CitizenViewPage extends BasePage {
     public boolean clickButtonContaining(String text) {
         CONTEXT.set();
         String esc = text.replace("\\", "\\\\").replace("'", "\\'");
+        // Prefer visible buttons only: AppointmentSelection stays mounted (v-show) on Kontakt/Übersicht
+        // and its Weiter must not steal the click from CustomerInfo/AppointmentSummary.
         String script =
-                "var label='" + esc + "';function walkClick(n){if(!n)return false;if(n.shadowRoot&&walkClick(n.shadowRoot))return true;"
+                "var label='" + esc + "';"
+                        + "function visible(el){if(!el||!el.getBoundingClientRect)return false;"
+                        + "var r=el.getBoundingClientRect();if(r.width<=0||r.height<=0)return false;"
+                        + "var st=window.getComputedStyle(el);return st.visibility!=='hidden'&&st.display!=='none'&&st.opacity!=='0';}"
+                        + "function walkClick(n){if(!n)return false;if(n.shadowRoot&&walkClick(n.shadowRoot))return true;"
                         + "var tag=(n.tagName||'').toUpperCase();var isBtn=(tag==='BUTTON'||tag==='A'||tag==='MUC-BUTTON');"
-                        + "if(isBtn){var t=(n.textContent||'').trim();if(t.indexOf(label)>=0&&!n.disabled){n.scrollIntoView({block:'center'});n.click();return true;}}"
+                        + "if(isBtn){var t=(n.textContent||'').trim();"
+                        + "if(t.indexOf(label)>=0&&!n.disabled&&visible(n)){n.scrollIntoView({block:'center'});n.click();return true;}}"
                         + "var c=n.children;if(c)for(var i=0;i<c.length;i++)if(walkClick(c[i]))return true;return false;}"
                         + "return walkClick(document.body);";
         Object o = ((JavascriptExecutor) DriverUtil.getDriver()).executeScript(script);
@@ -2100,5 +2181,219 @@ public class CitizenViewPage extends BasePage {
             return origin + u;
         }
         return "http://" + u;
+    }
+
+    /** Last Kontakt values filled by {@link #fillContactDetailsRandomWithoutContinue()} for later asserts. */
+    private String lastContactPhone = CONTACT_PHONE_E2E;
+    private String lastContactCustomText = CONTACT_LOREM_REQUIRED;
+
+    /**
+     * Kontakt step only — fills name/email/phone/Zusatzfelder but does <em>not</em> click Weiter
+     * (e.g. after Bürger-Login, before Übersicht).
+     */
+    public void fillContactDetailsRandomWithoutContinue() {
+        fillContactDetailsRandom();
+        lastContactPhone = CONTACT_PHONE_E2E;
+        lastContactCustomText = CONTACT_LOREM_REQUIRED;
+    }
+
+    public void continueFromContactFormToSummary() {
+        CONTEXT.set();
+        clickWeiter(30);
+        waitForPreconfirmPageAfterUpdate();
+    }
+
+    public boolean deepContactCustomTextFieldExists() {
+        // MucTextArea binds the control as id="textarea-{prop}" (prop "remarks" is not on the host).
+        return deepElementExists("#textarea-remarks")
+                || deepElementExists("#remarks")
+                || deepElementExists("muc-text-area#remarks")
+                || deepElementExists("#input-remarks");
+    }
+
+    public boolean deepContactCustomTextField2Exists() {
+        return deepElementExists("#textarea-remarks2")
+                || deepElementExists("#remarks2")
+                || deepElementExists("muc-text-area#remarks2")
+                || deepElementExists("#input-remarks2");
+    }
+
+    /** Read value of input/textarea resolved from host id (shadow-safe). */
+    public String deepGetById(String id) {
+        CONTEXT.set();
+        String script =
+                "var want=arguments[0];"
+                        + "var ids=[];ids.push(want);"
+                        + "if(want.indexOf('input-')===0)ids.push(want.slice(6));else ids.push('input-'+want);"
+                        + "if(want.indexOf('textarea-')===0)ids.push(want.slice(9));else ids.push('textarea-'+want);"
+                        + "function byId(root,id){try{if(root.getElementById)return root.getElementById(id);}catch(e0){}"
+                        + "try{return root.querySelector('#'+id.replace(/([^a-zA-Z0-9_-])/g,'\\\\$1'));}catch(e1){return root.querySelector('[id=\"'+id.replace(/\"/g,'')+'\"]');}}"
+                        + "function resolve(el){if(!el)return null;if(el.tagName==='INPUT'||el.tagName==='TEXTAREA')return el;"
+                        + "if(el.shadowRoot){var q=el.shadowRoot.querySelector('input:not([type=hidden]):not([type=checkbox]):not([type=radio]),textarea');if(q)return q;}return null;}"
+                        + "function scanRoot(root){if(!root)return null;for(var i=0;i<ids.length;i++){var el=byId(root,ids[i]);var r=resolve(el);if(r)return r;}"
+                        + "var nodes=root.querySelectorAll('*');for(var j=0;j<nodes.length;j++){if(nodes[j].shadowRoot){var r2=scanRoot(nodes[j].shadowRoot);if(r2)return r2;}}return null;}"
+                        + "var e=scanRoot(document);if(!e)e=scanRoot(document.body);"
+                        + "return e?String(e.value||''):null;";
+        Object o = ((JavascriptExecutor) DriverUtil.getDriver()).executeScript(script, id);
+        return o == null ? null : String.valueOf(o);
+    }
+
+    public void assertContactPhoneAndCustomFieldsVisibleWithValues() {
+        CONTEXT.set();
+        waitUntilShadowContains("Kontaktdaten", Math.max(30, DEFAULT_EXPLICIT_WAIT_TIME));
+        Assert.assertTrue(
+                deepContactPhoneFieldExists(),
+                "Telephone field (#telephonenumber) must remain visible on the Kontakt form.");
+        Assert.assertTrue(
+                deepContactCustomTextFieldExists(),
+                "Custom text field (#remarks) must remain visible on the Kontakt form.");
+        Assert.assertTrue(
+                deepContactCustomTextField2Exists(),
+                "Second custom text field (#remarks2) must remain visible on the Kontakt form.");
+        String phone = deepGetById("telephonenumber");
+        Assert.assertNotNull(phone, "Telephone field value could not be read.");
+        Assert.assertTrue(
+                phone.contains(lastContactPhone) || phone.equals(lastContactPhone),
+                "Telephone field should keep entered value. expectedContains="
+                        + lastContactPhone
+                        + " actual="
+                        + phone);
+        String remarks = deepGetById("remarks");
+        Assert.assertNotNull(remarks, "Custom text field value could not be read.");
+        Assert.assertTrue(
+                remarks.equals(lastContactCustomText) || remarks.contains(lastContactCustomText),
+                "Custom text field should keep entered value. expected="
+                        + lastContactCustomText
+                        + " actual="
+                        + remarks);
+        String remarks2 = deepGetById("remarks2");
+        Assert.assertNotNull(remarks2, "Second custom text field value could not be read.");
+        Assert.assertTrue(
+                remarks2.equals(lastContactCustomText) || remarks2.contains(lastContactCustomText),
+                "Second custom text field should keep entered value. expected="
+                        + lastContactCustomText
+                        + " actual="
+                        + remarks2);
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: Kontakt phone + Zusatzfelder still visible with values");
+    }
+
+    /**
+     * Booking summary Ort block for Scheidplatz (provider id + name + street from scope address).
+     */
+    public void assertScheidplatzLocationOnSummary(int officeId) {
+        assertProviderSummaryVisible(officeId, "Bürgerbüro Scheidplatz");
+        String summaryText = deepVisibleProviderSummaryText(officeId);
+        Assert.assertNotNull(summaryText, "Expected visible Scheidplatz summary for provider-" + officeId);
+        Assert.assertTrue(
+                summaryText.contains("Belgradstraße") || summaryText.contains("Riesenfeldstraße"),
+                "Ort address for Scheidplatz should show Belgradstraße or Riesenfeldstraße in visible summary. actual="
+                        + summaryText);
+        Assert.assertTrue(
+                summaryText.contains("80804") && summaryText.contains("München"),
+                "Ort address for Scheidplatz should show postal code/city in visible summary. actual="
+                        + summaryText);
+    }
+
+    /** Zurück from Übersicht (preconfirm) back to Kontakt form. */
+    public void goBackFromBookingSummaryToContact() {
+        CONTEXT.set();
+        ScenarioLogManager.getLogger().info("zmscitizenview: Zurück from booking summary to Kontakt");
+        waitForAndClickButtonContaining("Zurück", DEFAULT_EXPLICIT_WAIT_TIME);
+        waitUntilShadowContains("Kontaktdaten", Math.max(30, DEFAULT_EXPLICIT_WAIT_TIME));
+    }
+
+    /**
+     * Bürger-Login on Kontakt: click in-app Anmelden (saves localStorage via requestLogin),
+     * complete Keycloak as {@code citizen}/{@code vorschau} (dbs-fragments client), wait until
+     * logged-in callout returns. Avoids the host {@code dbs-login} chrome button, which does not
+     * persist booking UI state before redirect.
+     */
+    public void loginViaBuergerLoginWithKeycloak() throws Exception {
+        CONTEXT.set();
+        ScenarioLogManager.getLogger().info("zmscitizenview: click in-app Anmelden (Bürger-Login)");
+        try {
+            new WebDriverWait(DriverUtil.getDriver(), Duration.ofSeconds(DEFAULT_EXPLICIT_WAIT_TIME))
+                    .until(d -> clickInAppBuergerLoginAnmelden());
+        } catch (TimeoutException e) {
+            ScenarioLogManager.getLogger()
+                    .warn("zmscitizenview: in-app Anmelden not found; falling back to any Anmelden button");
+            waitForAndClickButtonContaining("Anmelden", DEFAULT_EXPLICIT_WAIT_TIME);
+        }
+
+        String username =
+                TestPropertiesHelper.getPropertyAsString("citizenUserName", true, "citizen");
+        String password =
+                TestPropertiesHelper.getPropertyAsString("citizenUserPassword", true, "vorschau");
+        completeKeycloakLoginForm(username, password);
+
+        waitWithThreeWindows(
+                () -> shadowDomContainsText("Sie sind angemeldet")
+                        || shadowDomContainsText("Kontaktdaten"),
+                "Citizen view after Keycloak Bürger-Login");
+        Assert.assertTrue(
+                shadowDomContainsText("Sie sind angemeldet.") || shadowDomContainsText("Kontaktdaten"),
+                "Expected return to Kontakt form after Bürger-Login (logged-in callout or Kontaktdaten).");
+        ScenarioLogManager.getLogger().info("zmscitizenview: Bürger-Login completed");
+    }
+
+    /**
+     * Clicks the Kontakt callout {@code muc-button} labeled Anmelden (not host {@code dbs-login}).
+     * Uses pointer+click so Vue {@code @click} → {@code requestLogin} runs (localStorage + OIDC).
+     */
+    private boolean clickInAppBuergerLoginAnmelden() {
+        CONTEXT.set();
+        String script =
+                "function inDbsLogin(n){while(n){if(n.tagName&&n.tagName.toLowerCase()==='dbs-login')return true;n=n.parentNode;"
+                        + "if(n&&n.host)n=n.host;}return false;}"
+                        + "function fire(el){el.scrollIntoView({block:'center'});"
+                        + "try{el.dispatchEvent(new PointerEvent('pointerdown',{bubbles:true}));}catch(e0){}"
+                        + "try{el.dispatchEvent(new MouseEvent('mousedown',{bubbles:true}));}catch(e1){}"
+                        + "try{el.dispatchEvent(new PointerEvent('pointerup',{bubbles:true}));}catch(e2){}"
+                        + "try{el.dispatchEvent(new MouseEvent('mouseup',{bubbles:true}));}catch(e3){}"
+                        + "el.click();return true;}"
+                        + "function walk(n){if(!n)return false;if(n.shadowRoot&&walk(n.shadowRoot))return true;"
+                        + "var tag=(n.tagName||'').toUpperCase();"
+                        + "if((tag==='MUC-BUTTON'||tag==='BUTTON')&&!inDbsLogin(n)){"
+                        + "var t=(n.textContent||'').replace(/\\s+/g,' ').trim();"
+                        + "if(t.indexOf('Anmelden')>=0&&!n.disabled)return fire(n);}"
+                        + "var c=n.children;if(c)for(var i=0;i<c.length;i++)if(walk(c[i]))return true;return false;}"
+                        + "return walk(document.body);";
+        Object o = ((JavascriptExecutor) DriverUtil.getDriver()).executeScript(script);
+        return Boolean.TRUE.equals(o);
+    }
+
+    public void assertCitizenLoggedInOnContactForm() {
+        CONTEXT.set();
+        waitWithThreeWindows(
+                () -> shadowDomContainsText("Sie sind angemeldet"),
+                "Logged-in callout on Kontakt");
+        Assert.assertTrue(
+                shadowDomContainsText("Sie sind angemeldet."),
+                "Expected 'Sie sind angemeldet.' after Bürger-Login on Kontakt form.");
+    }
+
+    /**
+     * Keycloak username/password + kc-login form submit for the citizen {@code dbs-fragments} client redirect.
+     * Does not embed credentials in the browser URL (unlike some admin/statistic Chrome helpers).
+     */
+    private void completeKeycloakLoginForm(String username, String password) throws Exception {
+        WebDriverWait wait = new WebDriverWait(DRIVER, Duration.ofSeconds(DEFAULT_EXPLICIT_WAIT_TIME));
+        try {
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.id("username")));
+        } catch (TimeoutException e) {
+            throw new TimeoutException(
+                    "Keycloak login form (#username) not shown after Anmelden. currentUrl="
+                            + DRIVER.getCurrentUrl(),
+                    e);
+        }
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("kc-login")));
+        ScenarioLogManager.getLogger().info("zmscitizenview: Keycloak login form detected url={}", DRIVER.getCurrentUrl());
+
+        ScenarioLogManager.getLogger().info("zmscitizenview: entering Keycloak citizen credentials");
+        enterTextInWebElement(DEFAULT_EXPLICIT_WAIT_TIME, username, "username", LocatorType.ID);
+        enterTextInWebElement(DEFAULT_EXPLICIT_WAIT_TIME, password, "password", LocatorType.ID);
+        clickOnWebElement(DEFAULT_EXPLICIT_WAIT_TIME, "kc-login", LocatorType.ID, false);
+        ScenarioLogManager.getLogger().info("zmscitizenview: Keycloak login submitted");
     }
 }

--- a/zmsautomation/src/test/java/zms/ataf/ui/steps/CitizenViewSteps.java
+++ b/zmsautomation/src/test/java/zms/ataf/ui/steps/CitizenViewSteps.java
@@ -387,4 +387,50 @@ public class CitizenViewSteps {
                 .info("zmscitizenview: assert only Pass calendar services offered on combination step");
         page.assertPassOnlyCombinationServicesVisible();
     }
+
+    @When("I fill contact details without continuing in the citizen view")
+    public void iFillContactDetailsWithoutContinuing() {
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: fill Kontakt form without Weiter (phone/Zusatzfelder)");
+        page.fillContactDetailsRandomWithoutContinue();
+    }
+
+    @When("I continue from the contact form in the citizen view")
+    public void iContinueFromTheContactFormInTheCitizenView() {
+        ScenarioLogManager.getLogger().info("zmscitizenview: Kontakt Weiter → Übersicht");
+        page.continueFromContactFormToSummary();
+    }
+
+    @Then("the telephone and custom text fields should remain visible with entered values in the citizen view")
+    public void theTelephoneAndCustomTextFieldsShouldRemainVisibleWithEnteredValues() {
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: assert phone + Zusatzfelder still visible with values");
+        page.assertContactPhoneAndCustomFieldsVisibleWithValues();
+    }
+
+    @When("I log in via Bürger-Login with Keycloak in the citizen view")
+    public void iLogInViaBuergerLoginWithKeycloak() throws Exception {
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: Bürger-Login → Keycloak citizen user (dbs-fragments)");
+        page.loginViaBuergerLoginWithKeycloak();
+    }
+
+    @Then("I should be logged in on the contact form in the citizen view")
+    public void iShouldBeLoggedInOnTheContactForm() {
+        ScenarioLogManager.getLogger().info("zmscitizenview: assert Sie sind angemeldet on Kontakt");
+        page.assertCitizenLoggedInOnContactForm();
+    }
+
+    @Then("the booking summary should show Scheidplatz location for provider {int} in the citizen view")
+    public void theBookingSummaryShouldShowScheidplatzLocation(int officeId) {
+        ScenarioLogManager.getLogger()
+                .info("zmscitizenview: assert Übersicht Ort for Scheidplatz provider {}", officeId);
+        page.assertScheidplatzLocationOnSummary(officeId);
+    }
+
+    @When("I go back from the booking summary to the contact form in the citizen view")
+    public void iGoBackFromTheBookingSummaryToTheContactForm() {
+        ScenarioLogManager.getLogger().info("zmscitizenview: Zurück Übersicht → Kontakt");
+        page.goBackFromBookingSummaryToContact();
+    }
 }

--- a/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1571_scheidplatz_contact_location_back_login.feature
+++ b/zmsautomation/src/test/resources/features/ui/zmscitizenview/zmskvr-1571_scheidplatz_contact_location_back_login.feature
@@ -1,0 +1,37 @@
+#language: en
+@web @zmscitizenview @ZMSKVR-1571 @executeLocally
+Feature: ZMSKVR-1571 Scheidplatz — Ort on overview; Kontakt fields after Bürger-Login and Zurück
+  As a citizen booking at Bürgerbüro Scheidplatz (showAlternativeLocations)
+  I want Ort on the Übersicht and phone/Zusatzfelder on Kontakt after Bürger-Login and Zurück
+  So that the booking UI stays consistent with confirmation mails
+
+  # Scheidplatz provider 102524 has showAlternativeLocations=true. Jump-in uses Personalausweis 1063453.
+  # Bürger-Login uses local Keycloak client dbs-fragments (user citizen / vorschau).
+  # Flow: login first (name/email from account), then fill phone/Zusatzfelder only — matches real UX.
+
+  Background:
+    Given the Citizen API is available
+    When I request the offices and services endpoint
+    Then the response status code should be 200
+    And the response should contain offices and services
+
+  @jumpin @scheidplatz
+  Scenario: Scheidplatz overview keeps Ort; Bürger-Login then Kontakt fields survive Zurück
+    Given I open zmscitizenview with jump-in service "1063453" and location "102524"
+    Then the service combination step should be visible
+    When I continue from the service combination step
+    Then provider checkbox 102524 should be visible in the citizen view
+    When I select office 102524 in the citizen view
+    And I wait for appointment slots to be ready in the citizen view
+    And I click Später in the time slot grid if available in the citizen view
+    And I scroll to and highlight the preferred timeslot for office 102524 in the citizen view
+    And I click the highlighted timeslot in the citizen view
+    And I continue after slot selection with Weiter for office 102524 in the citizen view
+    When I log in via Bürger-Login with Keycloak in the citizen view
+    Then I should be logged in on the contact form in the citizen view
+    When I fill contact details without continuing in the citizen view
+    Then the telephone and custom text fields should remain visible with entered values in the citizen view
+    When I continue from the contact form in the citizen view
+    Then the booking summary should show Scheidplatz location for provider 102524 in the citizen view
+    When I go back from the booking summary to the contact form in the citizen view
+    Then the telephone and custom text fields should remain visible with entered values in the citizen view

--- a/zmsautomation/src/test/resources/testautomation.properties
+++ b/zmsautomation/src/test/resources/testautomation.properties
@@ -20,6 +20,10 @@ testautomation.test.execution.test.environment=LOCAL
 testautomation.userName=ataf
 testautomation.userPassword=vorschau
 
+# zmscitizenview Bürger-Login (Keycloak client dbs-fragments; migration 09_add-citizen-client.yml)
+testautomation.citizenUserName=citizen
+testautomation.citizenUserPassword=vorschau
+
 # Bypass proxy for internal Docker hostnames. If the browser uses HTTP_PROXY, requests to
 # these hosts must not go through Sayrigh/corporate proxy — the proxy cannot resolve
 # keycloak / refarch-gateway / citizenview (Host Not Resolvable on gateway page).

--- a/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentSelection.vue
@@ -2249,17 +2249,20 @@ watch(
     if (captchaSessionExpired.value) {
       return;
     }
-    // Sync single-selection provider immediately
+    // Keep the reserved office when several Orte stay checked. Clearing it here
+    // hid telephone/custom fields on Kontakt and Ort on Übersicht (ZMSKVR-1571).
     const selectedIds = Object.keys(selectedProviders.value).filter(
       (id) => selectedProviders.value[id]
     );
-    if (selectedIds.length === 1 && selectableProviders.value) {
+    if (selectedIds.length === 0) {
+      selectedProvider.value = undefined;
+    } else if (selectedIds.length === 1 && selectableProviders.value) {
       const provider = selectableProviders.value.find(
         (p) => p.id.toString() === selectedIds[0]
       );
-      selectedProvider.value = provider ?? undefined;
-    } else if (selectedIds.length !== 1) {
-      selectedProvider.value = undefined;
+      if (provider) {
+        selectedProvider.value = provider;
+      }
     }
 
     const hasAvailableDays =

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -99,11 +99,14 @@
               />
             </div>
 
-            <!-- Keep mounted through overview so Zurück does not remount and wipe selectedProvider. -->
+            <!-- Keep mounted through overview so Zurück does not remount and wipe selectedProvider.
+                 Skip hash-opened Übersicht (empty selectedServiceMap) so the calendar does not fetch. -->
             <div v-show="currentView === 1">
               <AppointmentSelection
                 v-if="
-                  currentView === 1 || currentView === 2 || currentView === 3
+                  currentView === 1 ||
+                  ((currentView === 2 || currentView === 3) &&
+                    selectedServiceMap.size > 0)
                 "
                 :key="appointmentSelectionKey"
                 :global-state="globalState"

--- a/zmscitizenview/src/components/Appointment/AppointmentView.vue
+++ b/zmscitizenview/src/components/Appointment/AppointmentView.vue
@@ -99,10 +99,12 @@
               />
             </div>
 
-            <!-- Keep mounted across customer-info (view 2) so back does not remount/refetch. -->
+            <!-- Keep mounted through overview so Zurück does not remount and wipe selectedProvider. -->
             <div v-show="currentView === 1">
               <AppointmentSelection
-                v-if="currentView === 1 || currentView === 2"
+                v-if="
+                  currentView === 1 || currentView === 2 || currentView === 3
+                "
                 :key="appointmentSelectionKey"
                 :global-state="globalState"
                 :is-rebooking="isRebooking"

--- a/zmscitizenview/src/local-dev/local-dbs-login.ts
+++ b/zmscitizenview/src/local-dev/local-dbs-login.ts
@@ -30,12 +30,22 @@ type StoredSession = {
 
 function readConfig(): LoginConfig {
   const el = document.querySelector("dbs-login");
+  let kcUrl = (
+    el?.getAttribute("kc-url") ||
+    import.meta.env.VITE_KC_URL ||
+    ""
+  ).replace(/\/$/, "");
+  // ATAF: page is http://citizenview:8082 — localhost Keycloak is unreachable
+  // from the browser container; use the compose DNS name.
+  if (
+    typeof window !== "undefined" &&
+    window.location.hostname === "citizenview" &&
+    /^(https?:\/\/)(localhost|127\.0\.0\.1)(:|\/|$)/i.test(kcUrl)
+  ) {
+    kcUrl = "http://keycloak:8080/auth";
+  }
   return {
-    kcUrl: (
-      el?.getAttribute("kc-url") ||
-      import.meta.env.VITE_KC_URL ||
-      ""
-    ).replace(/\/$/, ""),
+    kcUrl,
     realm:
       el?.getAttribute("kc-realm") || import.meta.env.VITE_KC_REALM || "zms",
     clientId:
@@ -68,12 +78,29 @@ function randomString(length = 64): string {
   return Array.from(values, (v) => chars[v % chars.length]).join("");
 }
 
-async function pkceChallenge(verifier: string): Promise<string> {
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(verifier)
+/**
+ * PKCE S256 challenge. http://citizenview (ATAF) is not a secure context, so
+ * SubtleCrypto is missing; that host may use plain PKCE against local Keycloak.
+ */
+async function pkceChallenge(
+  verifier: string
+): Promise<{ challenge: string; method: "S256" | "plain" }> {
+  if (globalThis.crypto?.subtle) {
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(verifier)
+    );
+    return { challenge: base64UrlEncode(digest), method: "S256" };
+  }
+  if (
+    typeof window !== "undefined" &&
+    window.location.hostname === "citizenview"
+  ) {
+    return { challenge: verifier, method: "plain" };
+  }
+  throw new Error(
+    "PKCE S256 requires WebCrypto SubtleCrypto (secure context)."
   );
-  return base64UrlEncode(digest);
 }
 
 function parseJwt(token: string): Record<string, unknown> {
@@ -176,7 +203,7 @@ async function startLogin(config: LoginConfig): Promise<void> {
 
   const verifier = randomString(64);
   const state = randomString(32);
-  const challenge = await pkceChallenge(verifier);
+  const { challenge, method } = await pkceChallenge(verifier);
   sessionStorage.setItem(STORAGE_VERIFIER, verifier);
   sessionStorage.setItem(STORAGE_STATE, state);
 
@@ -189,7 +216,7 @@ async function startLogin(config: LoginConfig): Promise<void> {
   url.searchParams.set("scope", "openid profile email");
   url.searchParams.set("state", state);
   url.searchParams.set("code_challenge", challenge);
-  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("code_challenge_method", method);
 
   window.location.assign(url.toString());
 }
@@ -396,7 +423,9 @@ function renderHostChrome(config: LoginConfig): void {
 
   if (!loggedIn) {
     button.addEventListener("click", () => {
-      void startLogin(config);
+      void startLogin(config).catch((err) => {
+        console.error("[local-dbs-login] startLogin failed:", err);
+      });
     });
     host.appendChild(button);
     return;
@@ -518,7 +547,12 @@ export async function initLocalDbsLogin(): Promise<void> {
   }
 
   document.addEventListener(AUTH_REQUEST, () => {
-    void startLogin(config);
+    void startLogin(config).catch((err) => {
+      console.error(
+        "[local-dbs-login] startLogin (authorization-request) failed:",
+        err
+      );
+    });
   });
 
   renderHostChrome(config);

--- a/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentSelection.spec.ts
@@ -3380,4 +3380,48 @@ describe("AppointmentSelection", () => {
       expect(wrapper.find(".m-spinner-container").exists()).toBe(false);
     });
   });
+
+  describe("ZMSKVR-1571 selectedProvider retention", () => {
+    it("does not clear the reserved office when multiple locations stay checked", async () => {
+      const reservedOffice = {
+        id: 1,
+        name: "Bürgerbüro A",
+        address: {
+          street: "Main",
+          house_number: "1",
+          postal_code: "80331",
+          city: "München",
+        },
+        scope: { telephoneActivated: true, customTextfieldActivated: true },
+        showAlternativeLocations: true,
+      };
+      const otherOffice = {
+        id: 2,
+        name: "Bürgerbüro B",
+        address: {
+          street: "Other",
+          house_number: "2",
+          postal_code: "80331",
+          city: "München",
+        },
+        scope: { id: "2" },
+        showAlternativeLocations: true,
+      };
+
+      const wrapper = createWrapper({
+        selectedProvider: reservedOffice,
+        selectedService: {
+          id: "service1",
+          providers: [reservedOffice, otherOffice],
+        },
+      });
+
+      wrapper.vm.selectableProviders = [reservedOffice, otherOffice];
+      wrapper.vm.selectedProviders = { "1": true, "2": true };
+      await nextTick();
+      await flushPromises();
+
+      expect(wrapper.vm.selectedProvider?.id).toBe(1);
+    });
+  });
 });

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -295,6 +295,15 @@ describe("AppointmentView", () => {
         true
       );
     });
+
+    it("keeps AppointmentSelection mounted on overview so back does not remount", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.currentView = 3;
+      await nextTick();
+      expect(wrapper.find('[data-test="AppointmentSelection"]').exists()).toBe(
+        true
+      );
+    });
   });
 
   describe("Error States", () => {

--- a/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
+++ b/zmscitizenview/tests/unit/Appointment/AppointmentView.spec.ts
@@ -298,10 +298,25 @@ describe("AppointmentView", () => {
 
     it("keeps AppointmentSelection mounted on overview so back does not remount", async () => {
       const wrapper = createWrapper({ appointmentHash: undefined });
+      wrapper.vm.selectedServiceMap = new Map([["123", 1]]);
+      wrapper.vm.currentView = 1;
+      await nextTick();
+      const selection = wrapper.find('[data-test="AppointmentSelection"]');
+      expect(selection.exists()).toBe(true);
+
+      wrapper.vm.currentView = 3;
+      await nextTick();
+      expect(
+        wrapper.find('[data-test="AppointmentSelection"]').element
+      ).toBe(selection.element);
+    });
+
+    it("does not mount AppointmentSelection on hash overview without a service map", async () => {
+      const wrapper = createWrapper({ appointmentHash: undefined });
       wrapper.vm.currentView = 3;
       await nextTick();
       expect(wrapper.find('[data-test="AppointmentSelection"]').exists()).toBe(
-        true
+        false
       );
     });
   });


### PR DESCRIPTION
## Summary
- Keep `AppointmentSelection` mounted on Übersicht so Zurück does not remount it.
- Stop clearing `selectedProvider` when more than one Ort is checked. That wipe hid telephone/custom fields on Kontakt and Ort on the next Übersicht, at every location.
- ATAF: first zmscitizenview Bürger-Login coverage (`@ZMSKVR-1571`) — Zurück from Übersicht plus Keycloak login on Kontakt.

`zmscitizenview/src/local-dev/local-dbs-login.ts` is local/ATAF only. Host pages load it when `VITE_USE_LOCAL_CITIZEN_LOGIN=true` (dev / `http://citizenview`). Production embeds keep `VITE_USE_LOCAL_CITIZEN_LOGIN=false` and use the CDN `dbs-login` loader, so this PKCE/Keycloak-DNS change does not ship in prod.

## Test plan
- [x] Book a slot at any Bürgerbüro with several Orte checked
- [x] Fill Kontakt (including phone / Zusatzfelder) and go to Übersicht — Ort is shown
- [x] Click Zurück — phone and Zusatzfelder are still there with their values
- [x] Click Weiter — Ort is still shown
- [x] Repeat after Bürger-Login on Kontakt
- [x] ATAF `@ZMSKVR-1571` on this branch

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected provider when multiple offices remain selected.
  * Kept appointment selections intact when navigating to the overview and back.
  * Continued synchronizing the provider when exactly one office is selected.
  * Prevented unnecessary calendar loading when no service is selected.

* **New Features**
  * Added support for Bürger-Login during appointment booking.
  * Preserved contact details when navigating back from the booking summary.
  * Improved display of the selected office in booking summaries.

* **Tests**
  * Added coverage for provider retention, navigation, login, and contact-field persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->