### PR TITLE
fix(zmskvr-1596): Prevent display number on following processes

### DIFF
--- a/zmsbackend/src/Zmsbackend/Process/Service/Process.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/Process.php
@@ -267,6 +267,10 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         $process->id = $this->readNewProcessId();
         $process->setRandomAuthKey();
         $process->createTimestamp = $dateTime->getTimestamp();
+        if ($parentProcess !== 0) {
+            $process->displayNumber = '';
+        }
+
         $query->addValuesNewProcess($process, $parentProcess, $childProcessCount);
 
         if ($parentProcess === 0 && !empty($process->getDisplayNumber())) {

--- a/zmsbackend/src/Zmsbackend/Process/Service/Process.php
+++ b/zmsbackend/src/Zmsbackend/Process/Service/Process.php
@@ -269,9 +269,10 @@ class Process extends \BO\Zmsbackend\Base implements \BO\Zmsbackend\Interfaces\R
         $process->createTimestamp = $dateTime->getTimestamp();
         $query->addValuesNewProcess($process, $parentProcess, $childProcessCount);
 
-        if (!empty($process->getDisplayNumber())) {
+        if ($parentProcess === 0 && !empty($process->getDisplayNumber())) {
             $query->addValueDisplayNumber($process);
         }
+
         $query->addValuesScopeData($process);
         $query->addValuesAppointmentData($process);
         $query->addValuesUpdateProcess($process, $dateTime, $parentProcess);

--- a/zmsbackend/tests/Zmsbackend/Process/Service/ProcessTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Service/ProcessTest.php
@@ -892,4 +892,49 @@ class ProcessTest extends \BO\Zmsbackend\Tests\Service\Base
             ProcessStatusFree::resolveRoundRobinGroupKey('10489', [10489, 10503])
         );
     }
+
+    public function testFollowingProcessDoesNotGetDisplayNumber()
+    {
+        $now = static::$now;
+
+        $query = new class extends Query {
+            public function writeFollowingProcess(
+                Entity $process,
+                \DateTimeInterface $now,
+                int $parentProcess
+            ): Entity {
+                return $this->writeNewProcess(
+                    $process,
+                    $now,
+                    $parentProcess
+                );
+            }
+        };
+
+        $process = self::getTestProcessEntity();
+        $process->displayNumber = 'TEST123';
+
+        $followingProcess = $query->writeFollowingProcess(
+            $process,
+            $now,
+            10029
+        );
+
+        $connection = \BO\Zmsbackend\Connection\Select::getWriteConnection();
+
+        $statement = $connection->prepare(
+            'SELECT displayNumber
+            FROM buerger
+            WHERE BuergerID = :processId'
+        );
+
+        $statement->execute([
+            'processId' => $followingProcess->id
+        ]);
+
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        $this->assertIsArray($row);
+        $this->assertNull($row['displayNumber']);
+    }
 }


### PR DESCRIPTION
### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Child processes no longer inherit display numbers from their parent processes.
  * Root processes continue to receive display numbers as expected.

* **Tests**
  * Added regression coverage to verify correct display-number behavior for child processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->