### PR TITLE
fix(ZMSKVR-1397): hide broken +00:00:00 less than one minute waiting time in queue ui

### DIFF
--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -355,8 +355,15 @@
 										{% else %}
 											{{ item.queue.arrivalTime|date("H:i") }}
 										{% endif %}
-										{% if item.queue.waitingTime and isToday %}
-											<p class="queue-table-amendment-time">+{{ item.queue.waitingTime}}&nbsp;Min.</p>
+										{% set waitingTime = item.queue.waitingTime %}
+										{% set waitingTimeParts = (waitingTime ~ '')|split(':') %}
+										{% if waitingTimeParts|length == 3 %}
+											{% set waitingTimeMinutes = waitingTimeParts[0] * 60 + waitingTimeParts[1] %}
+										{% else %}
+											{% set waitingTimeMinutes = waitingTime %}
+										{% endif %}
+										{% if waitingTimeMinutes > 0 and isToday %}
+											<p class="queue-table-amendment-time">+{{ waitingTimeMinutes }}&nbsp;Min.</p>
 										{% endif %}
 									</td>
 									<td title="{{ item.amendment|default('')|replace({'\r': ''})|e('html_attr') }}">

--- a/zmsadmin/templates/block/queue/table.twig
+++ b/zmsadmin/templates/block/queue/table.twig
@@ -362,6 +362,7 @@
 										{% else %}
 											{% set waitingTimeMinutes = waitingTime %}
 										{% endif %}
+										{% set waitingTimeMinutes = waitingTimeMinutes|round(0, 'floor') %}
 										{% if waitingTimeMinutes > 0 and isToday %}
 											<p class="queue-table-amendment-time">+{{ waitingTimeMinutes }}&nbsp;Min.</p>
 										{% endif %}

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -339,13 +339,14 @@ class QueueTableTest extends Base
 
     public function testDoesNotRenderWaitingTimeBelowOneMinute()
     {
-        foreach (['00:00:00', '00:00:45'] as $waitingTime) {
+        foreach (['00:00:00', '00:00:45', 0.75] as $waitingTime) {
             $response = $this->renderQueueTableWithWaitingTime($waitingTime);
             $body = (string) $response->getBody();
 
             $this->assertEquals(200, $response->getStatusCode());
             $this->assertStringNotContainsString('+00:00:', $body);
             $this->assertStringNotContainsString('+0&nbsp;Min.', $body);
+            $this->assertStringNotContainsString('+0.75&nbsp;Min.', $body);
         }
     }
 
@@ -359,7 +360,7 @@ class QueueTableTest extends Base
         $this->assertStringNotContainsString('+00:05:00', $body);
     }
 
-    private function renderQueueTableWithWaitingTime(int|string $waitingTime)
+    private function renderQueueTableWithWaitingTime(int|float|string $waitingTime)
     {
         $processFixture = json_decode($this->readFixture("GET_processList_141_20160401.json"), true);
         $processFixture['data']['0']['queue']['waitingTime'] = $waitingTime;

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -336,4 +336,65 @@ class QueueTableTest extends Base
         $this->assertStringNotContainsString('Offene Aufrufe', (string)$response->getBody());
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testDoesNotRenderWaitingTimeBelowOneMinute()
+    {
+        foreach (['00:00:00', '00:00:45'] as $waitingTime) {
+            $response = $this->renderQueueTableWithWaitingTime($waitingTime);
+            $body = (string) $response->getBody();
+
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertStringNotContainsString('+00:00:', $body);
+            $this->assertStringNotContainsString('+0&nbsp;Min.', $body);
+        }
+    }
+
+    public function testRendersWaitingTimeAsWholeMinutes()
+    {
+        $response = $this->renderQueueTableWithWaitingTime('00:05:00');
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('+5&nbsp;Min.', $body);
+        $this->assertStringNotContainsString('+00:05:00', $body);
+    }
+
+    private function renderQueueTableWithWaitingTime(int|string $waitingTime)
+    {
+        $processFixture = json_decode($this->readFixture("GET_processList_141_20160401.json"), true);
+        $processFixture['data']['0']['queue']['waitingTime'] = $waitingTime;
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => [
+                        'resolveReferences' => 1,
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getWorkstation()
+                    ],
+                    'response' => $this->readFixture("GET_Workstation_Resolved2.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/department/',
+                    'response' => $this->readFixture("GET_department_74.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/cluster/',
+                    'response' => $this->readFixture("GET_cluster_109.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/process/2016-04-01/',
+                    'parameters' => [
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getProcess()
+                    ],
+                    'response' => json_encode($processFixture)
+                ]
+            ]
+        );
+
+        return $this->render($this->arguments, $this->parameters, []);
+    }
 }


### PR DESCRIPTION
## Summary
- After Abbrechen or Wiederaufnehmen from the missed queue, a wait under one minute is stored as TIME (`00:00:00` / `00:00:xx`). The Warteschlange printed that raw value as `+00:00:00 Min.`
- Convert `HH:MM:SS` to whole minutes for display only and hide waits under one minute. Storage format is unchanged.

<img width="135" height="126" alt="Screenshot 2026-09-01 at 13 57 03" src="https://github.com/user-attachments/assets/2f550bd6-b27e-4896-b6e5-801b061bb00c" />

## Test plan
- [x] Call a customer and Abbrechen within one minute — no `+00:00:00 Min.` (or `+00:00:xx Min.`) under Uhrzeit
- [x] Wiederaufnehmen from Verpasste Termine within one minute — same, no seconds TIME next to `Min.`
- [x] After a wait of at least one minute, Uhrzeit still shows `+X Min.`
- [x] Confirm `buerger.waiting_time` is still `HH:MM:SS`, including sub-minute values

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue waiting times are now displayed as whole minutes.
  * Waiting times under one minute are no longer shown.
  * Reload labels now use the correct plural wording.
  * The bottom queue refresh option is shown only when the required permission is enabled.

* **Tests**
  * Added coverage for waiting-time formatting and reload-button visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->