### PR TITLE
fix(GH-3116): retry authenticated Composer downloads in CI

### DIFF
--- a/.github/scripts/composer-ci.sh
+++ b/.github/scripts/composer-ci.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Authenticate Composer against github.com (avoids unauthenticated API 504s /
+# rate limits in Actions) and retry flaky dist downloads.
+set -euo pipefail
+
+if [[ -z "${COMPOSER_AUTH:-}" ]]; then
+  token="${GITHUB_TOKEN:-}"
+  if [[ -z "${token}" && -r /run/secrets/github_token ]]; then
+    token="$(cat /run/secrets/github_token)"
+  fi
+  if [[ -n "${token}" ]]; then
+    export COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${token}\"}}"
+  fi
+fi
+
+run() {
+  if [[ "${1:-}" == "--make-live" ]]; then
+    make live
+  else
+    composer "$@"
+  fi
+}
+
+attempts="${COMPOSER_CI_ATTEMPTS:-3}"
+delay="${COMPOSER_CI_RETRY_DELAY:-15}"
+n=1
+until run "$@"; do
+  if (( n >= attempts )); then
+    exit 1
+  fi
+  echo "Composer command failed (attempt ${n}/${attempts}); retrying in ${delay}s..." >&2
+  sleep "${delay}"
+  n=$((n + 1))
+  delay=$((delay * 2))
+done

--- a/.github/workflows/build-api-docs.yaml
+++ b/.github/workflows/build-api-docs.yaml
@@ -28,9 +28,11 @@ jobs:
           tools: composer
 
       - name: Install PHP dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer install --working-dir=zmsbackend
-          composer install --working-dir=zmscitizenapi
+          bash .github/scripts/composer-ci.sh install --working-dir=zmsbackend
+          bash .github/scripts/composer-ci.sh install --working-dir=zmscitizenapi
 
       - name: Run PHP post-install scripts
         run: |

--- a/.github/workflows/generate-database-er-model.yaml
+++ b/.github/workflows/generate-database-er-model.yaml
@@ -50,9 +50,11 @@ jobs:
           .venv/bin/pip install pymysql jinja2
 
       - name: Install Composer Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Installing Composer dependencies for zmsbackend"
-          (cd zmsbackend && composer install --no-progress --prefer-dist --optimize-autoloader)
+          (cd zmsbackend && bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --optimize-autoloader)
         shell: bash
 
       - name: Setup Database and Import Schema

--- a/.github/workflows/php-build-images.yaml
+++ b/.github/workflows/php-build-images.yaml
@@ -52,6 +52,9 @@ jobs:
         with:
           swap-size-gb: 10
       - name: Build Image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_BUILDKIT: "1"
         run: |
           tag="${{ github.ref_name }}"
           if [ "${{ github.ref_type }}" = "branch" ]; then
@@ -65,6 +68,7 @@ jobs:
           fi
           docker build . \
             --file ".resources/Containerfile" \
+            --secret id=github_token,env=GITHUB_TOKEN \
             --tag "ghcr.io/${{ github.repository }}/${{ matrix.module }}:$tag" \
             --build-arg "MODULE=${{ matrix.module }}" \
             --build-arg "PHP_VERSION=${{ matrix.php_version }}" \

--- a/.github/workflows/php-code-quality.yaml
+++ b/.github/workflows/php-code-quality.yaml
@@ -18,10 +18,24 @@ jobs:
           persist-credentials: false
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.module }}-${{ hashFiles(format('{0}/composer.lock', matrix.module)) }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.module }}-
+
       - name: Install Composer Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd "${{ matrix.module }}"
-          composer install --no-progress --prefer-dist --optimize-autoloader
+          bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --optimize-autoloader
 
       - name: PHPCS / PSR-12
         run: |

--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -40,11 +40,25 @@ jobs:
           echo "xdebug.mode=coverage" >> /tmp/php/conf.d/xdebug.ini
           echo "xdebug.start_with_request=yes" >> /tmp/php/conf.d/xdebug.ini
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.module }}-${{ hashFiles(format('{0}/composer.lock', matrix.module)) }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.module }}-
+
       - name: Install Composer Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           cd "${{ matrix.module }}"
-          composer install --no-progress --prefer-dist --optimize-autoloader
+          bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Run Unit Tests with Coverage
         env:
@@ -140,10 +154,24 @@ jobs:
           persist-credentials: false
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-zmsbackend-${{ hashFiles('zmsbackend/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-zmsbackend-
+
       - name: Install Composer Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Installing Composer dependencies for zmsbackend"
-          (cd zmsbackend && composer install --no-progress --prefer-dist --optimize-autoloader)
+          (cd zmsbackend && bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --optimize-autoloader)
         shell: bash
 
       - name: Import Test Data and Run Unit Tests
@@ -199,12 +227,26 @@ jobs:
           extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql
           coverage: xdebug
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-zmsclient-${{ hashFiles('zmsclient/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-zmsclient-
+
       - name: Install Composer Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           modules=('zmsclient')
           for module in "${modules[@]}"; do
             echo "Installing Composer dependencies for $module"
-            (cd "$module" && composer install --no-progress --prefer-dist --optimize-autoloader)
+            (cd "$module" && bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --optimize-autoloader)
           done
         shell: bash
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -73,8 +73,10 @@ jobs:
             ${{ runner.os }}-composer-${{ matrix.project }}-
 
       - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ${{ matrix.project }}
-        run: composer install --no-progress --prefer-dist --no-interaction
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --no-interaction
 
       - name: Run Psalm Security Scan
         id: psalm
@@ -188,10 +190,12 @@ jobs:
             ${{ runner.os }}-composer-psalm-monorepo-
 
       - name: Install dependencies (all monorepo modules)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for project in mellon zmsadmin zmsbackend zmscalldisplay zmscitizenapi zmsclient zmsdldb zmsentities zmsmessaging zmsslim zmsstatistic zmsticketprinter; do
             echo "Installing ${project}..."
-            composer install --no-progress --prefer-dist --no-interaction --working-dir="${project}"
+            bash "${GITHUB_WORKSPACE}/.github/scripts/composer-ci.sh" install --no-progress --prefer-dist --no-interaction --working-dir="${project}"
           done
 
       - name: Run Psalm dead-code scan (monorepo)

--- a/.resources/Containerfile
+++ b/.resources/Containerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG PHP_VERSION
 FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
 RUN useradd --shell /bin/bash --create-home build
@@ -9,7 +10,8 @@ ARG APP_VERSION=version.unknown
 ENV COMPOSER_MIRROR_PATH_REPOS=1
 ENV ZMS_VERSION=${APP_VERSION}
 RUN echo "${APP_VERSION}" > VERSION
-RUN make live
+RUN --mount=type=secret,id=github_token,required=false,mode=0444 \
+    bash /build/.github/scripts/composer-ci.sh --make-live
 
 ARG PHP_VERSION
 FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base


### PR DESCRIPTION
## Summary
- Composer was downloading GitHub zipballs unauthenticated (`api.github.com/.../zipball/...`), which 504s when many Renovate/Dependabot CI jobs share runner IPs.
- CI now passes `GITHUB_TOKEN` into Composer, retries failed installs, caches Composer files for unit tests and code quality, and mounts the token as a BuildKit secret for `make live` image builds.

Fixes #3116

## Test plan
- [ ] Confirm php unit tests / code quality still install Composer deps
- [ ] Confirm php image build still runs `make live`
- [ ] Re-run a failing job from #3116 or open several PRs and check Composer no longer dies on GitHub 504s