### PR TITLE
fix(ZMS): add safe Mellon types for Psalm notes

### DIFF
--- a/mellon/src/Mellon/Collection.php
+++ b/mellon/src/Mellon/Collection.php
@@ -20,7 +20,7 @@ class Collection
       */
     protected $validatorList = array();
 
-    public function __construct($validatorList)
+    public function __construct(array $validatorList = [])
     {
         $this->validatorList = $validatorList;
         $flat = $this->getFlatArray();
@@ -61,7 +61,7 @@ class Collection
     /**
      * @return Array
      */
-    public function getStatus($sub = null, $getUnvalidated = false)
+    public function getStatus(?array $sub = null, bool $getUnvalidated = false)
     {
         $messages = array();
         if (null === $sub) {
@@ -95,7 +95,7 @@ class Collection
     }
 
     /** @psalm-api */
-    public function getValid($parameterName): Parameter
+    public function getValid(string $parameterName): Parameter
     {
         if (isset($this->validatorList[$parameterName])) {
             return $this->validatorList[$parameterName];

--- a/mellon/src/Mellon/Condition.php
+++ b/mellon/src/Mellon/Condition.php
@@ -4,7 +4,7 @@ namespace BO\Mellon;
 
 class Condition
 {
-    protected $collection = [];
+    protected Collection $collection;
 
     public function __construct(Valid ...$validList)
     {

--- a/mellon/src/Mellon/Failure/Exception.php
+++ b/mellon/src/Mellon/Failure/Exception.php
@@ -12,15 +12,14 @@ use BO\Mellon\Valid;
 class Exception extends \Exception
 {
     /**
-     * @var \BO\Mellon\Valid $validator
-     *
+     * @var Valid|null $validator
      */
-    protected $validator = null;
+    protected ?Valid $validator = null;
 
     public function setValidator(Valid $validator): static
     {
         $this->validator = $validator;
-        $this->message = (string)$validator->getMessages();
+        $this->message = (string)($validator->getMessages() ?? '');
         $this->message .=
             "({"
             . $validator->getName()

--- a/mellon/src/Mellon/Failure/Message.php
+++ b/mellon/src/Mellon/Failure/Message.php
@@ -15,9 +15,9 @@ use BO\Mellon\Valid;
   */
 class Message
 {
-    public $message = '';
+    public string $message = '';
 
-    public function __construct($message)
+    public function __construct(string $message)
     {
         $this->message = $message;
     }

--- a/mellon/src/Mellon/Failure/MessageList.php
+++ b/mellon/src/Mellon/Failure/MessageList.php
@@ -10,10 +10,15 @@ namespace BO\Mellon\Failure;
 use BO\Mellon\Valid;
 
 /**
- * @extends \ArrayObject<int, Message>
+ * @extends \ArrayObject<int|null, Message>
  */
 class MessageList extends \ArrayObject
 {
+    public function offsetSet(mixed $key, mixed $value): void
+    {
+        parent::offsetSet($key, $value);
+    }
+
     public function __toString()
     {
         $string = "Validation failed: ";

--- a/mellon/src/Mellon/Parameter.php
+++ b/mellon/src/Mellon/Parameter.php
@@ -16,21 +16,18 @@ abstract class Parameter
     /**
       * value of parameter
       *
-      * @var string|null $value
+      * @var mixed $value
      */
-    protected $value = '';
+    protected mixed $value = '';
 
     /**
       * name of parameter
       *
-      * @var String $name
+      * @var string $name
       */
-    protected $name = '';
+    protected string $name = '';
 
-    /**
-      *
-      */
-    public function __construct($value, $name = '')
+    public function __construct(mixed $value, ?string $name = '')
     {
         $this->setValue($value);
         $this->setName($name);
@@ -39,7 +36,7 @@ abstract class Parameter
     /**
      * @return self
      */
-    protected function setValue($value)
+    protected function setValue(mixed $value): self
     {
         $this->value = $value;
         return $this;
@@ -48,9 +45,9 @@ abstract class Parameter
     /**
      * @return self
      */
-    public function setName($name)
+    public function setName(?string $name): self
     {
-        $this->name = $name;
+        $this->name = $name ?? '';
         return $this;
     }
 

--- a/mellon/src/Mellon/Unvalidated.php
+++ b/mellon/src/Mellon/Unvalidated.php
@@ -15,9 +15,9 @@ namespace BO\Mellon;
 class Unvalidated extends \BO\Mellon\Parameter
 {
     /**
-     * @var callable $setValid
+     * @var callable|null $setValid
      */
-    protected $setValid;
+    protected $setValid = null;
 
     /**
      * Raw value before any validation; safe to use for pre-processing (e.g. trim) before is* methods.
@@ -47,7 +47,7 @@ class Unvalidated extends \BO\Mellon\Parameter
      *
      * @return \BO\Mellon\Valid
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments)
     {
         if (0 !== strpos($name, 'is')) {
             throw new Exception("parameters should validate first");
@@ -81,13 +81,16 @@ class Unvalidated extends \BO\Mellon\Parameter
      *
      * @return \BO\Mellon\Valid
      */
-    protected function findTypedValidator($name)
+    protected function findTypedValidator(string $name): Valid
     {
         $partList = preg_split('#([A-Z][a-z]+)#', $name, -1, PREG_SPLIT_DELIM_CAPTURE);
         if (isset($partList[1])) {
             $class = __NAMESPACE__ . '\\Valid' . $partList[1];
             if (class_exists($class)) {
                 $newClass = new $class($this->value, $this->name);
+                if (!$newClass instanceof Valid) {
+                    throw new Exception("Validation class $class does not exists");
+                }
                 if ($this->setValid) {
                     $callback = $this->setValid;
                     $callback($newClass);

--- a/mellon/src/Mellon/Valid.php
+++ b/mellon/src/Mellon/Valid.php
@@ -17,9 +17,9 @@ class Valid extends \BO\Mellon\Parameter
     /**
       * validation errors
       *
-      * @var Array $messages
+      * @var Failure\MessageList|null $messages
       */
-    private $messages = null;
+    private ?Failure\MessageList $messages = null;
 
     /**
       * TRUE if value is validated, at least once
@@ -38,9 +38,9 @@ class Valid extends \BO\Mellon\Parameter
     /**
       * default value to return
       *
-      * @var String $default
+      * @var mixed $default
       */
-    protected $default = null;
+    protected mixed $default = null;
 
     /**
      * validate a value using PHP builtin function filter_var()
@@ -49,9 +49,9 @@ class Valid extends \BO\Mellon\Parameter
      * @param int $filter see documentation for filter_var()
      * @param int|array $options see documentation for filter_var()
      *
-     * @return self
+     * @return static
      */
-    protected function validate($message, $filter, $options = 0)
+    protected function validate($message, $filter, $options = 0): static
     {
         if (null !== $this->value) {
             $this->validated = true;
@@ -177,7 +177,7 @@ class Valid extends \BO\Mellon\Parameter
     /**
      * Allow only values equal to the given value
      *
-     * @param Int $value value to compare
+     * @param array $list values to compare
      * @param String $message error message in case of failure
      *
      * @return self
@@ -198,7 +198,7 @@ class Valid extends \BO\Mellon\Parameter
     /**
      * Allow only values equal to the given value
      *
-     * @param Int $value value to compare
+     * @param array $list values to compare
      * @param String $message error message in case of failure
      *
      * @return self
@@ -286,7 +286,7 @@ class Valid extends \BO\Mellon\Parameter
     /**
      * Returns a list of error messages
      *
-     * @return Array
+     * @return Failure\MessageList|null
      */
     public function getMessages()
     {
@@ -327,7 +327,7 @@ class Valid extends \BO\Mellon\Parameter
      *
      * @throws \Exception
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments)
     {
         if (0 === strpos($name, 'is')) {
             throw new Exception(

--- a/mellon/src/Mellon/ValidBool.php
+++ b/mellon/src/Mellon/ValidBool.php
@@ -27,10 +27,10 @@ class ValidBool extends Valid
      *
      * @param String $message error message in case of failure
      *
-     * @return self
+     * @return static
      * @psalm-api
      */
-    public function isBool($message = 'not a boolean value')
+    public function isBool($message = 'not a boolean value'): static
     {
         return $this->validate($message, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
     }

--- a/mellon/src/Mellon/ValidDatetime.php
+++ b/mellon/src/Mellon/ValidDatetime.php
@@ -11,10 +11,12 @@ use DateTime;
 
 class ValidDatetime extends Valid
 {
-    protected $dateTime;
+    protected DateTimeImmutable|false|null $dateTime = null;
 
-    public function isDatetime($message = 'Please enter a valid date', $format = false): Valid
-    {
+    public function isDatetime(
+        string $message = 'Please enter a valid date',
+        string|false $format = false
+    ): Valid {
         $this->validated = true;
         $date = $this->value;
         if ($date) {
@@ -34,7 +36,7 @@ class ValidDatetime extends Valid
         return $this;
     }
 
-    public function isOldEnough($years = 18, $message = 'Minimum age of 18 years is required'): Valid
+    public function isOldEnough(int $years = 18, string $message = 'Minimum age of 18 years is required'): Valid
     {
         if ($this->dateTime instanceof \DateTimeInterface) {
             $now = new DateTime();

--- a/mellon/src/Mellon/ValidFile.php
+++ b/mellon/src/Mellon/ValidFile.php
@@ -22,9 +22,12 @@ class ValidFile extends Valid
      * @return self
      */
 
-    protected $fileName = '';
+    protected string $fileName = '';
 
-    protected $acceptableTypes = array(
+    /**
+     * @var array<string, string>
+     */
+    protected array $acceptableTypes = array(
         'pdf' => 'application/pdf',
         'jpeg' => 'image/jpeg',
         'jpg' => 'image/jpg',
@@ -32,7 +35,7 @@ class ValidFile extends Valid
         'png' => 'image/png'
     );
 
-    public function isFile($name = 'fileupload', $message = 'No valid file found.'): static
+    public function isFile(string $name = 'fileupload', string $message = 'No valid file found.'): static
     {
         $this->fileName = $name;
         $this->validated = true;
@@ -42,7 +45,7 @@ class ValidFile extends Valid
         return $this;
     }
 
-    public function hasType($type = 'jpeg', $message = 'Invalid file type.'): static
+    public function hasType(string $type = 'jpeg', string $message = 'Invalid file type.'): static
     {
         if (isset($_FILES[$this->fileName])) {
             if (
@@ -55,7 +58,7 @@ class ValidFile extends Valid
         return $this;
     }
 
-    public function hasMaxSize($maxSize = 50, $message = 'File size not valid.'): static
+    public function hasMaxSize(int $maxSize = 50, string $message = 'File size not valid.'): static
     {
         $maxByteSize = $maxSize * 1000 * 1024;
         if (isset($_FILES[$this->fileName])) {

--- a/mellon/src/Mellon/ValidJson.php
+++ b/mellon/src/Mellon/ValidJson.php
@@ -15,8 +15,8 @@ namespace BO\Mellon;
   */
 class ValidJson extends Valid
 {
-    protected $originalJsonString = null;
-    protected $defaultJsonString = '{}';
+    protected ?string $originalJsonString = null;
+    protected string $defaultJsonString = '{}';
 
     /**
      * Allow only valid json
@@ -28,13 +28,13 @@ class ValidJson extends Valid
      */
     public function isJson($message = null)
     {
-        $this->originalJsonString = $this->value;
-        $undeclaredMessage = $message;
-        if (null === $message) {
-            $undeclaredMessage = "Json: Empty";
-        }
+        $this->originalJsonString = is_string($this->value) ? $this->value : null;
+        $undeclaredMessage = $message ?? 'Json: Empty';
         $this->isDeclared($undeclaredMessage);
         $jsonString = $this->value;
+        if (!is_string($jsonString)) {
+            return $this;
+        }
         $array = json_decode($jsonString, true);
         if (null === $array && $jsonString) {
             if (null === $message) {
@@ -64,12 +64,12 @@ class ValidJson extends Valid
      * Set a default string value if a string does not validate
      * The parsed value like an array or an object should be set by setDefault()
      *
-     * @param String $value
+     * @param string $defaultJsonString
      *
      * @return self
      * @psalm-api
      */
-    public function setDefaultJson($defaultJsonString)
+    public function setDefaultJson(string $defaultJsonString)
     {
             $this->defaultJsonString = $defaultJsonString;
             return $this;
@@ -85,6 +85,6 @@ class ValidJson extends Valid
         if ($this->hasFailed() || !$this->validated) {
             return $this->defaultJsonString;
         }
-        return $this->originalJsonString;
+        return $this->originalJsonString ?? '';
     }
 }

--- a/mellon/src/Mellon/ValidNumber.php
+++ b/mellon/src/Mellon/ValidNumber.php
@@ -17,10 +17,10 @@ class ValidNumber extends Valid
      *
      * @param String $message error message in case of failure
      *
-     * @return self
+     * @return static
      * @psalm-api
      */
-    public function isNumber($message = 'no valid number')
+    public function isNumber($message = 'no valid number'): static
     {
         return $this->validate($message, FILTER_VALIDATE_INT);
     }


### PR DESCRIPTION
## Summary
- Add types/docs on the Mellon files with open Psalm notes, without changing the intentional falsy checks (`isRequired`, JSON/datetime empty handling).
- Keep parameter names nullable (`?string`) because `Validator::value()` passes `null`.
- `$value` stays `mixed` so array/JSON validators still work.

## Test plan
- [ ] Mellon PHPUnit passes
- [ ] Psalm notes on the listed Mellon paths drop on the next scan
- [ ] Callers that omit a parameter name still construct `Unvalidated`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation reliability through clearer input handling and more consistent error behavior.
  - Invalid validator implementations are now detected and reported instead of being used unexpectedly.
  - JSON validation now handles non-string values and missing original content more safely.
  - Validation messages and status results behave more consistently when values are empty or unavailable.

- **Refactor**
  - Added stronger type checks across validation inputs and results, helping identify incorrect values earlier while preserving existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->