### PR TITLE
fix(ZMSKVR-1597): Absage Dienstleistungslink uses root_parent_id

### DIFF
--- a/zmsbackend/migrations/91787615970-fix-mail-delete-service-link-root-parent.sql
+++ b/zmsbackend/migrations/91787615970-fix-mail-delete-service-link-root-parent.sql
@@ -1,0 +1,25 @@
+START TRANSACTION;
+
+-- ZMSKVR-1597: Absage mails still linked Dienstleistung pages via request.id.
+-- Variants have no DLDB/stadt.muenchen.de page at that id (empty or 404).
+-- Same replacement as 91780800003, scoped to cancellation templates.
+
+UPDATE `mailtemplate`
+SET `value` = REPLACE(
+    `value`,
+    '{{ requestGroup[\'request\'].id }}',
+    '{{ requestGroup[\'request\'].root_parent_id }}'
+)
+WHERE `name` IN ('mail_delete.twig', 'mail_admin_delete.twig')
+  AND `value` LIKE '%{{ requestGroup[\'request\'].id }}%';
+
+UPDATE `mailtemplate`
+SET `value` = REPLACE(
+    `value`,
+    '{% set requestId = requestGroup[\'request\'].id %}',
+    '{% set requestId = requestGroup[\'request\'].root_parent_id %}'
+)
+WHERE `name` IN ('mail_delete.twig', 'mail_admin_delete.twig')
+  AND `value` LIKE '%requestGroup[\'request\'].id %}%';
+
+COMMIT;

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessConfirmationMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessConfirmationMail.php
@@ -35,8 +35,9 @@ class ProcessConfirmationMail extends \BO\Zmsbackend\Api\BaseController
         $input = Validator::input()->isJson()->assertValid()->getValue();
         $process = new Process($input);
         $process->testValid();
-        $this->testProcessData($process);
+        $this->testProcessAccess($process);
         $process = (new ProcessRepository())->readEntity($process->id, $process->authKey);
+        $this->testEmailRequired($process);
 
         $mail = $this->writeMail($process);
         $message = \BO\Zmsbackend\Api\Response\Message::create($request);
@@ -69,14 +70,23 @@ class ProcessConfirmationMail extends \BO\Zmsbackend\Api\BaseController
     /**
      * @return void
      */
-    protected function testProcessData(Process $process)
+    protected function testProcessAccess(Process $process)
     {
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessNotFound();
-        } elseif ($authCheck['authKey'] !== $process->authKey) {
+        }
+        if ($authCheck['authKey'] !== $process->authKey) {
             throw new \BO\Zmsbackend\Process\Exception\AuthKeyMatchFailed();
-        } elseif (
+        }
+    }
+
+    /**
+     * @return void
+     */
+    protected function testEmailRequired(Process $process)
+    {
+        if (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&
             ! $process->getFirstClient()->hasEmail()
         ) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteMail.php
@@ -35,8 +35,9 @@ class ProcessDeleteMail extends \BO\Zmsbackend\Api\BaseController
         $initiator = Validator::param('initiator')->isString()->getValue();
 
         $process->testValid();
-        $this->testProcessData($process);
+        $this->testProcessAccess($process);
         $process = (new ProcessRepository())->readEntity($process->id, $process->authKey);
+        $this->testEmailRequired($process);
 
         \BO\Zmsbackend\Connection\Select::getWriteConnection();
 
@@ -71,14 +72,23 @@ class ProcessDeleteMail extends \BO\Zmsbackend\Api\BaseController
     /**
      * @return void
      */
-    protected function testProcessData(Process $process)
+    protected function testProcessAccess(Process $process)
     {
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->getId());
         if (! $authCheck) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessNotFound();
-        } elseif ($authCheck['authKey'] !== $process->authKey) {
+        }
+        if ($authCheck['authKey'] !== $process->authKey) {
             throw new \BO\Zmsbackend\Process\Exception\AuthKeyMatchFailed();
-        } elseif (
+        }
+    }
+
+    /**
+     * @return void
+     */
+    protected function testEmailRequired(Process $process)
+    {
+        if (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&
             ! $process->getFirstClient()->hasEmail()
         ) {

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessDeleteMail.php
@@ -36,6 +36,7 @@ class ProcessDeleteMail extends \BO\Zmsbackend\Api\BaseController
 
         $process->testValid();
         $this->testProcessData($process);
+        $process = (new ProcessRepository())->readEntity($process->id, $process->authKey);
 
         \BO\Zmsbackend\Connection\Select::getWriteConnection();
 
@@ -75,6 +76,8 @@ class ProcessDeleteMail extends \BO\Zmsbackend\Api\BaseController
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->getId());
         if (! $authCheck) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessNotFound();
+        } elseif ($authCheck['authKey'] !== $process->authKey) {
+            throw new \BO\Zmsbackend\Process\Exception\AuthKeyMatchFailed();
         } elseif (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&
             ! $process->getFirstClient()->hasEmail()

--- a/zmsbackend/src/Zmsbackend/Process/Api/ProcessPreconfirmationMail.php
+++ b/zmsbackend/src/Zmsbackend/Process/Api/ProcessPreconfirmationMail.php
@@ -34,8 +34,9 @@ class ProcessPreconfirmationMail extends \BO\Zmsbackend\Api\BaseController
         $input = Validator::input()->isJson()->assertValid()->getValue();
         $process = new Process($input);
         $process->testValid();
-        $this->testProcessData($process);
+        $this->testProcessAccess($process);
         $process = (new ProcessRepository())->readEntity($process->id, $process->authKey);
+        $this->testEmailRequired($process);
         $mail = $this->writeMail($process);
         $message = \BO\Zmsbackend\Api\Response\Message::create($request);
         $message->data = ($mail->hasId()) ? $mail : null;
@@ -67,14 +68,23 @@ class ProcessPreconfirmationMail extends \BO\Zmsbackend\Api\BaseController
     /**
      * @return void
      */
-    protected function testProcessData(Process $process)
+    protected function testProcessAccess(Process $process)
     {
         $authCheck = (new ProcessRepository())->readAuthKeyByProcessId($process->id);
         if (! $authCheck) {
             throw new \BO\Zmsbackend\Process\Exception\ProcessNotFound();
-        } elseif ($authCheck['authKey'] !== $process->authKey) {
+        }
+        if ($authCheck['authKey'] !== $process->authKey) {
             throw new \BO\Zmsbackend\Process\Exception\AuthKeyMatchFailed();
-        } elseif (
+        }
+    }
+
+    /**
+     * @return void
+     */
+    protected function testEmailRequired(Process $process)
+    {
+        if (
             $process->toProperty()->scope->preferences->client->emailRequired->get() &&
             ! $process->getFirstClient()->hasEmail()
         ) {

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessConfirmationMailTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessConfirmationMailTest.php
@@ -114,11 +114,9 @@ class ProcessConfirmationMailTest extends \BO\Zmsbackend\Tests\Api\Base
         ], []);
     }
 
