### PR TITLE
fix(GH): harden Composer installs against GitHub zipball 504s

### DIFF
--- a/.github/actions/composer-install/action.yml
+++ b/.github/actions/composer-install/action.yml
@@ -1,0 +1,45 @@
+name: Install Composer dependencies
+description: Authenticated, cached, retried composer install (mitigates GitHub zipball 504s)
+
+inputs:
+  working-directory:
+    description: Module directory that contains composer.json / composer.lock
+    required: true
+  github-token:
+    description: GitHub token used as github-oauth for api.github.com dist downloads
+    required: true
+  composer-args:
+    description: Extra arguments passed to composer install
+    required: false
+    default: --no-progress --prefer-dist --optimize-autoloader --no-interaction
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Composer GitHub OAuth
+      if: inputs.github-token != ''
+      shell: bash
+      env:
+        COMPOSER_GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: composer config --global github-oauth.github.com "$COMPOSER_GITHUB_TOKEN"
+
+    - name: Cache Composer packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        # Workspace path so the cache works in job containers (host-side actions/cache
+        # cannot see /root/.composer inside the container filesystem).
+        path: ${{ github.workspace }}/.composer-cache/${{ inputs.working-directory }}
+        key: ${{ runner.os }}-composer-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/composer.lock', inputs.working-directory)) }}
+        restore-keys: |
+          ${{ runner.os }}-composer-${{ inputs.working-directory }}-
+
+    - name: Install Composer dependencies
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+      env:
+        COMPOSER_CACHE_DIR: ${{ github.workspace }}/.composer-cache/${{ inputs.working-directory }}
+        COMPOSER_MAX_PARALLEL_HTTP: "4"
+      with:
+        timeout_minutes: 15
+        max_attempts: 5
+        retry_wait_seconds: 20
+        command: composer install ${{ inputs.composer-args }} --working-dir="${{ inputs.working-directory }}"

--- a/.github/workflows/generate-database-er-model.yaml
+++ b/.github/workflows/generate-database-er-model.yaml
@@ -50,10 +50,10 @@ jobs:
           .venv/bin/pip install pymysql jinja2
 
       - name: Install Composer Dependencies
-        run: |
-          echo "Installing Composer dependencies for zmsbackend"
-          (cd zmsbackend && composer install --no-progress --prefer-dist --optimize-autoloader)
-        shell: bash
+        uses: ./.github/actions/composer-install
+        with:
+          working-directory: zmsbackend
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Database and Import Schema
         env:

--- a/.github/workflows/php-build-images.yaml
+++ b/.github/workflows/php-build-images.yaml
@@ -52,6 +52,9 @@ jobs:
         with:
           swap-size-gb: 10
       - name: Build Image
+        env:
+          DOCKER_BUILDKIT: "1"
+          COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
         run: |
           tag="${{ github.ref_name }}"
           if [ "${{ github.ref_type }}" = "branch" ]; then
@@ -63,8 +66,12 @@ jobs:
             # Show the release tag for tag builds (prod releases)
             app_version="$(git describe --tags --always)"
           fi
+          auth_file="$(mktemp)"
+          trap 'rm -f "$auth_file"' EXIT
+          printf '%s' "$COMPOSER_AUTH" > "$auth_file"
           docker build . \
             --file ".resources/Containerfile" \
+            --secret id=composer_auth,src="$auth_file" \
             --tag "ghcr.io/${{ github.repository }}/${{ matrix.module }}:$tag" \
             --build-arg "MODULE=${{ matrix.module }}" \
             --build-arg "PHP_VERSION=${{ matrix.php_version }}" \

