### PR TITLE
fix(GH): bump fast-uri and qs for Trivy CVEs

### DIFF
--- a/zmscitizenapi/package-lock.json
+++ b/zmscitizenapi/package-lock.json
@@ -252,9 +252,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "dev": true,
       "funding": [
         {

--- a/zmscitizenapi/package.json
+++ b/zmscitizenapi/package.json
@@ -17,7 +17,7 @@
   "overrides": {
     "handlebars": "^4.7.9",
     "dompurify": "^3.4.12",
-    "fast-uri": "^4.1.2",
+    "fast-uri": "^4.1.4",
     "fast-xml-builder": "^1.1.7",
     "postcss": "^8.5.10",
     "protobufjs": "^8.6.0",

--- a/zmscitizenview/package-lock.json
+++ b/zmscitizenview/package-lock.json
@@ -5471,7 +5471,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/zmscitizenview/package.json
+++ b/zmscitizenview/package.json
@@ -51,6 +51,7 @@
   "// overrides.brace-expansion": "Force 5.0.8 for CVE-2026-14257 (DoS via unbounded expansion length); no 1.x/2.x backport.",
   "// overrides.immutable": "sass pins immutable@5.1.5; force ^5.1.9 (CVE-2026-59879, CVE-2026-59880).",
   "// overrides.nanoid": "postcss pins nanoid@3.3.16; force ^3.3.17 (CVE-2026-67213).",
+  "// overrides.qs": "local-web-server -> co-body pins qs@6.15.3; force ^6.16.0 (CVE-2026-82417, CVE-2026-82562).",
   "overrides": {
     "vite-plugin-vuetify": {
       "make-dir": "5.1.0"
@@ -63,6 +64,7 @@
     "morgan": "^1.11.0",
     "immutable": "^5.1.9",
     "brace-expansion": "5.0.9",
-    "nanoid": "^3.3.17"
+    "nanoid": "^3.3.17",
+    "qs": "^6.16.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `fast-uri` from 4.1.2 to 4.1.4 in `zmscitizenapi` to clear HIGH CVEs [CVE-2026-75899](https://avd.aquasec.com/nvd/cve-2026-75899), [CVE-2026-75931](https://avd.aquasec.com/nvd/cve-2026-75931), [CVE-2026-75975](https://avd.aquasec.com/nvd/cve-2026-75975), and [CVE-2026-76172](https://avd.aquasec.com/nvd/cve-2026-76172).
- Override nested `qs` to 6.16.0 in `zmscitizenview` (`local-web-server` → `co-body`) to clear MEDIUM CVEs [CVE-2026-82417](https://avd.aquasec.com/nvd/cve-2026-82417) and [CVE-2026-82562](https://avd.aquasec.com/nvd/cve-2026-82562).
- This unblocks the failing Trivy check on `next` ([run 33718921497](https://github.com/it-at-m/eappointment/actions/runs/33718921497/job/100533873925)).

## Test plan
- [ ] Trivy Security Check passes on this PR
- [ ] Combined workflow Trivy job is green after merge to `next`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated underlying components in the Citizen API and Citizen View to address known security vulnerabilities.
  - Applied additional security safeguards to improve the application’s resilience against affected request-handling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->