### PR TITLE
fix(ZMSKVR-1559): hide queue reload for agent_basic

### DIFF
--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -35,9 +35,9 @@
 		</form>
 		{% endif %}
 		{% if showAnyQueues %}
-		<a href="#" title="Liste neu laden" class="button button--diamond reload">
+		<a href="#" title="Listen neu laden" class="button button--diamond reload">
 			<i class="fas fa-sync" aria-hidden="true"></i>
-			<span class="aural">Liste neu laden</span>
+			<span class="aural">Listen neu laden</span>
 		</a>
 		{% endif %}
 		{% if permissions.waitingqueue %}
@@ -719,7 +719,7 @@ content.addClass('hidden')
 			</style>
 		</div>
 		{% endif %}
-		{% if showAnyQueues %}
+		{% if showAnyQueues and 'agent_basic' not in workstation.useraccount.roles|default([]) %}
 		<div class="form-actions">
 			<div class="right">
 				<button title="{% trans %}Warteschlange neu laden{% endtrans %}" class="button button-reload reload">

--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -719,7 +719,7 @@ content.addClass('hidden')
 			</style>
 		</div>
 		{% endif %}
-		{% if showAnyQueues and 'agent_basic' not in workstation.useraccount.roles|default([]) %}
+		{% if showAnyQueues and permissions.waitingqueue %}
 		<div class="form-actions">
 			<div class="right">
 				<button title="{% trans %}Warteschlange neu laden{% endtrans %}" class="button button-reload reload">

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -336,4 +336,77 @@ class QueueTableTest extends Base
         $this->assertStringNotContainsString('Offene Aufrufe', (string)$response->getBody());
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testHeaderReloadButtonUsesPluralListenLabel()
+    {
+        $this->setQueueTableApiCalls($this->readFixture("GET_Workstation_Resolved2.json"));
+
+        $response = $this->render($this->arguments, $this->parameters, []);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('title="Listen neu laden"', $body);
+        $this->assertStringContainsString('Listen neu laden', $body);
+        $this->assertStringContainsString('Warteschlange aktualisieren', $body);
+    }
+
+    public function testAgentBasicHidesQueueReloadButton()
+    {
+        $workstation = json_decode($this->readFixture("GET_Workstation_Resolved2.json"), true);
+        $workstation['data']['useraccount']['roles'] = ['agent_basic'];
+        $workstation['data']['useraccount']['permissions'] = [
+            'appointment' => true,
+            'customersearch' => true,
+            'emergency' => true,
+            'finishedqueue' => true,
+            'missedqueue' => true,
+            'parkedqueue' => true,
+            'waitingqueue' => false,
+            'superuser' => false,
+        ];
+
+        $this->setQueueTableApiCalls(json_encode($workstation));
+
+        $response = $this->render($this->arguments, $this->parameters, []);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('Warteschlange aktualisieren', $body);
+        $this->assertStringContainsString('Listen neu laden', $body);
+    }
+
+    private function setQueueTableApiCalls(string $workstationFixture): void
+    {
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => [
+                        'resolveReferences' => 1,
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getWorkstation()
+                    ],
+                    'response' => $workstationFixture
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/department/',
+                    'response' => $this->readFixture("GET_department_74.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/cluster/',
+                    'response' => $this->readFixture("GET_cluster_109.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/process/2016-04-01/',
+                    'parameters' => [
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getProcess()
+                    ],
+                    'response' => $this->readFixture("GET_processList_141_20160401.json")
+                ]
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Hide **Warteschlange aktualisieren** on Sachbearbeiterplatz for role `agent_basic` (Sachbearbeitung Basis).
- Rename the Terminübersicht reload control to **Listen neu laden** so it is clear that parked, finished, and other lists are reloaded together.

## Test plan
- Log in as Sachbearbeitung Basis and open Sachbearbeiterplatz: the bottom **Warteschlange aktualisieren** button is gone; the blue bar reload control is labeled **Listen neu laden**.
- Log in as a role with waiting queue (e.g. agent_queue): **Warteschlange aktualisieren** is still shown.
- Blue-bar reload still refreshes the lists.

### Pull Request Checklist (Feature Branch to `next`):
- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit zmsautomation ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the queue table reload label to use the plural wording “Listen neu laden.”
  * Updated visibility of the “Warteschlange aktualisieren” button to depend on waiting-queue permission rather than the `agent_basic` role.
  * Users without waiting-queue permission no longer see the queue update button, while the general list reload option remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->