--- a/.github/workflows/php-code-quality.yaml
+++ b/.github/workflows/php-code-quality.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   module-code-quality:
@@ -19,9 +20,10 @@ jobs:
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Composer Dependencies
-        run: |
-          cd "${{ matrix.module }}"
-          composer install --no-progress --prefer-dist --optimize-autoloader
+        uses: ./.github/actions/composer-install
+        with:
+          working-directory: ${{ matrix.module }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PHPCS / PSR-12
         run: |

--- a/.github/workflows/php-code-quality.yaml
+++ b/.github/workflows/php-code-quality.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   module-code-quality:

--- a/.github/workflows/php-unit-tests.yaml
+++ b/.github/workflows/php-unit-tests.yaml
@@ -41,10 +41,10 @@ jobs:
           echo "xdebug.start_with_request=yes" >> /tmp/php/conf.d/xdebug.ini
 
       - name: Install Composer Dependencies
-        run: |
-          set -e
-          cd "${{ matrix.module }}"
-          composer install --no-progress --prefer-dist --optimize-autoloader
+        uses: ./.github/actions/composer-install
+        with:
+          working-directory: ${{ matrix.module }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unit Tests with Coverage
         env:
@@ -141,10 +141,10 @@ jobs:
       - name: Configure Git Safe Directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Composer Dependencies
-        run: |
-          echo "Installing Composer dependencies for zmsbackend"
-          (cd zmsbackend && composer install --no-progress --prefer-dist --optimize-autoloader)
-        shell: bash
+        uses: ./.github/actions/composer-install
+        with:
+          working-directory: zmsbackend
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import Test Data and Run Unit Tests
         env:
@@ -200,13 +200,10 @@ jobs:
           coverage: xdebug
 
       - name: Install Composer Dependencies
-        run: |
-          modules=('zmsclient')
-          for module in "${modules[@]}"; do
-            echo "Installing Composer dependencies for $module"
-            (cd "$module" && composer install --no-progress --prefer-dist --optimize-autoloader)
-          done
-        shell: bash
+        uses: ./.github/actions/composer-install
+        with:
+          working-directory: zmsclient
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unit Tests
         env:

--- a/.resources/Containerfile
+++ b/.resources/Containerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG PHP_VERSION
 FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-dev as build
 RUN useradd --shell /bin/bash --create-home build
@@ -7,9 +8,13 @@ WORKDIR /build/${MODULE}
 USER build:build
 ARG APP_VERSION=version.unknown
 ENV COMPOSER_MIRROR_PATH_REPOS=1
+ENV COMPOSER_MAX_PARALLEL_HTTP=4
 ENV ZMS_VERSION=${APP_VERSION}
 RUN echo "${APP_VERSION}" > VERSION
-RUN make live
+# COMPOSER_AUTH is a BuildKit secret so the GitHub token never lands in an image layer.
+# mode=0444: this RUN executes as USER build, and secret mounts default to 0400 root.
+RUN --mount=type=secret,id=composer_auth,required=false,mode=0444 \
+    bash -c 'if [ -f /run/secrets/composer_auth ]; then export COMPOSER_AUTH="$(cat /run/secrets/composer_auth)"; fi; make live'
 
 ARG PHP_VERSION
 FROM ghcr.io/it-at-m/eappointment/zmsbase:${PHP_VERSION}-base

--- a/.resources/scripts/composer-with-retry.sh
+++ b/.resources/scripts/composer-with-retry.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 # Retry composer on transient GitHub dist failures (HTTP 504/400 on zipball/codeload).
 # Successful packages stay in the Composer cache, so later attempts only refetch failures.
+#
+# COMPOSER is left for Composer itself (alternate composer.json filename).
+# Override the executable with COMPOSER_BINARY if needed.
 set -u
 
 MAX_ATTEMPTS="${COMPOSER_INSTALL_RETRIES:-5}"
 SLEEP_BASE="${COMPOSER_INSTALL_RETRY_SLEEP:-8}"
 export COMPOSER_MAX_PARALLEL_HTTP="${COMPOSER_MAX_PARALLEL_HTTP:-4}"
 
-COMPOSER_BIN="${COMPOSER:-composer}"
+if ! [[ "${MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "COMPOSER_INSTALL_RETRIES must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "${SLEEP_BASE}" =~ ^(0|[1-9][0-9]*)$ ]]; then
+  echo "COMPOSER_INSTALL_RETRY_SLEEP must be a non-negative integer" >&2
+  exit 2
+fi
+
+COMPOSER_BIN="${COMPOSER_BINARY:-composer}"
 
 if [ "$#" -eq 0 ]; then
   echo "Usage: $0 <composer-args...>" >&2

--- a/.resources/scripts/composer-with-retry.sh
+++ b/.resources/scripts/composer-with-retry.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Retry composer on transient GitHub dist failures (HTTP 504/400 on zipball/codeload).
+# Successful packages stay in the Composer cache, so later attempts only refetch failures.
+set -u
+
+MAX_ATTEMPTS="${COMPOSER_INSTALL_RETRIES:-5}"
+SLEEP_BASE="${COMPOSER_INSTALL_RETRY_SLEEP:-8}"
+export COMPOSER_MAX_PARALLEL_HTTP="${COMPOSER_MAX_PARALLEL_HTTP:-4}"
+
+COMPOSER_BIN="${COMPOSER:-composer}"
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <composer-args...>" >&2
+  exit 2
+fi
+
+attempt=1
+while true; do
+  if "${COMPOSER_BIN}" "$@"; then
+    exit 0
+  fi
+  if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+    echo "composer failed after ${MAX_ATTEMPTS} attempts" >&2
+    exit 1
+  fi
+  sleep_s=$((attempt * SLEEP_BASE))
+  echo "composer failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${sleep_s}s..." >&2
+  attempt=$((attempt + 1))
+  sleep "${sleep_s}"
+done

--- a/zmsadmin/Makefile
+++ b/zmsadmin/Makefile
@@ -32,7 +32,7 @@ materialize-zmslayout-deps: # copy file:../zmslayout deps (no symlinks; safe for
 	done
 
 live: # init live system
-	composer install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	npm install --legacy-peer-deps
 	$(MAKE) materialize-zmslayout-deps
 	npm run build

--- a/zmsbackend/Makefile
+++ b/zmsbackend/Makefile
@@ -10,5 +10,5 @@ dev: # init development system
 	composer update
 
 live: # init live system, delete unnecessary libs
-	composer install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	bin/configure

--- a/zmscalldisplay/Makefile
+++ b/zmscalldisplay/Makefile
@@ -24,7 +24,7 @@ js: now
 
 
 live: # init live system
-	composer install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	npm install --legacy-peer-deps
 	npm run build
 	npm install requirejs --no-save --legacy-peer-deps

--- a/zmscitizenapi/Makefile
+++ b/zmscitizenapi/Makefile
@@ -11,7 +11,7 @@ dev: # init development system
 	npm install
 
 live: # init live system, delete unnecessary libs
-	composer install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	bin/configure
 	npm install
 	npm run build

--- a/zmsmessaging/Makefile
+++ b/zmsmessaging/Makefile
@@ -10,7 +10,7 @@ fix: # run code fixing
 	php ../../bin/phpcbf --standard=psr2 tests/
 
 live: # init live system, delete unnecessary libs
-	composer install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 
 dev: # init development system
 	composer update

--- a/zmsstatistic/Makefile
+++ b/zmsstatistic/Makefile
@@ -28,7 +28,7 @@ materialize-zmslayout-deps: # copy file:../zmslayout deps (no symlinks; safe for
 	done
 
 live: # init live system
-	composer install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	npm install --legacy-peer-deps
 	$(MAKE) materialize-zmslayout-deps
 	npm run build

--- a/zmsticketprinter/Makefile
+++ b/zmsticketprinter/Makefile
@@ -25,7 +25,7 @@ fix: # run code fixing
 	npm run fix
 
 live: # init live system
-	$(COMPOSER) install --no-dev --prefer-dist --optimize-autoloader
+	COMPOSER=$(COMPOSER) bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	npm install --legacy-peer-deps
 	npm run build
 	npm install requirejs --no-save --legacy-peer-deps

--- a/zmsticketprinter/Makefile
+++ b/zmsticketprinter/Makefile
@@ -1,5 +1,3 @@
-COMPOSER=composer
-
 help:
 	grep -P "^\w+:" Makefile|sort|perl -pe 's/^(\w+):([^\#]+)(\#\s*(.*))?/\1\n\t\4\n/'
 
@@ -8,7 +6,7 @@ now: # Dummy target
 build: css js # Build javascript and css
 
 update: # update with devel composer.json
-	COMPOSER=composer.devel.json $(COMPOSER) update
+	COMPOSER=composer.devel.json composer update
 
 css:
 	npm run css
@@ -25,14 +23,14 @@ fix: # run code fixing
 	npm run fix
 
 live: # init live system
-	COMPOSER_BINARY="$(COMPOSER)" bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
+	bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	npm install --legacy-peer-deps
 	npm run build
 	npm install requirejs --no-save --legacy-peer-deps
 	mkdir -p public/_libs/requirejs && cp -r node_modules/requirejs/* public/_libs/requirejs/
 
 dev: # init development system
-	$(COMPOSER) update
+	composer update
 	npm install
 
 coverage:

--- a/zmsticketprinter/Makefile
+++ b/zmsticketprinter/Makefile
@@ -25,7 +25,7 @@ fix: # run code fixing
 	npm run fix
 
 live: # init live system
-	COMPOSER=$(COMPOSER) bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
+	COMPOSER_BINARY="$(COMPOSER)" bash ../.resources/scripts/composer-with-retry.sh install --no-dev --prefer-dist --optimize-autoloader
 	npm install --legacy-peer-deps
 	npm run build
 	npm install requirejs --no-save --legacy-peer-deps


### PR DESCRIPTION
## Summary
- Mitigate flaky Composer `HTTP/2 504` zipball failures from `api.github.com` in PHP unit tests and image builds ([#3116](https://github.com/it-at-m/eappointment/issues/3116)).
- Authenticate Composer with `GITHUB_TOKEN`, cache packages under the workspace, and retry installs (CI action + `make live`).
- Pass GitHub OAuth into Docker builds as a BuildKit secret so the token is not baked into image layers.

## Test plan
- [x] Confirm PHP unit tests install Composer dependencies without zipball 504s (retries if GitHub is briefly unavailable).
- [x] Confirm PHP image builds (`make live`) succeed with the BuildKit `composer_auth` secret.
- [x] Re-run a previously failing Actions job / wait for this PR’s combined PHP workflow.

Closes #3116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated, cached Composer dependency installation with configurable options.
  - Added automatic retries for transient Composer download failures.
  - Added secure credential handling during container image builds.

- **Improvements**
  - Updated build and testing workflows to use consistent dependency installation.
  - Optimized Composer network concurrency and production dependency installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->