### PR TITLE
fix(GH): run a single Trivy config on pull requests

### DIFF
--- a/.github/workflows/combined-workflow-with-docs.yaml
+++ b/.github/workflows/combined-workflow-with-docs.yaml
@@ -14,7 +14,6 @@ permissions:
   pages: write
   id-token: write
   actions: write
-  security-events: write
 
 jobs:
   call-php-code-quality:
@@ -25,10 +24,6 @@ jobs:
 
   call-zmscitizenview-coverage:
     uses: ./.github/workflows/zmscitizenview-coverage.yaml
-
-  # OWASP/dependency reports are no longer published to GitHub Pages; this job still runs for CI visibility.
-  call-trivy-security-checks:
-    uses: ./.github/workflows/trivy.yaml
 
   aggregate-reports:
     needs: [call-php-unit-tests, call-zmscitizenview-coverage]

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -18,7 +18,6 @@ jobs:
         branch: [main, next]
     permissions:
       contents: read
-      security-events: write
       actions: read
     steps:
       - name: Checkout repository
@@ -50,7 +49,6 @@ jobs:
         run: |
           trivy convert --format table --output trivy-results.txt trivy-report.json
           cat trivy-results.txt
-          trivy convert --format sarif --output trivy-results.sarif trivy-report.json
 
       - name: Upload vulnerability scan results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -59,13 +57,6 @@ jobs:
           name: trivy-report-${{ matrix.branch }}
           path: trivy-report.json
           retention-days: 7
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy-${{ matrix.branch }}
 
   notify-webex:
     name: 📣 Notify Webex on scheduled failure

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -2,12 +2,15 @@ name: 🛡️ Trivy Security Check
 
 on:
   pull_request:
-  workflow_call:
   workflow_dispatch:
   push:
     branches:
       - main
       - next
+
+concurrency:
+  group: trivy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -20,10 +20,40 @@ jobs:
       TRIVY_SKIP_VERSION_CHECK: "true"
     permissions:
       contents: read
-      security-events: write
       actions: read
     steps:
-      - name: Run Trivy Security check on Repository
-        uses: it-at-m/lhm_actions/action-templates/actions/action-trivy@54b32c7d11363cad45838c9a3d8a8560b93f0e8c # v1.5.4
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Trivy vulnerability scanner in repository mode
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_SKIP_VERSION_CHECK: "true"
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          exit-code: "1"
+          timeout: 15m0s
+          trivyignores: .trivyignore
+          output: trivy-report.json
+
+      - name: Convert Trivy report
+        if: always() && hashFiles('trivy-report.json') != ''
+        shell: bash
+        env:
+          # convert in 0.70.0 has no --skip-version-check; a set env maps to that flag and fails
+          TRIVY_SKIP_VERSION_CHECK: ""
+        run: |
+          trivy convert --format table --output trivy-results.txt trivy-report.json
+          cat trivy-results.txt
+
+      - name: Upload vulnerability scan results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: trivy-report
+          path: trivy-report.json
+          retention-days: 7

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -20,40 +20,10 @@ jobs:
       TRIVY_SKIP_VERSION_CHECK: "true"
     permissions:
       contents: read
+      security-events: write
       actions: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Run Trivy vulnerability scanner in repository mode
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - name: Run Trivy Security check on Repository
+        uses: it-at-m/lhm_actions/action-templates/actions/action-trivy@54b32c7d11363cad45838c9a3d8a8560b93f0e8c # v1.5.4
         env:
           TRIVY_SKIP_VERSION_CHECK: "true"
-        with:
-          scan-type: fs
-          scan-ref: .
-          format: json
-          exit-code: "1"
-          timeout: 15m0s
-          trivyignores: .trivyignore
-          output: trivy-report.json
-
-      - name: Convert Trivy report
-        if: always() && hashFiles('trivy-report.json') != ''
-        shell: bash
-        env:
-          # convert in 0.70.0 has no --skip-version-check; a set env maps to that flag and fails
-          TRIVY_SKIP_VERSION_CHECK: ""
-        run: |
-          trivy convert --format table --output trivy-results.txt trivy-report.json
-          cat trivy-results.txt
-
-      - name: Upload vulnerability scan results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: trivy-report
-          path: trivy-report.json
-          retention-days: 7


### PR DESCRIPTION
## Summary
- The extra **Code scanning results / Trivy** check is GitHub comparing PRs to Trivy SARIF identities already stored on **`main`**. Merging into `next` does not change that.
- `action-trivy` always uploads SARIF, so every PR created another Code scanning check (and it did not match `main`'s four identities, so it showed **neutral / configurations not found**).
- PRs/`main`/`next` now run a single **Actions** Trivy job that fails on findings and uploads an artifact. No SARIF, so GitHub should not add a second check once leftover analyses on `main` are gone.
- Also drop the duplicate `next` `workflow_call` and scheduled SARIF uploads.

## Test plan
- [ ] This PR should still show **🛡️ Trivy Security Check** as the workflow job.
- [ ] After leftover Trivy analyses on `main` are deleted, new PRs should not get the skipped/neutral **Code scanning results / Trivy** check.