### PR TITLE
fix(ZMSKVR-1417): remove LHM logo from mail signatures

### DIFF
--- a/zmsbackend/migrations/91787714170-remove-lhm-logo-from-mail-signature.sql
+++ b/zmsbackend/migrations/91787714170-remove-lhm-logo-from-mail-signature.sql
@@ -1,0 +1,26 @@
+START TRANSACTION;
+
+-- ZMSKVR-1417: Remove LHM logo from Termin-E-Mail signatures.
+-- Presse- und Informationsamt: the LHM logo must not be used in e-mails.
+-- Lives in snippets.twig block sendoff_munich (global and customized copies).
+
+UPDATE `mailtemplate`
+SET `value` = REPLACE(
+    `value`,
+    CONCAT(
+        '<img src="https://assets.muenchen.de/logos/lhm/logo-lhm-muenchen-256.jpg"',
+        ' alt="Logo der Landeshauptstadt München" width="180" height="auto">'
+    ),
+    ''
+)
+WHERE `value` LIKE '%logo-lhm-muenchen-256.jpg%';
+
+UPDATE `mailtemplate`
+SET `value` = REGEXP_REPLACE(
+    `value`,
+    '<img[^>]*src="https://assets\\.muenchen\\.de/logos/lhm/[^"]*"[^>]*>',
+    ''
+)
+WHERE `value` LIKE '%assets.muenchen.de/logos/lhm/%';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Flyway migration strips the `logo-lhm-muenchen-256.jpg` image (and any other `assets.muenchen.de/logos/lhm/` img) from all `mailtemplate` rows, including customized `snippets.twig` copies.
- Greeting text ("Mit freundlichen Grüßen / Landeshauptstadt München") stays.

## Test plan
- [x] After deploy/migration, open a confirmation / reminder / cancellation mail preview and confirm the LHM image is gone
- [x] Confirm the sendoff text is still present
- [x] Re-run migration on a DB that already applied it (should be a no-op)

### Pull Request Checklist (Feature Branch to `next`):

- [x] Ich habe die neuesten Änderungen aus dem `next` Branch in meinen Feature-Branch gemergt.
- [x] Relevante Tests wurden mit [zmsautomation](https://github.com/it-at-m/eappointment/actions/workflows/zmsautomation-workflow.yaml) ausgeführt.
- [x] Das Code-Review wurde abgeschlossen.
- [x] Fachliche Tests wurden durchgeführt und sind abgeschlossen.
- [x] Ich habe erforderliche Dokumentation im Ordner `docs` hinzugefügt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the LHM logo from applicable email signatures.
  * Prevented remaining variations of the LHM logo from appearing in email signature content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->