### PR TITLE
fix(ZMS): keep queue table when called-list API fails

### DIFF
--- a/zmsadmin/src/Zmsadmin/QueueTable.php
+++ b/zmsadmin/src/Zmsadmin/QueueTable.php
@@ -186,15 +186,22 @@ class QueueTable extends BaseController
             return [];
         }
 
-        $queueListCalled = \App::$http
-            ->readGetResult(
-                '/useraccount/queue/',
-                [
-                    'resolveReferences' => 2,
-                    'status' => 'called,processing',
-                ]
-            )
-            ->getCollection() ?? [];
+        try {
+            $queueListCalled = \App::$http
+                ->readGetResult(
+                    '/useraccount/queue/',
+                    [
+                        'resolveReferences' => 2,
+                        'status' => 'called,processing',
+                    ]
+                )
+                ->getCollection() ?? [];
+        } catch (\BO\Zmsclient\Exception $exception) {
+            \App::$log->error('Failed to load called queue list', [
+                'error' => $exception->getMessage(),
+            ]);
+            return [];
+        }
 
         if (! ($queueListCalled instanceof QueueList)) {
             return [];

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -286,6 +286,72 @@ class QueueTableTest extends Base
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testCalledListApiFailureStillRendersQueueTable()
+    {
+        $workstationJson = $this->readFixture("GET_Workstation_Resolved2.json");
+        $data = json_decode($workstationJson, true);
+        $data['data']['useraccount']['permissions'] = [
+            'openqueue' => true,
+            'waitingqueue' => true,
+            'parkedqueue' => true,
+        ];
+        $modifiedWorkstationJson = json_encode($data);
+
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => [
+                        'resolveReferences' => 1,
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getWorkstation()
+                    ],
+                    'response' => $modifiedWorkstationJson
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/department/',
+                    'response' => $this->readFixture("GET_department_74.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/cluster/',
+                    'response' => $this->readFixture("GET_cluster_109.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/process/2016-04-01/',
+                    'parameters' => [
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getProcess()
+                    ],
+                    'response' => $this->readFixture("GET_processList_141_20160401.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/useraccount/queue/',
+                    'parameters' => [
+                        'resolveReferences' => 2,
+                        'status' => 'called,processing',
+                    ],
+                    'exception' => new \BO\Zmsclient\Exception\ApiFailed()
+                ]
+            ]
+        );
+
+        $response = $this->render($this->arguments, [
+            'selecteddate' => '2016-04-01',
+            'withCalled' => 1
+        ], []);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('queue-table', $body);
+        $this->assertStringContainsString('Warteschlange', $body);
+        $this->assertStringContainsString('Offene Aufrufe', $body);
+        $this->assertStringContainsString('Keine Einträge gefunden.', $body);
+        $this->assertStringNotContainsString('Zuviele API Abrufe registriert', $body);
+    }
+
     public function testWaitingqueueWithoutOpenqueueLoadsProcessListOnly()
     {
         $workstationJson = $this->readFixture("GET_Workstation_Resolved2.json");


### PR DESCRIPTION
## Summary
- Isolate `GET /useraccount/queue/` in `QueueTable` so an empty or failed called-list response no longer aborts the whole Warteschlangen-Ansicht.
- After a recall, parked and waiting rows still render; Offene Aufrufe stays empty instead of showing the misleading „Zuviele API Abrufe“ overlay.
- Adds a regression test that stubs `ApiFailed` on the called-list request.

## Test plan
- [ ] Open Terminübersicht with Offene Aufrufe expanded (`withCalled=1`) and confirm parked + waiting rows still load.
- [ ] Recall a parked/called appointment and confirm the queue table does not die with „Zuviele API Abrufe registriert“.
- [ ] When UserQueue succeeds, Offene Aufrufe still lists called/processing items.
- [ ] `QueueTableTest` in zmsadmin (covers the `ApiFailed` isolation path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queue tables now continue to display when the queue service is temporarily unavailable.
  - Users see an empty queue state instead of a page error when queue data cannot be loaded.
  - Improved handling prevents API failures from interrupting the queue view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->