### PR TITLE
fix(ZMSKVR-1497): allow login and Standort confirm without a departments payload

### DIFF
--- a/zmsbackend/src/Zmsbackend/Useraccount/Api/UserQueue.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Api/UserQueue.php
@@ -48,7 +48,7 @@ class UserQueue extends \BO\Zmsbackend\Api\BaseController
         $departmentService = new Department();
         $queueList = new QueueList();
 
-        foreach ($useraccount['departments'] as $department) {
+        foreach ($useraccount->getDepartmentList() as $department) {
             $queueList->addList(
                 $departmentService->readQueueList(
                     $department->id,

--- a/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountAdd.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountAdd.php
@@ -49,6 +49,9 @@ class UseraccountAdd extends \BO\Zmsbackend\Api\BaseController
         if (0 == count($input)) {
             throw new \BO\Zmsbackend\Useraccount\Exception\UseraccountInvalidInput();
         }
+        if (!isset($entity['departments'])) {
+            $entity->departments = [];
+        }
         try {
             $entity->testValid('de_DE', 1);
         } catch (\Exception $exception) {

--- a/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountUpdate.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Api/UseraccountUpdate.php
@@ -59,6 +59,9 @@ class UseraccountUpdate extends \BO\Zmsbackend\Api\BaseController
         if (0 == count($input)) {
             throw new \BO\Zmsbackend\Useraccount\Exception\UseraccountInvalidInput();
         }
+        if (!isset($entity['departments'])) {
+            $entity->departments = [];
+        }
         try {
             $entity->testValid('de_DE', 1);
         } catch (\Exception $exception) {

--- a/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
+++ b/zmsbackend/src/Zmsbackend/Useraccount/Service/Useraccount.php
@@ -139,12 +139,8 @@ class Useraccount extends \BO\Zmsbackend\Base
 
     protected function extractDepartmentIdsFromEntity($useraccount): array
     {
-        if (!isset($useraccount->departments) || empty($useraccount->departments)) {
-            return [];
-        }
-
         $ids = [];
-        foreach ($useraccount->departments as $department) {
+        foreach ($useraccount->getDepartmentList() as $department) {
             if (is_object($department) && isset($department->id)) {
                 $ids[] = $department->id;
             } elseif (is_array($department) && isset($department['id'])) {
@@ -802,7 +798,7 @@ class Useraccount extends \BO\Zmsbackend\Base
         if (!$entity->isSuperUser()) {
             $this->deleteAssignedDepartments($loginName);
             $userId = $this->readEntityIdByLoginName($loginName);
-            foreach ($entity->departments as $department) {
+            foreach ($entity->getDepartmentList() as $department) {
                 $this->perform(
                     \BO\Zmsbackend\Useraccount\Repository\Useraccount::QUERY_WRITE_ASSIGNED_DEPARTMENTS,
                     array(

--- a/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationLoginTest.php
+++ b/zmsbackend/tests/Zmsbackend/Workstation/Api/WorkstationLoginTest.php
@@ -36,6 +36,19 @@ class WorkstationLoginTest extends \BO\Zmsbackend\Tests\Api\Base
         $this->assertTrue(200 == $response->getStatusCode());
     }
 
+    public function testLoginWithCredentialsOnly()
+    {
+        $response = $this->render([], [
+            '__body' => json_encode([
+                'id' => static::$loginName,
+                'password' => static::$authKey,
+            ]),
+            'nocommit' => 1
+        ], []);
+        $this->assertStringContainsString('workstation.json', (string)$response->getBody());
+        $this->assertTrue(200 == $response->getStatusCode());
+    }
+
     public function testAuthKeyFound()
     {
         $this->expectException('\BO\Zmsbackend\Useraccount\Exception\AuthKeyFound');

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -16,8 +16,7 @@ class Useraccount extends Schema\Entity
     public static $schema = "useraccount.json";
 
     /**
-     * @return (Collection\DepartmentList|false[])[]
-     *
+     * @return array<string, mixed>
      */
     #[\Override]
     public function getDefaults()
@@ -55,8 +54,16 @@ class Useraccount extends Schema\Entity
                 "waitingqueue" => false,
                 "superuser" => false
             ],
-            'departments' => new Collection\DepartmentList(),
         ];
+    }
+
+    #[\Override]
+    public function addData(array|object $mergeData): static
+    {
+        if (isset($mergeData['departments']) && !($this['departments'] ?? null) instanceof Collection\DepartmentList) {
+            $this->departments = new Collection\DepartmentList();
+        }
+        return parent::addData($mergeData);
     }
 
     /**
@@ -75,8 +82,8 @@ class Useraccount extends Schema\Entity
 
     public function getDepartmentList(): Collection\DepartmentList
     {
-        if (!$this->departments instanceof Collection\DepartmentList) {
-            $this->departments = new Collection\DepartmentList($this->departments);
+        if (!isset($this['departments']) || !$this->departments instanceof Collection\DepartmentList) {
+            $this->departments = new Collection\DepartmentList($this['departments'] ?? []);
             foreach ($this->departments as $key => $department) {
                 $this->departments[$key] = new Department($department);
             }
@@ -86,17 +93,16 @@ class Useraccount extends Schema\Entity
 
     public function addDepartment(Department|array $department): static
     {
+        $this->getDepartmentList();
         $this->departments[] = $department;
         return $this;
     }
 
     public function getDepartment($departmentId)
     {
-        if (count($this->departments)) {
-            foreach ($this->getDepartmentList() as $department) {
-                if ($department['id'] == $departmentId) {
-                    return $department;
-                }
+        foreach ($this->getDepartmentList() as $department) {
+            if ($department['id'] == $departmentId) {
+                return $department;
             }
         }
         return new Department(['name' => 'Not existing']);
@@ -269,7 +275,7 @@ class Useraccount extends Schema\Entity
 
     public function getDepartmentById($departmentId): Department
     {
-        foreach ($this->departments as $department) {
+        foreach ($this->getDepartmentList() as $department) {
             if ($departmentId == $department['id']) {
                 return new Department($department);
             }
@@ -279,7 +285,7 @@ class Useraccount extends Schema\Entity
 
     public function getDepartmentByIds(array $departmentIds): Department
     {
-        foreach ($this->departments as $department) {
+        foreach ($this->getDepartmentList() as $department) {
             if (in_array($department['id'], $departmentIds)) {
                 return new Department($department);
             }
@@ -316,11 +322,14 @@ class Useraccount extends Schema\Entity
     {
         $departmentList = new Collection\DepartmentList();
         $entity = clone $this;
-        foreach ($this->departments as $department) {
-            if (! is_array($department) && ! $department instanceof Department) {
-                $department = new Department(array('id' => $department));
+        foreach ($this['departments'] ?? [] as $department) {
+            if ($department instanceof Department) {
+                $departmentList->addEntity($department);
+            } else {
+                $departmentList->addEntity(new Department(
+                    is_array($department) ? $department : ['id' => $department]
+                ));
             }
-            $departmentList->addEntity($department);
         }
         $entity->departments = $departmentList;
         return $entity;

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -60,7 +60,13 @@ class Useraccount extends Schema\Entity
     #[\Override]
     public function addData(array|object $mergeData): static
     {
-        if (isset($mergeData['departments']) && !($this['departments'] ?? null) instanceof Collection\DepartmentList) {
+        $hasDepartments = false;
+        if (is_array($mergeData) || $mergeData instanceof \ArrayAccess) {
+            $hasDepartments = isset($mergeData['departments']);
+        } elseif (is_object($mergeData)) {
+            $hasDepartments = isset($mergeData->departments);
+        }
+        if ($hasDepartments && !($this['departments'] ?? null) instanceof Collection\DepartmentList) {
             $this->departments = new Collection\DepartmentList();
         }
         return parent::addData($mergeData);
@@ -82,8 +88,11 @@ class Useraccount extends Schema\Entity
 
     public function getDepartmentList(): Collection\DepartmentList
     {
-        if (!isset($this['departments']) || !$this->departments instanceof Collection\DepartmentList) {
-            $this->departments = new Collection\DepartmentList($this['departments'] ?? []);
+        if (!isset($this['departments'])) {
+            return new Collection\DepartmentList();
+        }
+        if (!$this->departments instanceof Collection\DepartmentList) {
+            $this->departments = new Collection\DepartmentList($this->departments);
             foreach ($this->departments as $key => $department) {
                 $this->departments[$key] = new Department($department);
             }
@@ -93,7 +102,11 @@ class Useraccount extends Schema\Entity
 
     public function addDepartment(Department|array $department): static
     {
-        $this->getDepartmentList();
+        if (!isset($this['departments'])) {
+            $this->departments = new Collection\DepartmentList();
+        } elseif (!$this->departments instanceof Collection\DepartmentList) {
+            $this->getDepartmentList();
+        }
         $this->departments[] = $department;
         return $this;
     }

--- a/zmsentities/src/Zmsentities/Workstation.php
+++ b/zmsentities/src/Zmsentities/Workstation.php
@@ -65,7 +65,7 @@ class Workstation extends Schema\Entity
     public function getDepartmentList(): Collection\DepartmentList
     {
         $departmentList = new Collection\DepartmentList();
-        foreach ($this->getUseraccount()->departments as $department) {
+        foreach ($this->getUseraccount()->getDepartmentList() as $department) {
             $departmentList->addEntity(new Department($department));
         }
         return $departmentList;

--- a/zmsentities/tests/Zmsentities/UseraccountTest.php
+++ b/zmsentities/tests/Zmsentities/UseraccountTest.php
@@ -351,4 +351,26 @@ class UseraccountTest extends EntityCommonTests
         unset($workstation->useraccount['departments']);
         $this->assertTrue($workstation->testValid());
     }
+
+    public function testGetDepartmentListDoesNotPersistOmittedDepartments()
+    {
+        $entity = new \BO\Zmsentities\Useraccount([
+            'id' => 'johndoe',
+            'password' => 'secret1',
+        ]);
+        $this->assertSame(0, $entity->getDepartmentList()->count());
+        $this->assertFalse(isset($entity['departments']));
+        $this->assertTrue($entity->testValid());
+    }
+
+    public function testAddDataAcceptsPlainObject()
+    {
+        $entity = new \BO\Zmsentities\Useraccount();
+        $entity->addData((object) [
+            'id' => 'johndoe',
+            'password' => 'secret1',
+        ]);
+        $this->assertSame('johndoe', $entity->id);
+        $this->assertTrue($entity->testValid());
+    }
 }

--- a/zmsentities/tests/Zmsentities/UseraccountTest.php
+++ b/zmsentities/tests/Zmsentities/UseraccountTest.php
@@ -324,4 +324,31 @@ class UseraccountTest extends EntityCommonTests
         $entity->id = '';
         $this->assertNull($entity->getOidcProviderFromName());
     }
+
+    public function testLoginPayloadDoesNotRequireDepartments()
+    {
+        $entity = new \BO\Zmsentities\Useraccount([
+            'id' => 'johndoe',
+            'password' => 'secret1',
+        ]);
+        $this->assertTrue($entity->testValid());
+    }
+
+    public function testEmptyDepartmentsRejected()
+    {
+        $this->expectException('\BO\Zmsentities\Exception\SchemaValidation');
+        $entity = new \BO\Zmsentities\Useraccount([
+            'id' => 'johndoe',
+            'password' => 'secret1',
+            'departments' => [],
+        ]);
+        $entity->testValid();
+    }
+
+    public function testWorkstationUpdateWithoutDepartmentsIsValid()
+    {
+        $workstation = (new \BO\Zmsentities\Workstation())->getExample();
+        unset($workstation->useraccount['departments']);
+        $this->assertTrue($workstation->testValid());
+    }
 }

--- a/zmsentities/tests/Zmsentities/WorkstationTest.php
+++ b/zmsentities/tests/Zmsentities/WorkstationTest.php
@@ -75,6 +75,13 @@ class WorkstationTest extends EntityCommonTests
         $entity->testDepartmentList();
     }
 
+    public function testGetDepartmentListWhenUseraccountHasNoDepartments()
+    {
+        $entity = $this->getExample();
+        unset($entity->getUseraccount()['departments']);
+        $this->assertEquals(0, $entity->getDepartmentList()->count());
+    }
+
     public function testGetVariantName()
     {
         $entity = $this->getExample();


### PR DESCRIPTION
## Summary
- `#3164` required at least one Behörde on `useraccount.departments` (`minItems: 1`). Login and Standort confirm omit `departments`, but `Useraccount` still defaulted to an empty list, so schema validation returned 400.
- That is what turned [next zmsautomation](https://github.com/it-at-m/eappointment/actions/runs/33423411460) red after the morning green run: `POST /workstation/login/` and `POST /workstation/` 400. Citizen/statistic shards fail on the same path (mail auto-login / Auswahl bestätigen).
- **Does not undo ZMSKVR-1497.** Saving or creating a user without a Behörde still fails `minItems` (`Bitte wählen Sie (mindestens) eine Behörde aus.`). Only login and workstation update may omit the field.

Cherry-picked from #3187 (`0971134d6`…`e69a1a2ca`); no 1049 matching/test-data changes.

## Test plan
- [ ] Merge unblocks password login: `POST /workstation/login/` with `{id, password}` returns 200
- [ ] zmsadmin/zmsstatistic Standort confirm (Auswahl bestätigen) succeeds
- [ ] Useraccount create/update with no Behörde still shows the 1497 error
- [ ] Re-run `zmsautomation | manual | next | chrome` and expect the login/mail 400s gone