### PR TITLE
fix(ZMSKVR-1424): keep queue table when called-list API fails

### DIFF
--- a/zmsadmin/src/Zmsadmin/QueueTable.php
+++ b/zmsadmin/src/Zmsadmin/QueueTable.php
@@ -186,15 +186,22 @@ class QueueTable extends BaseController
             return [];
         }
 
-        $queueListCalled = \App::$http
-            ->readGetResult(
-                '/useraccount/queue/',
-                [
-                    'resolveReferences' => 2,
-                    'status' => 'called,processing',
-                ]
-            )
-            ->getCollection() ?? [];
+        try {
+            $queueListCalled = \App::$http
+                ->readGetResult(
+                    '/useraccount/queue/',
+                    [
+                        'resolveReferences' => 2,
+                        'status' => 'called,processing',
+                    ]
+                )
+                ->getCollection() ?? [];
+        } catch (\BO\Zmsclient\Exception $exception) {
+            \App::$log->error('Failed to load called queue list', [
+                'error' => $exception->getMessage(),
+            ]);
+            return [];
+        }
 
         if (! ($queueListCalled instanceof QueueList)) {
             return [];

--- a/zmsadmin/tests/Zmsadmin/QueueTableTest.php
+++ b/zmsadmin/tests/Zmsadmin/QueueTableTest.php
@@ -286,6 +286,72 @@ class QueueTableTest extends Base
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testCalledListApiFailureStillRendersQueueTable()
+    {
+        $workstationJson = $this->readFixture("GET_Workstation_Resolved2.json");
+        $data = json_decode($workstationJson, true);
+        $data['data']['useraccount']['permissions'] = [
+            'openqueue' => true,
+            'waitingqueue' => true,
+            'parkedqueue' => true,
+        ];
+        $modifiedWorkstationJson = json_encode($data);
+
+        $this->setApiCalls(
+            [
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/workstation/',
+                    'parameters' => [
+                        'resolveReferences' => 1,
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getWorkstation()
+                    ],
+                    'response' => $modifiedWorkstationJson
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/department/',
+                    'response' => $this->readFixture("GET_department_74.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/cluster/',
+                    'response' => $this->readFixture("GET_cluster_109.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/scope/141/process/2016-04-01/',
+                    'parameters' => [
+                        'gql' => \BO\Zmsadmin\Helper\GraphDefaults::getProcess()
+                    ],
+                    'response' => $this->readFixture("GET_processList_141_20160401.json")
+                ],
+                [
+                    'function' => 'readGetResult',
+                    'url' => '/useraccount/queue/',
+                    'parameters' => [
+                        'resolveReferences' => 2,
+                        'status' => 'called,processing',
+                    ],
+                    'exception' => new \BO\Zmsclient\Exception\ApiFailed()
+                ]
+            ]
+        );
+
+        $response = $this->render($this->arguments, [
+            'selecteddate' => '2016-04-01',
+            'withCalled' => 1
+        ], []);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('queue-table', $body);
+        $this->assertStringContainsString('Warteschlange', $body);
+        $this->assertStringContainsString('Offene Aufrufe', $body);
+        $this->assertStringContainsString('Keine Einträge gefunden.', $body);
+        $this->assertStringNotContainsString('Zuviele API Abrufe registriert', $body);
+    }
+
     public function testWaitingqueueWithoutOpenqueueLoadsProcessListOnly()
     {
         $workstationJson = $this->readFixture("GET_Workstation_Resolved2.json");


### PR DESCRIPTION
## Summary
- Kleiner Try/Catch, damit die UI nicht kaputtgeht, falls die API während des Rollouts kurzzeitig nicht erreichbar ist und ein Test dazu.
- Isolate `GET /useraccount/queue/` in `QueueTable` so an empty or failed called-list response no longer aborts the whole Warteschlangen-Ansicht.
- After a recall, parked and waiting rows still render; Offene Aufrufe stays empty instead of showing the misleading „Zuviele API Abrufe“ overlay.
- Adds a regression test that stubs `ApiFailed` on the called-list request.

<img width="182" height="209" alt="Screenshot 2026-09-04 at 14 23 20" src="https://github.com/user-attachments/assets/0a85097b-d63f-40d3-931f-6f5c452a1334" />

## Test plan
- [x] Open Terminübersicht with Offene Aufrufe expanded (`withCalled=1`) and confirm parked + waiting rows still load.
- [x] Recall a parked/called appointment and confirm the queue table does not die with „Zuviele API Abrufe registriert“.
- [x] When UserQueue succeeds, Offene Aufrufe still lists called/processing items.
- [x] `QueueTableTest` in zmsadmin (covers the `ApiFailed` isolation path).

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [ ] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.