-    public function testMissingMail()
+    public function testMissingMailOnPayloadUsesStoredClient()
     {
-        $this->expectException('\BO\Zmsbackend\Process\Exception\EmailRequired');
-        $this->expectExceptionCode(400);
-        $this->render([], [
+        $response = $this->render([], [
             '__body' => '{
                 "id": '. self::PROCESS_ID .',
                 "authKey": "'. self::AUTHKEY .'",
@@ -160,6 +158,8 @@ class ProcessConfirmationMailTest extends \BO\Zmsbackend\Tests\Api\Base
                 "status": "confirmed"
             }'
         ], []);
+        $this->assertStringContainsString('mail.json', (string)$response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testUnvalidInput()

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessDeleteMailTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessDeleteMailTest.php
@@ -114,11 +114,9 @@ class ProcessDeleteMailTest extends \BO\Zmsbackend\Tests\Api\Base
         ], []);
     }
 
-    public function testMissingMail()
+    public function testMissingMailOnPayloadUsesStoredClient()
     {
-        $this->expectException('\BO\Zmsbackend\Process\Exception\EmailRequired');
-        $this->expectExceptionCode(400);
-        $this->render([], [
+        $response = $this->render([], [
             '__body' => '{
                 "id": '. self::PROCESS_ID .',
                 "authKey": "'. self::AUTHKEY .'",
@@ -148,6 +146,8 @@ class ProcessDeleteMailTest extends \BO\Zmsbackend\Tests\Api\Base
                 "status": "confirmed"
             }'
         ], []);
+        $this->assertStringContainsString('mail.json', (string)$response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testUnvalidInput()

--- a/zmsbackend/tests/Zmsbackend/Process/Api/ProcessDeleteMailTest.php
+++ b/zmsbackend/tests/Zmsbackend/Process/Api/ProcessDeleteMailTest.php
@@ -26,6 +26,50 @@ class ProcessDeleteMailTest extends \BO\Zmsbackend\Tests\Api\Base
         $this->render([], [], []);
     }
 
+    public function testAuthKeyMatchFailed()
+    {
+        $this->expectException('\BO\Zmsbackend\Process\Exception\AuthKeyMatchFailed');
+        $this->expectExceptionCode(403);
+        $this->render([], [
+            '__body' => '{
+                "id": '. self::PROCESS_ID .',
+                "authKey": "1234",
+                "scope": {
+                    "id": 141,
+                    "provider": {
+                        "id": 123456,
+                        "name": "Flughafen Schönefeld, Aufsicht",
+                        "source": "dldb"
+                    },
+                    "shortName": "Zentrale"
+                },
+                "clients": [
+                    {
+                        "familyName": "Max Mustermann",
+                        "email": "max@service.berlin.de",
+                        "telephone": "030 115"
+                    }
+                ],
+                "appointments" : [
+                    {
+                        "date": 1447869172,
+                        "scope": {
+                            "id": 141,
+                            "provider": {
+                                "id": 123456,
+                                "name": "Flughafen Schönefeld, Aufsicht",
+                                "source": "dldb"
+                            },
+                            "shortName": "Zentrale"
+                        },
+                        "slotCount": 2
+                    }
+                ],
+                "status": "confirmed"
+            }'
+        ], []);
+    }
+
     public function testNotFound()
     {
         $this->expectException('\BO\Zmsbackend\Process\Exception\ProcessNotFound');

--- a/zmsentities/tests/Zmsentities/MailTest.php
+++ b/zmsentities/tests/Zmsentities/MailTest.php
@@ -211,6 +211,51 @@ class MailTest extends EntityCommonTests
         $this->assertStringNotContainsString('service.berlin.de/dienstleistung/', $resolvedEntity->getHtmlPart());
     }
 
+    public function testDeleteMailUsesRootParentIdForServiceLink()
+    {
+        $template = <<<TWIG
+{% block german %}
+{% for requestGroup in requestGroups %}
+<a href="https://stadt.muenchen.de/service/info/{{ requestGroup['request'].root_parent_id }}/">{{ requestGroup['request'].name }}</a>
+{% endfor %}
+{% endblock %}
+TWIG;
+        $templatePath = \BO\Zmsentities\Helper\TemplateFinder::getTemplatePath();
+        $templateProvider = new class ($template, $templatePath) {
+            public function __construct(private string $template, private string $templatePath)
+            {
+            }
+
+            public function getTemplates(): array
+            {
+                return [
+                    'mail_delete.twig' => $this->template,
+                    'snippets.twig' => file_get_contents($this->templatePath . '/messaging/snippets.twig'),
+                    'subjects.twig' => file_get_contents($this->templatePath . '/messaging/subjects.twig'),
+                ];
+            }
+        };
+
+        $entity = (new $this->entityclass())->getExample();
+        $process = (new \BO\Zmsentities\Process())->getExample();
+        $process->requests = [];
+        $process->requests[] = new \BO\Zmsentities\Request([
+            'id' => '8',
+            'name' => 'Reisepass beantragen',
+            'root_parent_id' => '1063441',
+        ]);
+        $config = (new \BO\Zmsentities\Config())->getExample();
+        $entity->addMultiPart(array());
+        $entity->client = null;
+        $resolvedEntity = $entity->setTemplateProvider($templateProvider)
+            ->toResolvedEntity($process, $config, 'deleted');
+
+        $html = $resolvedEntity->getHtmlPart();
+        $this->assertStringContainsString('https://stadt.muenchen.de/service/info/1063441/', $html);
+        $this->assertStringNotContainsString('https://stadt.muenchen.de/service/info/8/', $html);
+        $this->assertStringNotContainsString('https://stadt.muenchen.de/service/info//', $html);
+    }
+
     public function testMailWithOneRequest()
     {
         $entity = (new $this->entityclass())->getExample();


### PR DESCRIPTION
## Summary
- Absage mails linked `stadt.muenchen.de/service/info/{{ request.id }}/`. For Terminvarianten that id is not the DLDB page, so the URL is empty or 404.
- Same template idea as **ZMSKVR-1453** / [#2658](https://github.com/it-at-m/eappointment/pull/2658) (`root_parent_id` instead of `request.id`, migration `91780800003`). That covered confirmation, reminder, and preconfirmed. Absage was left out, and delete mail never reloads the process.
- Confirmation already reloads from the DB (where `root_parent_id` is attached). Delete mail used the citizen payload, which has no `root_parent_id`.
- This PR: reload in `ProcessDeleteMail` like confirmation, and apply the same `root_parent_id` REPLACE to stored `mail_delete` / `mail_admin_delete` templates. Variants still book and cancel; only the description link goes to the root service.
- Confirmation, preconfirmation, and Absage now share the same checks: auth on the request, `emailRequired` on the process loaded from the DB.

## Test plan
- [x] Book Reisepass (or a variant), activate, cancel
- [x] Absage mail Dienstleistungslink opens the Leistungsbeschreibung (no 404, id present)
- [x] Repeat with a Terminvariante; link still targets the root service page

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.