### PR TITLE
fix(ZMS): resolve zmsdldb Psalm code scanning notes

### DIFF
--- a/zmsdldb/bootstrap.php
+++ b/zmsdldb/bootstrap.php
@@ -12,10 +12,12 @@ if (file_exists(APP_PATH . '/vendor/autoload.php')) {
 } else {
     define('VENDOR_PATH', APP_PATH . '/../..');
 }
+/** @psalm-suppress UnresolvableInclude */
 require_once(VENDOR_PATH . '/autoload.php');
 
 
 // initialize the static \App singleton
+/** @psalm-suppress UnresolvableInclude */
 require_once(APP_PATH . '/config.php');
 
 // Initialize App::$now if not already set

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -17,12 +17,12 @@ if (!defined('MYSQL_DATABASE')) {
     define('MYSQL_DATABASE', getenv('MYSQL_DATABASE') ? getenv('MYSQL_DATABASE') : 'zmsbo');
 }
 // MYSQL_PORT of type "tcp://127.0.0.1:3306"
-/** @psalm-suppress RiskyTruthyFalsyComparison */
-if (getenv('MYSQL_PORT')) {
+$mysqlPort = getenv('MYSQL_PORT');
+if (is_string($mysqlPort) && $mysqlPort !== '') {
     $dsn = "mysql:dbname=" . MYSQL_DATABASE . ";host=";
-    $dsn .= parse_url(getenv('MYSQL_PORT'), PHP_URL_HOST);
+    $dsn .= parse_url($mysqlPort, PHP_URL_HOST);
     $dsn .= ';port=';
-    $dsn .= parse_url(getenv('MYSQL_PORT'), PHP_URL_PORT);
+    $dsn .= parse_url($mysqlPort, PHP_URL_PORT);
     if (!defined('DSN_RW')) {
         define('DSN_RW', $dsn);
     }
@@ -32,10 +32,10 @@ if (getenv('MYSQL_PORT')) {
     }
 }
 // MYSQL_PORT_RO for readonly access of type "tcp://127.0.0.1:3306"
-/** @psalm-suppress RiskyTruthyFalsyComparison */
-if (getenv('MYSQL_PORT_RO')) {
+$mysqlPortRo = getenv('MYSQL_PORT_RO');
+if (is_string($mysqlPortRo) && $mysqlPortRo !== '') {
     // Allow simple load balancing with multiple values
-    $mysqlPortList = explode(',', getenv('MYSQL_PORT_RO'));
+    $mysqlPortList = explode(',', $mysqlPortRo);
     $mysqlPortRO = trim($mysqlPortList[array_rand($mysqlPortList)]);
     $dsn = "mysql:dbname=" . MYSQL_DATABASE . ";host=";
     $dsn .= parse_url($mysqlPortRO, PHP_URL_HOST);
@@ -101,7 +101,7 @@ class App extends \BO\Zmsbackend\Application
 }
 
 // Uncomment the following line for testing data with vendor/bin/importTestData
-/** @psalm-suppress RiskyTruthyFalsyComparison */
-if (getenv('ZMS_TIMEADJUST')) {
-    App::$now = new DateTimeImmutable(date(getenv('ZMS_TIMEADJUST')), new DateTimeZone('Europe/Berlin'));
+$timeAdjust = getenv('ZMS_TIMEADJUST');
+if (is_string($timeAdjust) && $timeAdjust !== '') {
+    App::$now = new DateTimeImmutable(date($timeAdjust), new DateTimeZone('Europe/Berlin'));
 }

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -20,9 +20,9 @@ if (!defined('MYSQL_DATABASE')) {
 $mysqlPort = getenv('MYSQL_PORT');
 if (is_string($mysqlPort) && $mysqlPort !== '') {
     $dsn = "mysql:dbname=" . MYSQL_DATABASE . ";host=";
-    $dsn .= parse_url($mysqlPort, PHP_URL_HOST);
+    $dsn .= (string) parse_url($mysqlPort, PHP_URL_HOST);
     $dsn .= ';port=';
-    $dsn .= parse_url($mysqlPort, PHP_URL_PORT);
+    $dsn .= (string) parse_url($mysqlPort, PHP_URL_PORT);
     if (!defined('DSN_RW')) {
         define('DSN_RW', $dsn);
     }
@@ -38,9 +38,9 @@ if (is_string($mysqlPortRo) && $mysqlPortRo !== '') {
     $mysqlPortList = explode(',', $mysqlPortRo);
     $mysqlPortRO = trim($mysqlPortList[array_rand($mysqlPortList)]);
     $dsn = "mysql:dbname=" . MYSQL_DATABASE . ";host=";
-    $dsn .= parse_url($mysqlPortRO, PHP_URL_HOST);
+    $dsn .= (string) parse_url($mysqlPortRO, PHP_URL_HOST);
     $dsn .= ';port=';
-    $dsn .= parse_url($mysqlPortRO, PHP_URL_PORT);
+    $dsn .= (string) parse_url($mysqlPortRO, PHP_URL_PORT);
     if (!defined('DSN_RO')) {
         define('DSN_RO', $dsn);
     }

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -64,6 +64,7 @@ class App extends \BO\Zmsbackend\Application
     const bool DEBUG = false;
     const bool DB_ENABLE_WSREPSYNCWAIT = true;
     /**
+     * @psalm-suppress InvalidConstantAssignmentValue
      * @var String DB_DSN_READONLY
      */
     const string DB_DSN_READONLY = DSN_RO;
@@ -74,11 +75,13 @@ class App extends \BO\Zmsbackend\Application
     const string DB_DSN_READWRITE = DSN_RW;
 
     /**
+     * @psalm-suppress InvalidConstantAssignmentValue
      * @var String DB_USERNAME
      */
     const string DB_USERNAME = MYSQL_USER;
 
     /**
+     * @psalm-suppress InvalidConstantAssignmentValue
      * @var String DB_PASSWORD
      */
     const string DB_PASSWORD = MYSQL_PASSWORD;

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -87,7 +87,7 @@ class App extends \BO\Zmsbackend\Application
      * Use caching
      *
      */
-    const TWIG_CACHE = ZMS_DLDB_TWIG_CACHE;
+    const string|false TWIG_CACHE = ZMS_DLDB_TWIG_CACHE;
     const string MODULE_NAME = 'zmsdldb';
 
     /** Fallback when settings key d115.openingTime is unset */

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -54,6 +54,9 @@ $value = getenv('ZMS_DLDB_TWIG_CACHE');
 /** @psalm-suppress RiskyTruthyFalsyComparison */
 define('ZMS_DLDB_TWIG_CACHE', ($value === 'false') ? false : ($value ?: '/cache/'));
 
+/**
+ * @psalm-suppress InvalidConstantAssignmentValue
+ */
 class App extends \BO\Zmsbackend\Application
 {
     const string APP_PATH = __DIR__;

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -18,7 +18,7 @@ if (!defined('MYSQL_DATABASE')) {
 }
 // MYSQL_PORT of type "tcp://127.0.0.1:3306"
 $mysqlPort = getenv('MYSQL_PORT');
-if (is_string($mysqlPort) && $mysqlPort !== '') {
+if (is_string($mysqlPort) && $mysqlPort !== '' && $mysqlPort !== '0') {
     $dsn = "mysql:dbname=" . MYSQL_DATABASE . ";host=";
     $dsn .= (string) parse_url($mysqlPort, PHP_URL_HOST);
     $dsn .= ';port=';
@@ -33,7 +33,7 @@ if (is_string($mysqlPort) && $mysqlPort !== '') {
 }
 // MYSQL_PORT_RO for readonly access of type "tcp://127.0.0.1:3306"
 $mysqlPortRo = getenv('MYSQL_PORT_RO');
-if (is_string($mysqlPortRo) && $mysqlPortRo !== '') {
+if (is_string($mysqlPortRo) && $mysqlPortRo !== '' && $mysqlPortRo !== '0') {
     // Allow simple load balancing with multiple values
     $mysqlPortList = explode(',', $mysqlPortRo);
     $mysqlPortRO = trim($mysqlPortList[array_rand($mysqlPortList)]);
@@ -108,6 +108,6 @@ class App extends \BO\Zmsbackend\Application
 
 // Uncomment the following line for testing data with vendor/bin/importTestData
 $timeAdjust = getenv('ZMS_TIMEADJUST');
-if (is_string($timeAdjust) && $timeAdjust !== '') {
+if (is_string($timeAdjust) && $timeAdjust !== '' && $timeAdjust !== '0') {
     App::$now = new DateTimeImmutable(date($timeAdjust), new DateTimeZone('Europe/Berlin'));
 }

--- a/zmsdldb/config.example.php
+++ b/zmsdldb/config.example.php
@@ -3,17 +3,21 @@
 
 // MYSQL_USER with access to DB
 if (!defined('MYSQL_USER')) {
+    /** @psalm-suppress RiskyTruthyFalsyComparison */
     define('MYSQL_USER', getenv('MYSQL_USER') ? getenv('MYSQL_USER') : 'root');
 }
 // MYSQL_PASSWORD
 if (!defined('MYSQL_PASSWORD')) {
+    /** @psalm-suppress RiskyTruthyFalsyComparison */
     define('MYSQL_PASSWORD', getenv('MYSQL_PASSWORD') ? getenv('MYSQL_PASSWORD') :'zmsbackend');
 }
 // MYSQL_DATABASE is the database name containing the tables
 if (!defined('MYSQL_DATABASE')) {
+    /** @psalm-suppress RiskyTruthyFalsyComparison */
     define('MYSQL_DATABASE', getenv('MYSQL_DATABASE') ? getenv('MYSQL_DATABASE') : 'zmsbo');
 }
 // MYSQL_PORT of type "tcp://127.0.0.1:3306"
+/** @psalm-suppress RiskyTruthyFalsyComparison */
 if (getenv('MYSQL_PORT')) {
     $dsn = "mysql:dbname=" . MYSQL_DATABASE . ";host=";
     $dsn .= parse_url(getenv('MYSQL_PORT'), PHP_URL_HOST);
@@ -28,6 +32,7 @@ if (getenv('MYSQL_PORT')) {
     }
 }
 // MYSQL_PORT_RO for readonly access of type "tcp://127.0.0.1:3306"
+/** @psalm-suppress RiskyTruthyFalsyComparison */
 if (getenv('MYSQL_PORT_RO')) {
     // Allow simple load balancing with multiple values
     $mysqlPortList = explode(',', getenv('MYSQL_PORT_RO'));
@@ -46,6 +51,7 @@ if (getenv('MYSQL_PORT_RO')) {
 }
 
 $value = getenv('ZMS_DLDB_TWIG_CACHE');
+/** @psalm-suppress RiskyTruthyFalsyComparison */
 define('ZMS_DLDB_TWIG_CACHE', ($value === 'false') ? false : ($value ?: '/cache/'));
 
 class App extends \BO\Zmsbackend\Application
@@ -95,6 +101,7 @@ class App extends \BO\Zmsbackend\Application
 }
 
 // Uncomment the following line for testing data with vendor/bin/importTestData
+/** @psalm-suppress RiskyTruthyFalsyComparison */
 if (getenv('ZMS_TIMEADJUST')) {
     App::$now = new DateTimeImmutable(date(getenv('ZMS_TIMEADJUST')), new DateTimeZone('Europe/Berlin'));
 }

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -12,9 +12,9 @@ namespace BO\Zmsdldb;
  */
 class AbstractAccess
 {
-    protected static $showDeprecated = false;
+    protected static bool $showDeprecated = false;
 
-    protected $accessInstance = array(
+    protected mixed $accessInstance = array(
         'de' => array(
             'Authority' => null,
             'Borough' => null,
@@ -37,7 +37,7 @@ class AbstractAccess
         )
     );
 
-    protected static $accessInstanceTypes = [
+    protected static mixed $accessInstanceTypes = [
         'Authority' => null,
         'Borough' => null,
         'Link' => null,

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -105,6 +105,7 @@ class AbstractAccess
         }
         $accessInstance = $this->getInstanceCompatibilities();
         if (
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             $instanceName
             && $instanceName != 'Missing'
             && method_exists($accessInstance[$instanceName], $actionType . $actionName)

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -104,8 +104,8 @@ class AbstractAccess
             }
         }
         $accessInstance = $this->getInstanceCompatibilities();
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (
-            /** @psalm-suppress RiskyTruthyFalsyComparison */
             $instanceName
             && $instanceName != 'Missing'
             && method_exists($accessInstance[$instanceName], $actionType . $actionName)

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -87,6 +87,7 @@ class AbstractAccess
         $actionName = 'Nothing';
         if (0 === strpos($functionName, 'fetch')) {
             $actionType = 'fetch';
+            /** @var string|null $instanceName */
             $instanceName = $this->getInstanceOnName($functionName, 5);
             $actionName = substr($functionName, 5 + strlen($instanceName ?? ''));
             if (! $actionName) {
@@ -94,6 +95,7 @@ class AbstractAccess
             }
         } elseif (0 === strpos($functionName, 'search')) {
             $actionType = 'search';
+            /** @var string|null $instanceName */
             $instanceName = $this->getInstanceOnName($functionName, 6);
             $actionName = substr($functionName, 6 + strlen($instanceName ?? ''));
             if (! $actionName) {

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -122,8 +122,7 @@ class AbstractAccess
     }
 
     /**
-     * @return string InstanceName
-     *
+     * @return string|null InstanceName
      */
     protected function getInstanceOnName(mixed $name, int $position = 0)
     {

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -154,44 +154,60 @@ class AbstractAccess
         throw new Exception("Locale for accessing $instanceName does not exists");
     }
 
-    public function fromAuthority(string $locale = 'de'): \BO\Zmsdldb\File\Base
+    public function fromAuthority(string $locale = 'de'): File\Authority
     {
-        return $this->from('Authority', $locale);
+        /** @var File\Authority $instance */
+        $instance = $this->from('Authority', $locale);
+        return $instance;
     }
 
-    public function fromBorough(): \BO\Zmsdldb\File\Base
+    public function fromBorough(): File\Borough
     {
-        return $this->from('Borough');
+        /** @var File\Borough $instance */
+        $instance = $this->from('Borough');
+        return $instance;
     }
 
     /** @psalm-api */
-    public function fromLink(string $locale = 'de'): \BO\Zmsdldb\File\Base
+    public function fromLink(string $locale = 'de'): File\Link
     {
-        return $this->from('Link', $locale);
+        /** @var File\Link $instance */
+        $instance = $this->from('Link', $locale);
+        return $instance;
     }
 
-    public function fromLocation(string $locale = 'de'): \BO\Zmsdldb\File\Base
+    public function fromLocation(string $locale = 'de'): File\Location
     {
-        return $this->from('Location', $locale);
+        /** @var File\Location $instance */
+        $instance = $this->from('Location', $locale);
+        return $instance;
     }
 
-    public function fromOffice(): \BO\Zmsdldb\File\Base
+    public function fromOffice(): File\Office
     {
-        return $this->from('Office');
+        /** @var File\Office $instance */
+        $instance = $this->from('Office');
+        return $instance;
     }
 
-    public function fromService(string $locale = 'de'): \BO\Zmsdldb\File\Base
+    public function fromService(string $locale = 'de'): File\Service
     {
-        return $this->from('Service', $locale);
+        /** @var File\Service $instance */
+        $instance = $this->from('Service', $locale);
+        return $instance;
     }
 
-    public function fromSetting(): \BO\Zmsdldb\File\Base
+    public function fromSetting(): File\Setting
     {
-        return $this->from('Setting');
+        /** @var File\Setting $instance */
+        $instance = $this->from('Setting');
+        return $instance;
     }
 
-    public function fromTopic(string $locale = 'de'): \BO\Zmsdldb\File\Base
+    public function fromTopic(string $locale = 'de'): File\Topic
     {
-        return $this->from('Topic', $locale);
+        /** @var File\Topic $instance */
+        $instance = $this->from('Topic', $locale);
+        return $instance;
     }
 }

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -199,10 +199,10 @@ class AbstractAccess
         return $instance;
     }
 
-    public function fromSetting(): File\Setting
+    public function fromSetting(string $locale = 'de'): File\Setting
     {
         /** @var File\Setting $instance */
-        $instance = $this->from('Setting');
+        $instance = $this->from('Setting', $locale);
         return $instance;
     }
 

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -51,7 +51,7 @@ class AbstractAccess
     /**
      * @psalm-api
      */
-    public function addAccessInstanceLocale($locale = 'de'): void
+    public function addAccessInstanceLocale(string $locale = 'de'): void
     {
         if (!isset($this->accessInstance[$locale])) {
             $this->accessInstance[$locale] = static::$accessInstanceTypes;
@@ -77,7 +77,7 @@ class AbstractAccess
      *
      * @return Mixed
      */
-    public function __call($functionName, $functionArguments)
+    public function __call(string $functionName, array $functionArguments)
     {
         if (self::$showDeprecated) {
             trigger_error("Deprecated access function: $functionName");
@@ -123,7 +123,7 @@ class AbstractAccess
      * @return string InstanceName
      *
      */
-    protected function getInstanceOnName($name, int $position = 0)
+    protected function getInstanceOnName(mixed $name, int $position = 0)
     {
         foreach (array_keys($this->getInstanceCompatibilities()) as $instanceName) {
             if ($position === strpos($name, $instanceName)) {
@@ -133,7 +133,7 @@ class AbstractAccess
         return null;
     }
 
-    protected function from(string $instanceName, $locale = 'de'): File\Base
+    protected function from(string $instanceName, string $locale = 'de'): File\Base
     {
         if (array_key_exists($instanceName, $this->accessInstance[$locale])) {
             $instance = $this->accessInstance[$locale][$instanceName];
@@ -154,7 +154,7 @@ class AbstractAccess
         throw new Exception("Locale for accessing $instanceName does not exists");
     }
 
-    public function fromAuthority($locale = 'de')
+    public function fromAuthority(string $locale = 'de')
     {
         return $this->from('Authority', $locale);
     }
@@ -165,12 +165,12 @@ class AbstractAccess
     }
 
     /** @psalm-api */
-    public function fromLink($locale = 'de')
+    public function fromLink(string $locale = 'de')
     {
         return $this->from('Link', $locale);
     }
 
-    public function fromLocation($locale = 'de')
+    public function fromLocation(string $locale = 'de')
     {
         return $this->from('Location', $locale);
     }
@@ -180,7 +180,7 @@ class AbstractAccess
         return $this->from('Office');
     }
 
-    public function fromService($locale = 'de')
+    public function fromService(string $locale = 'de')
     {
         return $this->from('Service', $locale);
     }
@@ -190,7 +190,7 @@ class AbstractAccess
         return $this->from('Setting');
     }
 
-    public function fromTopic($locale = 'de')
+    public function fromTopic(string $locale = 'de')
     {
         return $this->from('Topic', $locale);
     }

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -59,7 +59,7 @@ class AbstractAccess
     }
 
 
-    private function getInstanceCompatibilities()
+    private function getInstanceCompatibilities(): mixed
     {
         $accessInstance = $this->accessInstance['de'];
         $accessInstance['Authorities'] = $accessInstance['Authority'];
@@ -154,43 +154,43 @@ class AbstractAccess
         throw new Exception("Locale for accessing $instanceName does not exists");
     }
 
-    public function fromAuthority(string $locale = 'de')
+    public function fromAuthority(string $locale = 'de'): \BO\Zmsdldb\File\Base
     {
         return $this->from('Authority', $locale);
     }
 
-    public function fromBorough()
+    public function fromBorough(): \BO\Zmsdldb\File\Base
     {
         return $this->from('Borough');
     }
 
     /** @psalm-api */
-    public function fromLink(string $locale = 'de')
+    public function fromLink(string $locale = 'de'): \BO\Zmsdldb\File\Base
     {
         return $this->from('Link', $locale);
     }
 
-    public function fromLocation(string $locale = 'de')
+    public function fromLocation(string $locale = 'de'): \BO\Zmsdldb\File\Base
     {
         return $this->from('Location', $locale);
     }
 
-    public function fromOffice()
+    public function fromOffice(): \BO\Zmsdldb\File\Base
     {
         return $this->from('Office');
     }
 
-    public function fromService(string $locale = 'de')
+    public function fromService(string $locale = 'de'): \BO\Zmsdldb\File\Base
     {
         return $this->from('Service', $locale);
     }
 
-    public function fromSetting()
+    public function fromSetting(): \BO\Zmsdldb\File\Base
     {
         return $this->from('Setting');
     }
 
-    public function fromTopic(string $locale = 'de')
+    public function fromTopic(string $locale = 'de'): \BO\Zmsdldb\File\Base
     {
         return $this->from('Topic', $locale);
     }

--- a/zmsdldb/src/Zmsdldb/AbstractAccess.php
+++ b/zmsdldb/src/Zmsdldb/AbstractAccess.php
@@ -199,10 +199,10 @@ class AbstractAccess
         return $instance;
     }
 
-    public function fromSetting(string $locale = 'de'): File\Setting
+    public function fromSetting(): File\Setting
     {
         /** @var File\Setting $instance */
-        $instance = $this->from('Setting', $locale);
+        $instance = $this->from('Setting');
         return $instance;
     }
 

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -40,9 +40,7 @@ class Authorities extends Base
             $authorityId = $location['authority']['id'];
             $this->addAuthority($authorityId, $location['authority']['name']);
             $authority = $this[$authorityId];
-            if ($authority instanceof \BO\Zmsdldb\Entity\Authority) {
-                $authority['locations'][$location['id']] = $location;
-            }
+            $authority['locations'][$location['id']] = $location;
         }
         return $this;
     }
@@ -173,7 +171,9 @@ class Authorities extends Base
                     }
                 }
             } else {
-                $authorityIterator->offsetUnset($key);
+                if ($key !== null) {
+                    $authorityIterator->offsetUnset($key);
+                }
             }
         }
         return $this;

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -41,7 +41,7 @@ class Authorities extends Base
         return $this;
     }
 
-    public function addAuthority($authority_id, $name): static
+    public function addAuthority(mixed $authority_id, mixed $name): static
     {
         if (! $this->hasAuthority($authority_id)) {
             $authority = \BO\Zmsdldb\Entity\Authority::create($name);
@@ -50,7 +50,7 @@ class Authorities extends Base
         return $this;
     }
 
-    public function hasAuthority($authority_id): bool
+    public function hasAuthority(mixed $authority_id): bool
     {
         return $this->offsetExists($authority_id);
     }
@@ -58,7 +58,7 @@ class Authorities extends Base
     /**
      * @psalm-api
      */
-    public function readByExtendedService($service): static
+    public function readByExtendedService(mixed $service): static
     {
         foreach ($service['authorities'] as $authority) {
             if (! $this->hasAuthority($authority['id'])) {
@@ -190,7 +190,7 @@ class Authorities extends Base
         return $authoritylist;
     }
 
-    public function toListWithOfficePath($officepath)
+    public function toListWithOfficePath(mixed $officepath)
     {
         $authoritylist = clone $this;
         foreach ($authoritylist as $key => $authority) {
@@ -206,7 +206,7 @@ class Authorities extends Base
      * @psalm-api
      */
 
-    public function toListWithAssociatedLocations($locationlist)
+    public function toListWithAssociatedLocations(mixed $locationlist)
     {
         $authoritylist = $this->removeLocations();
         foreach ($locationlist as $location) {

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -190,7 +190,7 @@ class Authorities extends Base
         return $authoritylist;
     }
 
-    public function toListWithOfficePath(mixed $officepath)
+    public function toListWithOfficePath(mixed $officepath): \BO\Zmsdldb\Collection\Authorities
     {
         $authoritylist = clone $this;
         foreach ($authoritylist as $key => $authority) {

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -37,8 +37,12 @@ class Authorities extends Base
             )
             && $location['authority']['id']
         ) {
-            $this->addAuthority($location['authority']['id'], $location['authority']['name']);
-            $this[$location['authority']['id']]['locations'][$location['id']] = $location;
+            $authorityId = $location['authority']['id'];
+            $this->addAuthority($authorityId, $location['authority']['name']);
+            $authority = $this[$authorityId];
+            if ($authority instanceof \BO\Zmsdldb\Entity\Authority) {
+                $authority['locations'][$location['id']] = $location;
+            }
         }
         return $this;
     }

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -158,6 +158,9 @@ class Authorities extends Base
     {
         $authorityIterator = $this->getIterator();
         foreach ($authorityIterator as $key => $authority) {
+            if (!$authority instanceof \BO\Zmsdldb\Entity\Authority) {
+                continue;
+            }
             if ($authority->hasAppointments($serviceCsv, $external)) {
                 $locationIterator = $authority['locations']->getIterator();
                 foreach ($locationIterator as $subkey => $location) {

--- a/zmsdldb/src/Zmsdldb/Collection/Authorities.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Authorities.php
@@ -10,6 +10,8 @@ namespace BO\Zmsdldb\Collection;
 /**
  * @SuppressWarnings(TooManyPublicMethods)
  * Methods to apply on this collection
+ *
+ * @extends Base<\BO\Zmsdldb\Entity\Authority>
  */
 class Authorities extends Base
 {

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -30,6 +30,9 @@ class Base extends \ArrayObject
     public function sortWithCollator(string $field = 'name', string $locale = 'de'): static
     {
         $collator = collator_create($locale);
+        if ($collator === null) {
+            throw new \RuntimeException('Could not create collator for locale ' . $locale);
+        }
         $collator->setStrength(\Collator::QUATERNARY);
         $collator->setAttribute(\Collator::QUATERNARY, \Collator::ON);
         $collator->setAttribute(\Collator::CASE_FIRST, \Collator::ON);

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -26,7 +26,7 @@ class Base extends \ArrayObject
     /**
      * @psalm-api
      */
-    public function sortWithCollator($field = 'name', $locale = 'de'): static
+    public function sortWithCollator(string $field = 'name', string $locale = 'de'): static
     {
         $collator = collator_create($locale);
         $collator->setStrength(\Collator::QUATERNARY);

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -17,9 +17,6 @@ class Base extends \ArrayObject
 {
     public function offsetSet(mixed $key, mixed $value): void
     {
-        if ($key === null) {
-            $key = $this->count();
-        }
         parent::offsetSet($key, $value);
     }
 

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -11,10 +11,15 @@ use BO\Zmsdldb\Helper\Sorter;
 
 /**
  * @template T of \BO\Zmsdldb\Entity\Base
- * @extends \ArrayObject<int|string, T>
+ * @extends \ArrayObject<int|string|null, T>
  */
 class Base extends \ArrayObject
 {
+    public function offsetSet(mixed $key, mixed $value): void
+    {
+        parent::offsetSet($key, $value);
+    }
+
     public function sortByName(): static
     {
         $itemList = clone $this;

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -11,7 +11,7 @@ use BO\Zmsdldb\Helper\Sorter;
 
 /**
  * @template T of \BO\Zmsdldb\Entity\Base
- * @extends \ArrayObject<int|string|null, T>
+ * @extends \ArrayObject<int|string, T>
  */
 class Base extends \ArrayObject
 {

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -10,7 +10,8 @@ namespace BO\Zmsdldb\Collection;
 use BO\Zmsdldb\Helper\Sorter;
 
 /**
- * @extends \ArrayObject<int|string, \BO\Zmsdldb\Entity\Base>
+ * @template T of \BO\Zmsdldb\Entity\Base
+ * @extends \ArrayObject<int|string, T>
  */
 class Base extends \ArrayObject
 {

--- a/zmsdldb/src/Zmsdldb/Collection/Base.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Base.php
@@ -17,6 +17,9 @@ class Base extends \ArrayObject
 {
     public function offsetSet(mixed $key, mixed $value): void
     {
+        if ($key === null) {
+            $key = $this->count();
+        }
         parent::offsetSet($key, $value);
     }
 

--- a/zmsdldb/src/Zmsdldb/Collection/Boroughs.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Boroughs.php
@@ -7,6 +7,9 @@
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Borough>
+ */
 class Boroughs extends Base
 {
 }

--- a/zmsdldb/src/Zmsdldb/Collection/Links.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Links.php
@@ -7,6 +7,9 @@
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Link>
+ */
 class Links extends Base
 {
 }

--- a/zmsdldb/src/Zmsdldb/Collection/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Locations.php
@@ -57,7 +57,7 @@ class Locations extends Base
         $list = new self();
         foreach ($this as $location) {
             if ($location->hasAppointments($serviceCsv, $external)) {
-                $list[] = $location;
+                $list->append($location);
             }
         }
         return $list;

--- a/zmsdldb/src/Zmsdldb/Collection/Locations.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Locations.php
@@ -7,6 +7,9 @@
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Location>
+ */
 class Locations extends Base
 {
     public function __clone()

--- a/zmsdldb/src/Zmsdldb/Collection/Offices.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Offices.php
@@ -7,6 +7,9 @@
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Office>
+ */
 class Offices extends Base
 {
 }

--- a/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
+++ b/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
@@ -9,6 +9,9 @@ namespace BO\Zmsdldb\Collection;
 
 use BO\Zmsdldb\Entity\SearchResult as Entity;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\SearchResult>
+ */
 class SearchResults extends Base
 {
     /**

--- a/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
+++ b/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
@@ -46,7 +46,7 @@ class SearchResults extends Base
      *
      * @return null|static
      */
-    public function addSearchResultsData($data): static|null
+    public function addSearchResultsData(mixed $data): static|null
     {
         if ($data) {
             $this[] = $data;

--- a/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
+++ b/zmsdldb/src/Zmsdldb/Collection/SearchResults.php
@@ -36,7 +36,7 @@ class SearchResults extends Base
             foreach ($results as $data) {
                 if (count($data)) {
                     $item = Entity::create($data);
-                    $list[] = $item;
+                    $list->append($item);
                 }
             }
             $list;
@@ -52,7 +52,7 @@ class SearchResults extends Base
     public function addSearchResultsData(mixed $data): static|null
     {
         if ($data) {
-            $this[] = $data;
+            $this->append($data);
             return $this;
         }
         return null;
@@ -67,7 +67,7 @@ class SearchResults extends Base
         foreach ($order as $type) {
             foreach ($this as $item) {
                 if ($item->getType() == $type) {
-                    $list[] = $item;
+                    $list->append($item);
                 }
             }
         }

--- a/zmsdldb/src/Zmsdldb/Collection/Services.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Services.php
@@ -20,7 +20,7 @@ class Services extends Base
         $list = new self();
         foreach ($this as $service) {
             if ($service->containsLocation($locationCsv)) {
-                $list[] = $service;
+                $list->append($service);
             }
         }
         return $list;
@@ -65,7 +65,7 @@ class Services extends Base
         $list = new self();
         foreach ($this as $service) {
             if ($service->isLocale($locale)) {
-                $list[] = $service;
+                $list->append($service);
             }
         }
         return (count($list)) ? $list : null;

--- a/zmsdldb/src/Zmsdldb/Collection/Services.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Services.php
@@ -7,6 +7,9 @@
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Service>
+ */
 class Services extends Base
 {
     /**

--- a/zmsdldb/src/Zmsdldb/Collection/Services.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Services.php
@@ -9,7 +9,10 @@ namespace BO\Zmsdldb\Collection;
 
 class Services extends Base
 {
-    public function containsLocation($locationCsv = null): self
+    /**
+     * @param null|string $locationCsv
+     */
+    public function containsLocation(string|null $locationCsv = null): self
     {
         $list = new self();
         foreach ($this as $service) {
@@ -54,7 +57,7 @@ class Services extends Base
      *
      * @return null|self
      */
-    public function isLocale($locale): self|null
+    public function isLocale(mixed $locale): self|null
     {
         $list = new self();
         foreach ($this as $service) {

--- a/zmsdldb/src/Zmsdldb/Collection/Settings.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Settings.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Base>
+ */
 class Settings extends Base
 {
 }

--- a/zmsdldb/src/Zmsdldb/Collection/Topics.php
+++ b/zmsdldb/src/Zmsdldb/Collection/Topics.php
@@ -7,6 +7,9 @@
 
 namespace BO\Zmsdldb\Collection;
 
+/**
+ * @extends Base<\BO\Zmsdldb\Entity\Topic>
+ */
 class Topics extends Base
 {
     /**

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -30,7 +30,7 @@ class Authority extends Base
 
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (is_array($servicelist) && $servicelist !== []) {
-            $filter = new \Elastica\Filter\Terms('services.service', array_values((array)$servicelist));
+            $filter = new \Elastica\Filter\Terms('services.service', array_values($servicelist));
             $filter->setExecution('and');
             $query->setPostFilter($filter);
         }

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -29,7 +29,7 @@ class Authority extends Base
         $limit = 1000;
 
         /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if ($servicelist && count($servicelist)) {
+        if (is_array($servicelist) && $servicelist !== []) {
             $filter = new \Elastica\Filter\Terms('services.service', array_values((array)$servicelist));
             $filter->setExecution('and');
             $query->setPostFilter($filter);

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -21,7 +21,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList($servicelist = false)
+    public function fetchList(bool $servicelist = false)
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
@@ -49,7 +49,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fromLocationResults($resultList)
+    public function fromLocationResults(mixed $resultList)
     {
         $authorityList = new Collection();
         foreach ($resultList as $result) {

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -7,7 +7,6 @@
 
 namespace BO\Zmsdldb\Elastic;
 
-use BO\Zmsdldb\Entity\Authority as Entity;
 use BO\Zmsdldb\Collection\Authorities as Collection;
 use BO\Zmsdldb\File\Authority as Base;
 

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -21,7 +21,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(bool $servicelist = false)
+    public function fetchList(bool|array $servicelist = false)
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -28,6 +28,7 @@ class Authority extends Base
         $query = \Elastica\Query::create($boolquery);
         $limit = 1000;
 
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($servicelist && count($servicelist)) {
             $filter = new \Elastica\Filter\Terms('services.service', (array)$servicelist);
             $filter->setExecution('and');

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -30,7 +30,7 @@ class Authority extends Base
 
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($servicelist && count($servicelist)) {
-            $filter = new \Elastica\Filter\Terms('services.service', (array)$servicelist);
+            $filter = new \Elastica\Filter\Terms('services.service', array_values((array)$servicelist));
             $filter->setExecution('and');
             $query->setPostFilter($filter);
         }

--- a/zmsdldb/src/Zmsdldb/Elastic/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Authority.php
@@ -20,7 +20,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(bool|array $servicelist = false)
+    public function fetchList(mixed $servicelist = false)
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));

--- a/zmsdldb/src/Zmsdldb/Elastic/Borough.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Borough.php
@@ -7,8 +7,6 @@
 
 namespace BO\Zmsdldb\Elastic;
 
-use BO\Zmsdldb\Entity\Borough as Entity;
-use BO\Zmsdldb\Collection\Boroughs as Collection;
 use BO\Zmsdldb\File\Borough as Base;
 
 /**

--- a/zmsdldb/src/Zmsdldb/Elastic/Link.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Link.php
@@ -17,7 +17,7 @@ class Link extends Base
      * @return Collection
      */
     #[\Override]
-    public function readSearchResultList($query)
+    public function readSearchResultList(mixed $query)
     {
         $boolquery = Helper::boolFilteredQuery();
         $searchquery = new \Elastica\Query\QueryString();

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -42,9 +42,10 @@ class Location extends Base
     /**
      *
      * @return Collection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     #[\Override]
-    public function fetchList(bool|string $service_csv = '')
+    public function fetchList(bool|string $service_csv = '', bool $mixLanguages = false)
     {
         $query = Helper::boolFilteredQuery();
         $limit = 10000;
@@ -74,9 +75,10 @@ class Location extends Base
     /**
      *
      * @return Collection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     #[\Override]
-    public function fetchFromCsv(mixed $location_csv)
+    public function fetchFromCsv(mixed $location_csv, bool $mixLanguages = false)
     {
         $query = Helper::boolFilteredQuery();
         $filter = new \Elastica\Filter\Ids();

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -21,7 +21,7 @@ class Location extends Base
      * @return Entity|false
      */
     #[\Override]
-    public function fetchId($itemId)
+    public function fetchId(mixed $itemId)
     {
         if ($itemId) {
             $query = Helper::boolFilteredQuery();
@@ -44,7 +44,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList($service_csv = '')
+    public function fetchList(string $service_csv = '')
     {
         $query = Helper::boolFilteredQuery();
         $limit = 10000;
@@ -75,7 +75,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchFromCsv($location_csv)
+    public function fetchFromCsv(mixed $location_csv)
     {
         $query = Helper::boolFilteredQuery();
         $filter = new \Elastica\Filter\Ids();
@@ -102,7 +102,7 @@ class Location extends Base
      * @return \BO\Zmsdldb\Collection\Authorities
      * @psalm-api
      */
-    public function searchAll($querystring, $service_csv = '')
+    public function searchAll(mixed $querystring, string $service_csv = '')
     {
         $query = Helper::boolFilteredQuery();
         $mainquery = new \Elastica\Query();
@@ -163,7 +163,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    public function readSearchResultList($query, $service_csv = '')
+    public function readSearchResultList(mixed $query, string $service_csv = '')
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
@@ -220,7 +220,7 @@ class Location extends Base
             ->fromLocationResults($resultList);
     }
 
-    protected function fetchGeoJsonLocations($category, $getAll)
+    protected function fetchGeoJsonLocations(mixed $category, mixed $getAll)
     {
         $query = new \Elastica\Query();
         $query->setSource(['id', 'name', 'address.*', 'geo.*', 'meta.*', 'category.*']);
@@ -251,7 +251,7 @@ class Location extends Base
      * @return ((string|string[])[]|bool|mixed|string)[][]
      *
      */
-    public function fetchGeoJson($category = null, $getAll = false)
+    public function fetchGeoJson(mixed $category = null, bool $getAll = false)
     {
         $resultList = $this->fetchGeoJsonLocations($category, $getAll);
         $geoJson = [];
@@ -288,7 +288,7 @@ class Location extends Base
      *
      * @return Collection
      */
-    public function fetchLocationsForCompilation($authoritys = [], $locations = [])
+    public function fetchLocationsForCompilation(array $authoritys = [], array $locations = [])
     {
         $limit = 1000;
 

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -160,7 +160,7 @@ class Location extends Base
      * search locations
      * this function is similar to self::searchAll() but it might get different boosts in the future
      *
-     * @return Collection
+     * @return \BO\Zmsdldb\Collection\Authorities
      */
     #[\Override]
     public function readSearchResultList(mixed $query, string $service_csv = '')

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -50,7 +50,7 @@ class Location extends Base
         $limit = 10000;
         $query->getFilter()->addMust(Helper::localeFilter($this->locale));
         /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if ($service_csv) {
+        if (is_string($service_csv) && $service_csv !== '') {
             foreach (explode(',', $service_csv) as $service_id) {
                 $filter = new \Elastica\Filter\Term(array(
                     'services.service' => $service_id

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -303,11 +303,11 @@ class Location extends Base
         $boolquery->addMust($localeFilter);
 
         if (!empty($authoritys)) {
-            $authorityFilter = new \Elastica\Query\Terms('authority.id', $authoritys);
+            $authorityFilter = new \Elastica\Query\Terms('authority.id', array_values($authoritys));
             $boolquery->addMust($authorityFilter);
         }
         if (!empty($locations)) {
-            $locationFilter = new \Elastica\Query\Terms('id', $locations);
+            $locationFilter = new \Elastica\Query\Terms('id', array_values($locations));
             $boolquery->addMust($locationFilter);
         }
 

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -44,7 +44,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(string $service_csv = '')
+    public function fetchList(bool|string $service_csv = '')
     {
         $query = Helper::boolFilteredQuery();
         $limit = 10000;

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -49,6 +49,7 @@ class Location extends Base
         $query = Helper::boolFilteredQuery();
         $limit = 10000;
         $query->getFilter()->addMust(Helper::localeFilter($this->locale));
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($service_csv) {
             foreach (explode(',', $service_csv) as $service_id) {
                 $filter = new \Elastica\Filter\Term(array(
@@ -138,6 +139,7 @@ class Location extends Base
             'address.postal_code^9'
         ]);
         $query->getQuery()->addShould($searchquery);
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($service_csv) {
             foreach (explode(',', $service_csv) as $service_id) {
                 $filter = new \Elastica\Filter\Term(array(
@@ -202,6 +204,7 @@ class Location extends Base
             'address.postal_code^9'
         ]);
         $boolquery->getQuery()->addShould($searchquery);
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($service_csv) {
             foreach (explode(',', $service_csv) as $service_id) {
                 $filter = new \Elastica\Filter\Term(array(

--- a/zmsdldb/src/Zmsdldb/Elastic/Location.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Location.php
@@ -220,7 +220,7 @@ class Location extends Base
             ->fromLocationResults($resultList);
     }
 
-    protected function fetchGeoJsonLocations(mixed $category, mixed $getAll)
+    protected function fetchGeoJsonLocations(mixed $category, mixed $getAll): mixed
     {
         $query = new \Elastica\Query();
         $query->setSource(['id', 'name', 'address.*', 'geo.*', 'meta.*', 'category.*']);

--- a/zmsdldb/src/Zmsdldb/Elastic/Office.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Office.php
@@ -7,8 +7,6 @@
 
 namespace BO\Zmsdldb\Elastic;
 
-use BO\Zmsdldb\Entity\Office as Entity;
-use BO\Zmsdldb\Collection\Offices as Collection;
 use BO\Zmsdldb\File\Office as Base;
 
 /**

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -18,7 +18,7 @@ class Service extends Base
 {
     /**
      *
-     * @return Entity
+     * @return Entity|false
      */
     #[\Override]
     public function fetchId(mixed $itemId)

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -50,6 +50,7 @@ class Service extends Base
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
         $query = \Elastica\Query::create($boolquery);
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($location_csv) {
             $filter = new \Elastica\Filter\Terms('locations.location', explode(',', $location_csv));
             $filter->setExecution('and');
@@ -103,6 +104,7 @@ class Service extends Base
     {
         $query = new \Elastica\Query();
         $locationsCsvByUser = false;
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (! $location_csv) {
             $location_csv = $this->fetchLocationCsv($service_csv);
         } else {
@@ -124,6 +126,7 @@ class Service extends Base
         $boolquery->addShould($searchquery);
         $filter = new \Elastica\Filter\BoolFilter();
         $filter->addMust(Helper::localeFilter($this->locale));
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($location_csv) {
             $filter->addMust(new \Elastica\Filter\Terms('locations.location', explode(',', $location_csv)));
         }

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -51,7 +51,7 @@ class Service extends Base
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
         $query = \Elastica\Query::create($boolquery);
         /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if ($location_csv) {
+        if (is_string($location_csv) && $location_csv !== '') {
             $filter = new \Elastica\Filter\Terms('locations.location', explode(',', $location_csv));
             $filter->setExecution('and');
             $query->setPostFilter($filter);
@@ -127,7 +127,7 @@ class Service extends Base
         $filter = new \Elastica\Filter\BoolFilter();
         $filter->addMust(Helper::localeFilter($this->locale));
         /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if ($location_csv) {
+        if (is_string($location_csv) && $location_csv !== '') {
             $filter->addMust(new \Elastica\Filter\Terms('locations.location', explode(',', $location_csv)));
         }
         $filteredQuery = new \Elastica\Query\Filtered($boolquery, $filter);
@@ -142,7 +142,7 @@ class Service extends Base
             $service = new Entity($result->getData());
             $serviceList[$service['id']] = $service;
         }
-        if ($locationsCsvByUser) {
+        if ($locationsCsvByUser && is_string($location_csv)) {
             $serviceList = $serviceList->containsLocation($location_csv);
         }
         return $serviceList;

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -202,15 +202,15 @@ class Service extends Base
         $boolquery->addMust($localeFilter);
 
         if (!empty($authoritys)) {
-            $authorityFilter = new \Elastica\Query\Terms('authorities.id', $authoritys);
+            $authorityFilter = new \Elastica\Query\Terms('authorities.id', array_values($authoritys));
             $boolquery->addMust($authorityFilter);
         }
         if (!empty($locations)) {
-            $locationFilter = new \Elastica\Query\Terms('locations.location', $locations);
+            $locationFilter = new \Elastica\Query\Terms('locations.location', array_values($locations));
             $boolquery->addMust($locationFilter);
         }
         if (!empty($services)) {
-            $serviceFilter = new \Elastica\Query\Terms('id', $services);
+            $serviceFilter = new \Elastica\Query\Terms('id', array_values($services));
             $boolquery->addMust($serviceFilter);
         }
 

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -21,7 +21,7 @@ class Service extends Base
      * @return Entity
      */
     #[\Override]
-    public function fetchId($itemId)
+    public function fetchId(mixed $itemId)
     {
         if ($itemId) {
             $query = Helper::boolFilteredQuery();
@@ -45,7 +45,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList($location_csv = false)
+    public function fetchList(bool $location_csv = false)
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
@@ -72,7 +72,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchFromCsv($service_csv)
+    public function fetchFromCsv(mixed $service_csv)
     {
         $query = Helper::boolFilteredQuery();
         $filter = new \Elastica\Filter\Ids();
@@ -99,7 +99,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    public function searchAll($querystring, $service_csv = '', $location_csv = '')
+    public function searchAll(mixed $querystring, string $service_csv = '', string $location_csv = '')
     {
         $query = new \Elastica\Query();
         $locationsCsvByUser = false;
@@ -152,7 +152,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    public function readSearchResultList($query, $service_csv = '')
+    public function readSearchResultList(mixed $query, string $service_csv = '')
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
@@ -187,7 +187,7 @@ class Service extends Base
     /**
      * @psalm-api
      */
-    public function fetchServicesForCompilation($authoritys = [], $locations = [], $services = []): Collection
+    public function fetchServicesForCompilation(array $authoritys = [], array $locations = [], array $services = []): Collection
     {
         $limit = 1000;
 

--- a/zmsdldb/src/Zmsdldb/Elastic/Service.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Service.php
@@ -45,7 +45,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(bool $location_csv = false)
+    public function fetchList(bool|string $location_csv = false)
     {
         $boolquery = Helper::boolFilteredQuery();
         $boolquery->getFilter()->addMust(Helper::localeFilter($this->locale));
@@ -99,7 +99,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    public function searchAll(mixed $querystring, string $service_csv = '', string $location_csv = '')
+    public function searchAll(mixed $querystring, bool|string $service_csv = '', bool|string $location_csv = '')
     {
         $query = new \Elastica\Query();
         $locationsCsvByUser = false;

--- a/zmsdldb/src/Zmsdldb/Elastic/Setting.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Setting.php
@@ -7,8 +7,6 @@
 
 namespace BO\Zmsdldb\Elastic;
 
-use BO\Zmsdldb\Entity\Setting as Entity;
-use BO\Zmsdldb\Collection\Settings as Collection;
 use BO\Zmsdldb\File\Setting as Base;
 
 /**

--- a/zmsdldb/src/Zmsdldb/Elastic/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Topic.php
@@ -17,7 +17,7 @@ use BO\Zmsdldb\File\Topic as Base;
 class Topic extends Base
 {
     #[\Override]
-    public function readSearchResultList($querystring)
+    public function readSearchResultList(mixed $querystring)
     {
         $boolquery = Helper::boolFilteredQuery();
         $searchquery = new \Elastica\Query\QueryString();

--- a/zmsdldb/src/Zmsdldb/Elastic/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Elastic/Topic.php
@@ -16,6 +16,9 @@ use BO\Zmsdldb\File\Topic as Base;
   */
 class Topic extends Base
 {
+    /**
+     * @return Collection
+     */
     #[\Override]
     public function readSearchResultList(mixed $querystring)
     {

--- a/zmsdldb/src/Zmsdldb/ElasticAccess.php
+++ b/zmsdldb/src/Zmsdldb/ElasticAccess.php
@@ -33,14 +33,14 @@ class ElasticAccess extends FileAccess
      *
      * @return self
      */
-    public function __construct($index = null, $host = 'localhost', $port = '9200', $transport = 'Http')
+    public function __construct(mixed $index = null, string $host = 'localhost', string $port = '9200', string $transport = 'Http')
     {
         if ($index) {
             $this->connectElasticSearch($index, $host, $port, $transport);
         }
     }
 
-    public function connectElasticSearch($index, $host = 'localhost', $port = '9200', $transport = 'Http'): void
+    public function connectElasticSearch(mixed $index, string $host = 'localhost', string $port = '9200', string $transport = 'Http'): void
     {
         $this->connection = new \Elastica\Client(array(
                 'host' => $host,
@@ -74,7 +74,7 @@ class ElasticAccess extends FileAccess
      * @return self
      */
     #[\Override]
-    public function loadLocations($locationJson, $locale = 'de')
+    public function loadLocations(mixed $locationJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Location'] = new Elastic\Location($locationJson, $locale);
         $this->accessInstance[$locale]['Location']->setAccessInstance($this);
@@ -86,7 +86,7 @@ class ElasticAccess extends FileAccess
      * @return self
      */
     #[\Override]
-    public function loadServices($serviceJson, $locale = 'de')
+    public function loadServices(mixed $serviceJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Service'] = new Elastic\Service($serviceJson, $locale);
         $this->accessInstance[$locale]['Service']->setAccessInstance($this);
@@ -98,7 +98,7 @@ class ElasticAccess extends FileAccess
      * @return self
      */
     #[\Override]
-    public function loadTopics($topicJson, $locale = 'de')
+    public function loadTopics(mixed $topicJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Topic'] = new Elastic\Topic($topicJson, $locale);
         $this->accessInstance[$locale]['Topic']->setAccessInstance($this);
@@ -112,7 +112,7 @@ class ElasticAccess extends FileAccess
      * @return self
      */
     #[\Override]
-    public function loadSettings($settingsJson)
+    public function loadSettings(mixed $settingsJson)
     {
         $this->accessInstance['de']['Setting'] = new Elastic\Setting($settingsJson);
         $this->accessInstance['de']['Setting']->setAccessInstance($this);
@@ -129,7 +129,7 @@ class ElasticAccess extends FileAccess
      * @return self
      */
     #[\Override]
-    public function loadAuthorities($authorityJson, $locale = 'de')
+    public function loadAuthorities(mixed $authorityJson, string $locale = 'de')
     {
         $this->accessInstance[$locale]['Authority'] = new Elastic\Authority($authorityJson, $locale);
         $this->accessInstance[$locale]['Authority']->setAccessInstance($this);

--- a/zmsdldb/src/Zmsdldb/ElasticAccess.php
+++ b/zmsdldb/src/Zmsdldb/ElasticAccess.php
@@ -57,6 +57,9 @@ class ElasticAccess extends FileAccess
      */
     public function getIndex()
     {
+        if (!$this->index instanceof \Elastica\Index) {
+            throw new Exception('ElasticSearch index is not initialized');
+        }
         return $this->index;
     }
 
@@ -66,6 +69,9 @@ class ElasticAccess extends FileAccess
      */
     protected function getConnection()
     {
+        if (!$this->connection instanceof \Elastica\Client) {
+            throw new Exception('ElasticSearch connection is not initialized');
+        }
         return $this->connection;
     }
 

--- a/zmsdldb/src/Zmsdldb/ElasticAccess.php
+++ b/zmsdldb/src/Zmsdldb/ElasticAccess.php
@@ -18,16 +18,16 @@ class ElasticAccess extends FileAccess
     /**
      * The client used to talk to elastic search.
      *
-     * @var \Elastica\Client
+     * @var \Elastica\Client|null
      */
-    protected $connection;
+    protected $connection = null;
 
     /**
       * Index from elastic search
       *
-      * @var \Elastica\Index $index
+      * @var \Elastica\Index|null $index
       */
-    protected $index;
+    protected $index = null;
 
     /**
      *

--- a/zmsdldb/src/Zmsdldb/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Authority.php
@@ -108,8 +108,8 @@ class Authority extends Base
     /**
      * Check if Authority is part of ServiceList
      *
-     * @param String $serviceCsv
-     *            only check for this serviceCsv
+     * @param mixed $servicelist
+     *            only check for this service list
      *
      * @return bool
      */

--- a/zmsdldb/src/Zmsdldb/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Authority.php
@@ -19,7 +19,7 @@ class Authority extends Base
         }
     }
 
-    public static function create($name): self
+    public static function create(mixed $name): self
     {
         $data = array(
             'name' => $name,
@@ -113,7 +113,7 @@ class Authority extends Base
      *
      * @return self
      */
-    public function isInServiceList($servicelist = array())
+    public function isInServiceList(mixed $servicelist = array())
     {
         foreach ($servicelist as $service) {
             if ($service->offsetExists('authorities')) {

--- a/zmsdldb/src/Zmsdldb/Entity/Authority.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Authority.php
@@ -111,7 +111,7 @@ class Authority extends Base
      * @param String $serviceCsv
      *            only check for this serviceCsv
      *
-     * @return self
+     * @return bool
      */
     public function isInServiceList(mixed $servicelist = array())
     {

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -118,6 +118,7 @@ class Base extends \ArrayObject
 
     /**
      * @param static $array
+     * @param-out array|static $array
      */
     public static function doubleUnterlineToArray(&$array, string $key, mixed $value): mixed
     {

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -46,7 +46,7 @@ class Base extends \ArrayObject
         return $this['path'];
     }
 
-    public static function hasValidOffset($item, string $index): bool
+    public static function hasValidOffset(mixed $item, string $index): bool
     {
         return (
             (is_object($item) && $item->offsetExists($index)) ||
@@ -81,7 +81,7 @@ class Base extends \ArrayObject
         return $this['type'];
     }
 
-    protected static function subcount($countable): int|null
+    protected static function subcount(mixed $countable): int|null
     {
         if (is_array($countable) || $countable instanceof \Countable) {
             return count($countable);
@@ -89,7 +89,7 @@ class Base extends \ArrayObject
         return null;
     }
 
-    public function __set($name, $value)
+    public function __set(string $name, mixed $value)
     {
         $this->offsetSet($name, $value);
     }
@@ -117,7 +117,7 @@ class Base extends \ArrayObject
     /**
      * @param static $array
      */
-    public static function doubleUnterlineToArray(&$array, string $key, $value)
+    public static function doubleUnterlineToArray(&$array, string $key, mixed $value)
     {
         if (is_null($key)) {
             return $array = $value;

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -16,7 +16,7 @@ class Base extends \ArrayObject
      * return an ID for this entity
      *
      */
-    public function getId()
+    public function getId(): mixed
     {
         if (!$this->offsetExists('id')) {
             return false;
@@ -28,7 +28,7 @@ class Base extends \ArrayObject
      * return a name for this entity
      *
      */
-    public function getName()
+    public function getName(): mixed
     {
         return $this['name'];
     }
@@ -38,7 +38,7 @@ class Base extends \ArrayObject
      *
      * @psalm-api
      */
-    public function getPath()
+    public function getPath(): mixed
     {
         if (!$this->offsetExists('path')) {
             return false;
@@ -55,7 +55,7 @@ class Base extends \ArrayObject
     }
 
     /** @psalm-api */
-    public function getLocale()
+    public function getLocale(): mixed
     {
         $meta = $this['meta'];
         if (false === static::hasValidOffset($meta, 'locale')) {
@@ -65,7 +65,7 @@ class Base extends \ArrayObject
     }
 
     /** @psalm-api */
-    public function getLink()
+    public function getLink(): mixed
     {
         if (!$this->offsetExists('link')) {
             return false;
@@ -73,7 +73,7 @@ class Base extends \ArrayObject
         return $this['link'];
     }
 
-    public function getType()
+    public function getType(): mixed
     {
         if (!$this->offsetExists('type')) {
             return false;
@@ -117,7 +117,7 @@ class Base extends \ArrayObject
     /**
      * @param static $array
      */
-    public static function doubleUnterlineToArray(&$array, string $key, mixed $value)
+    public static function doubleUnterlineToArray(&$array, string $key, mixed $value): mixed
     {
         if (is_null($key)) {
             return $array = $value;

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -130,6 +130,9 @@ class Base extends \ArrayObject
         while ($numKeys > 1) {
             $key = array_shift($keys);
             $numKeys = count($keys);
+            if ($key === null) {
+                break;
+            }
             if (! isset($array[$key]) || ! is_array($array[$key])) {
                 $array[$key] = [];
             }
@@ -137,7 +140,10 @@ class Base extends \ArrayObject
             $array = &$array[$key];
         }
 
-        $array[array_shift($keys)] = $value;
+        $lastKey = array_shift($keys);
+        if ($lastKey !== null) {
+            $array[$lastKey] = $value;
+        }
 
         return $array;
     }

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -101,10 +101,12 @@ class Base extends \ArrayObject
             $value = json_decode($value, true);
             $this->exchangeArray($value);
         } else {
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if (stripos($index, '_json')) {
                 $value = json_decode($value, true);
                 $index = str_replace('_json', '', $index);
             }
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if (stripos($index, '__')) {
                 static::doubleUnterlineToArray($this, $index, $value);
                 return;

--- a/zmsdldb/src/Zmsdldb/Entity/Base.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Base.php
@@ -121,7 +121,7 @@ class Base extends \ArrayObject
      */
     public static function doubleUnterlineToArray(&$array, string $key, mixed $value): mixed
     {
-        if (is_null($key)) {
+        if ($key === '') {
             return $array = $value;
         }
         $keys = explode('__', $key);

--- a/zmsdldb/src/Zmsdldb/Entity/Link.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Link.php
@@ -18,7 +18,7 @@ class Link extends Base
      *
      */
     #[\Override]
-    public function getId()
+    public function getId(): mixed
     {
         return $this['link'];
     }

--- a/zmsdldb/src/Zmsdldb/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Location.php
@@ -18,8 +18,11 @@ class Location extends Base
      */
     public function containsService(mixed $service_csv)
     {
+        if (!is_string($service_csv) && !is_int($service_csv) && !is_float($service_csv)) {
+            return false;
+        }
         $location = $this->getArrayCopy();
-        $servicecompare = explode(',', $service_csv);
+        $servicecompare = explode(',', (string) $service_csv);
         $servicecount = array();
         foreach ($location['services'] as $serviceinfo) {
             $service_id = $serviceinfo['service'];
@@ -65,8 +68,11 @@ class Location extends Base
         if (null === $serviceCsv) {
             return $this['services'];
         }
+        if (!is_string($serviceCsv) && !is_int($serviceCsv) && !is_float($serviceCsv)) {
+            return array();
+        }
         $location = $this->getArrayCopy();
-        $servicecompare = explode(',', $serviceCsv);
+        $servicecompare = explode(',', (string) $serviceCsv);
 
         $serviceList = array();
         foreach ($location['services'] as $serviceinfo) {

--- a/zmsdldb/src/Zmsdldb/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Location.php
@@ -127,7 +127,7 @@ class Location extends Base
      * return geoJson
      *
      *
-     * @return string
+     * @return array
      */
     public function getGeoJson()
     {

--- a/zmsdldb/src/Zmsdldb/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Location.php
@@ -16,7 +16,7 @@ class Location extends Base
     /**
      * @return Bool
      */
-    public function containsService($service_csv)
+    public function containsService(mixed $service_csv)
     {
         $location = $this->getArrayCopy();
         $servicecompare = explode(',', $service_csv);
@@ -45,7 +45,7 @@ class Location extends Base
      * @return FALSE or Array
      * @psalm-api
      */
-    public function getServiceInfo($service_id)
+    public function getServiceInfo(mixed $service_id)
     {
         foreach ($this['services'] as $service) {
             if ($service['service'] == $service_id) {
@@ -112,7 +112,7 @@ class Location extends Base
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @psalm-api
      */
-    public function getAppointmentForService($service_id, $external = false)
+    public function getAppointmentForService(mixed $service_id, bool $external = false)
     {
         $serviceList = $this->getServiceInfoList($service_id);
 

--- a/zmsdldb/src/Zmsdldb/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Location.php
@@ -40,7 +40,7 @@ class Location extends Base
     }
 
     /**
-     * @var Int $service_id
+     * @param int $service_id
      *
      * @return FALSE or Array
      * @psalm-api

--- a/zmsdldb/src/Zmsdldb/Entity/Location.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Location.php
@@ -112,7 +112,7 @@ class Location extends Base
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @psalm-api
      */
-    public function getAppointmentForService(mixed $service_id, bool $external = false)
+    public function getAppointmentForService(mixed $service_id, bool $external = false): mixed
     {
         $serviceList = $this->getServiceInfoList($service_id);
 

--- a/zmsdldb/src/Zmsdldb/Entity/SearchResult.php
+++ b/zmsdldb/src/Zmsdldb/Entity/SearchResult.php
@@ -13,7 +13,7 @@ namespace BO\Zmsdldb\Entity;
   */
 class SearchResult extends Base
 {
-    public static function create($item): self
+    public static function create(mixed $item): self
     {
         $type = explode('\\', get_class($item));
         $data = array(

--- a/zmsdldb/src/Zmsdldb/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Service.php
@@ -21,7 +21,7 @@ class Service extends Base
      *
      * @return Bool
      */
-    public function containsLocation($location_csv)
+    public function containsLocation(string $location_csv)
     {
         $service = $this->getArrayCopy();
         $locationcompare = explode(',', $location_csv);
@@ -38,7 +38,7 @@ class Service extends Base
     /**
      * @psalm-api
      */
-    public function hasLocation($location_csv): bool
+    public function hasLocation(mixed $location_csv): bool
     {
         $service = $this->getArrayCopy();
         $locationcompare = explode(',', $location_csv);
@@ -53,7 +53,7 @@ class Service extends Base
     /**
      * @psalm-api
      */
-    public function hasAppointments($external = false): bool
+    public function hasAppointments(bool $external = false): bool
     {
         foreach ($this['locations'] as $location) {
             if (isset($location['appointment']['allowed'])) {

--- a/zmsdldb/src/Zmsdldb/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Service.php
@@ -24,7 +24,7 @@ class Service extends Base
     public function containsLocation(string|null $location_csv)
     {
         $service = $this->getArrayCopy();
-        $locationcompare = explode(',', $location_csv);
+        $locationcompare = explode(',', (string) $location_csv);
         $locationsfound = array();
         foreach ($service['locations'] as $locationinfo) {
             $location_id = $locationinfo['location'];
@@ -41,7 +41,7 @@ class Service extends Base
     public function hasLocation(mixed $location_csv): bool
     {
         $service = $this->getArrayCopy();
-        $locationcompare = explode(',', $location_csv);
+        $locationcompare = explode(',', (string) $location_csv);
         foreach ($service['locations'] as $locationinfo) {
             if (in_array($locationinfo['location'], $locationcompare)) {
                 return true;

--- a/zmsdldb/src/Zmsdldb/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Service.php
@@ -21,7 +21,7 @@ class Service extends Base
      *
      * @return Bool
      */
-    public function containsLocation(string $location_csv)
+    public function containsLocation(string|null $location_csv)
     {
         $service = $this->getArrayCopy();
         $locationcompare = explode(',', $location_csv);

--- a/zmsdldb/src/Zmsdldb/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Service.php
@@ -71,7 +71,7 @@ class Service extends Base
 
 
     /** @psalm-api */
-    public function isResponsibleForAll()
+    public function isResponsibleForAll(): mixed
     {
         return $this['responsibility_all'];
     }

--- a/zmsdldb/src/Zmsdldb/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Topic.php
@@ -26,6 +26,7 @@ class Topic extends Base
      */
     public function isLinked(): bool
     {
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         return ($this['relation']['navi'] || static::subcount($this['relation']['navi']));
     }
 

--- a/zmsdldb/src/Zmsdldb/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Topic.php
@@ -43,7 +43,7 @@ class Topic extends Base
         );
         foreach ($items as $item) {
             foreach ($item as $entity) {
-                $list[] = $entity;
+                $list->append($entity);
             }
         }
         return $list;

--- a/zmsdldb/src/Zmsdldb/Entity/Topic.php
+++ b/zmsdldb/src/Zmsdldb/Entity/Topic.php
@@ -49,7 +49,7 @@ class Topic extends Base
     }
 
     /** @psalm-api */
-    public function getParentId()
+    public function getParentId(): mixed
     {
         if (count($this['relation']['parents']) > 1) {
             foreach ($this['relation']['parents'] as $item) {

--- a/zmsdldb/src/Zmsdldb/File/Authority.php
+++ b/zmsdldb/src/Zmsdldb/File/Authority.php
@@ -35,7 +35,7 @@ class Authority extends Base
      *
      * @return Collection
      */
-    public function fetchList(bool|array $servicelist = false)
+    public function fetchList(mixed $servicelist = false)
     {
         $service_csv = implode(',', (array)$servicelist);
         $authoritylist = $this->getItemList()->removeLocations();

--- a/zmsdldb/src/Zmsdldb/File/Authority.php
+++ b/zmsdldb/src/Zmsdldb/File/Authority.php
@@ -89,7 +89,7 @@ class Authority extends Base
     }
 
     /** @psalm-api */
-    public function fetchSource()
+    public function fetchSource(): \BO\Zmsdldb\Collection\Base
     {
         return $this->getItemList();
     }

--- a/zmsdldb/src/Zmsdldb/File/Authority.php
+++ b/zmsdldb/src/Zmsdldb/File/Authority.php
@@ -19,7 +19,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data['data'] as $item) {
@@ -33,7 +33,7 @@ class Authority extends Base
      *
      * @return Collection
      */
-    public function fetchList($servicelist = false)
+    public function fetchList(bool $servicelist = false)
     {
         $service_csv = implode(',', (array)$servicelist);
         $authoritylist = $this->getItemList()->removeLocations();
@@ -64,7 +64,7 @@ class Authority extends Base
      *
      * @return Collection
      */
-    public function fromLocationResults($resultList)
+    public function fromLocationResults(mixed $resultList)
     {
         $authorityList = new Collection();
         foreach ($resultList as $result) {
@@ -79,7 +79,7 @@ class Authority extends Base
      * @return Collection
      * @psalm-api
      */
-    public function readListByOfficePath($officepath)
+    public function readListByOfficePath(mixed $officepath)
     {
         $authoritylist = $this->fetchList();
         if ($officepath) {

--- a/zmsdldb/src/Zmsdldb/File/Authority.php
+++ b/zmsdldb/src/Zmsdldb/File/Authority.php
@@ -12,6 +12,8 @@ use BO\Zmsdldb\Collection\Authorities as Collection;
 
 /**
  * Common methods shared by access classes
+ *
+ * @extends Base<Collection, Entity>
  */
 class Authority extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Authority.php
+++ b/zmsdldb/src/Zmsdldb/File/Authority.php
@@ -35,7 +35,7 @@ class Authority extends Base
      *
      * @return Collection
      */
-    public function fetchList(bool $servicelist = false)
+    public function fetchList(bool|array $servicelist = false)
     {
         $service_csv = implode(',', (array)$servicelist);
         $authoritylist = $this->getItemList()->removeLocations();

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -15,7 +15,7 @@ use BO\Zmsdldb\Exception;
   */
 abstract class Base
 {
-    protected $data = [];
+    protected mixed $data = [];
     /**
      * lazy loaded item list, use getItemList() to access this
      *

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -37,7 +37,7 @@ abstract class Base
     protected $locale = 'de';
 
     /**
-     * @var \BO\Zmsdldb\AbstractAccess $accessInstance
+     * @var \BO\Zmsdldb\AbstractAccess|null $accessInstance
      */
     private $accessInstance = null;
 

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -145,7 +145,9 @@ abstract class Base
             return false;
         }
 
-        return $itemList[$itemId];
+        /** @var TEntity $item */
+        $item = $itemList[$itemId];
+        return $item;
     }
 
     public function setAccessInstance(\BO\Zmsdldb\AbstractAccess $accessInstance): void

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -134,6 +134,7 @@ abstract class Base
 
     protected function setItemList(\BO\Zmsdldb\Collection\Base $list): static
     {
+        /** @var TCollection $list */
         $this->itemList = $list;
         return $this;
     }

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -59,7 +59,11 @@ abstract class Base
             if (!is_readable($jsonFile)) {
                 throw new Exception("Cannot read $jsonFile");
             }
-            $data = json_decode(file_get_contents($jsonFile), true);
+            $json = file_get_contents($jsonFile);
+            if ($json === false) {
+                throw new Exception("Cannot read $jsonFile");
+            }
+            $data = json_decode($json, true);
             if (!$data) {
                 throw new Exception("Could not decide $jsonFile");
             }

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -12,6 +12,8 @@ use BO\Zmsdldb\Exception;
 /**
   * Common methods shared by access classes
   *
+  * @template TCollection of \BO\Zmsdldb\Collection\Base
+  * @template TEntity of \BO\Zmsdldb\Entity\Base
   */
 abstract class Base
 {
@@ -19,7 +21,7 @@ abstract class Base
     /**
      * lazy loaded item list, use getItemList() to access this
      *
-     * @var \BO\Zmsdldb\Collection\Base $itemList
+     * @var TCollection|null $itemList
      */
     private $itemList = null;
 
@@ -39,6 +41,9 @@ abstract class Base
      */
     private $accessInstance = null;
 
+    /**
+     * @return TCollection
+     */
     abstract protected function parseData(mixed $data);
 
     public function __construct(mixed $dataFile, string $locale = "de")
@@ -113,7 +118,7 @@ abstract class Base
     }
 
     /**
-     * @return \BO\Zmsdldb\Collection\Base
+     * @return TCollection
      */
     public function getItemList()
     {
@@ -130,7 +135,7 @@ abstract class Base
     }
 
     /**
-     * @return \BO\Zmsdldb\Entity\Base|false
+     * @return TEntity|false
      */
     public function fetchId(string $itemId)
     {

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -39,9 +39,9 @@ abstract class Base
      */
     private $accessInstance = null;
 
-    abstract protected function parseData($data);
+    abstract protected function parseData(mixed $data);
 
-    public function __construct($dataFile, $locale = "de")
+    public function __construct(mixed $dataFile, string $locale = "de")
     {
         $this->dataFile = $dataFile;
         $this->locale = $locale;
@@ -123,7 +123,7 @@ abstract class Base
         return $this->itemList;
     }
 
-    protected function setItemList($list): static
+    protected function setItemList(\BO\Zmsdldb\Collection\Base $list): static
     {
         $this->itemList = $list;
         return $this;

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -162,6 +162,9 @@ abstract class Base
 
     public function access(): \BO\Zmsdldb\AbstractAccess
     {
+        if (!$this->accessInstance instanceof \BO\Zmsdldb\AbstractAccess) {
+            throw new Exception('Access instance is not initialized');
+        }
         return $this->accessInstance;
     }
 }

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -47,7 +47,7 @@ abstract class Base
         $this->locale = $locale;
     }
 
-    public function readDataFile()
+    public function readDataFile(): mixed
     {
         if (empty($this->data)) {
             $jsonFile = $this->dataFile;
@@ -64,7 +64,7 @@ abstract class Base
     }
 
     /** @psalm-api */
-    public function getDataAsArray()
+    public function getDataAsArray(): mixed
     {
         try {
             $data = $this->readDataFile();
@@ -76,7 +76,7 @@ abstract class Base
     }
 
     /** @psalm-api */
-    public function getHash()
+    public function getHash(): mixed
     {
         try {
             $data = $this->readDataFile();
@@ -88,7 +88,7 @@ abstract class Base
     }
 
     /** @psalm-api */
-    public function getData()
+    public function getData(): mixed
     {
         try {
             $data = $this->readDataFile();

--- a/zmsdldb/src/Zmsdldb/File/Base.php
+++ b/zmsdldb/src/Zmsdldb/File/Base.php
@@ -145,7 +145,7 @@ abstract class Base
     {
         $itemList = $this->getItemList();
 
-        if (! $itemId || !$itemList instanceof \BO\Zmsdldb\Collection\Base || !$itemList->offsetExists($itemId)) {
+        if (! $itemId || !$itemList->offsetExists($itemId)) {
             return false;
         }
 

--- a/zmsdldb/src/Zmsdldb/File/Borough.php
+++ b/zmsdldb/src/Zmsdldb/File/Borough.php
@@ -13,6 +13,7 @@ use BO\Zmsdldb\Collection\Boroughs as Collection;
 /**
   * Common methods shared by access classes
   *
+  * @extends Base<Collection, Entity>
   */
 class Borough extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Borough.php
+++ b/zmsdldb/src/Zmsdldb/File/Borough.php
@@ -20,7 +20,7 @@ class Borough extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data['data']['boroughs'] as $item) {

--- a/zmsdldb/src/Zmsdldb/File/Link.php
+++ b/zmsdldb/src/Zmsdldb/File/Link.php
@@ -31,7 +31,7 @@ class Link extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data as $topic) {
@@ -56,7 +56,7 @@ class Link extends Base
      * @return Entity
      * @psalm-api
      */
-    public function fetchPath($topic_path)
+    public function fetchPath(mixed $topic_path)
     {
         $topiclist = $this->fetchList();
         foreach ($topiclist as $topic) {
@@ -72,7 +72,7 @@ class Link extends Base
      *
      * @return Collection
      */
-    public function readSearchResultList($query)
+    public function readSearchResultList(mixed $query)
     {
         $list = $this->getItemList();
         $result = new Collection();

--- a/zmsdldb/src/Zmsdldb/File/Link.php
+++ b/zmsdldb/src/Zmsdldb/File/Link.php
@@ -81,7 +81,7 @@ class Link extends Base
         $result = new Collection();
         foreach ($list as $link) {
             if (false !== strpos($link['name'], $query)) {
-                $result[] = $link;
+                $result->append($link);
             }
         }
         return $result;

--- a/zmsdldb/src/Zmsdldb/File/Link.php
+++ b/zmsdldb/src/Zmsdldb/File/Link.php
@@ -12,6 +12,8 @@ use BO\Zmsdldb\Collection\Links as Collection;
 
 /**
  * Common methods shared by access classes
+ *
+ * @extends Base<Collection, Entity>
  */
 class Link extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Link.php
+++ b/zmsdldb/src/Zmsdldb/File/Link.php
@@ -56,7 +56,7 @@ class Link extends Base
 
     /**
      *
-     * @return Entity
+     * @return Entity|false
      * @psalm-api
      */
     public function fetchPath(mixed $topic_path)

--- a/zmsdldb/src/Zmsdldb/File/Link.php
+++ b/zmsdldb/src/Zmsdldb/File/Link.php
@@ -26,6 +26,7 @@ class Link extends Base
         $data = $this->access()
             ->fromTopic()
             ->fetchList();
+        /** @psalm-suppress InvalidArgument */
         $this->setItemList($this->parseData($data));
     }
 

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -38,11 +38,10 @@ class Location extends Base
      * @return Collection
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function fetchList(string|false $service_csv = false, bool $mixLanguages = false)
+    public function fetchList(bool|string $service_csv = false, bool $mixLanguages = false)
     {
         $locationlist = $this->getItemList();
-        /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if ($service_csv) {
+        if (is_string($service_csv) && $service_csv !== '') {
             $locationlist = new Collection(array_filter((array) $locationlist, function ($item) use ($service_csv) {
                 $location = new Entity($item);
                 return $location->containsService($service_csv);

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -81,7 +81,7 @@ class Location extends Base
     }
 
     /** @psalm-api */
-    public function fetchListByOffice(mixed $office)
+    public function fetchListByOffice(mixed $office): mixed
     {
         return $this->access()->fromAuthority()
         ->readListByOfficePath($office)

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -38,7 +38,7 @@ class Location extends Base
      * @return Collection
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function fetchList(bool|string $service_csv = false, bool $mixLanguages = false)
+    public function fetchList(string|false $service_csv = false, bool $mixLanguages = false)
     {
         $locationlist = $this->getItemList();
         /** @psalm-suppress RiskyTruthyFalsyComparison */

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -68,7 +68,7 @@ class Location extends Base
 
     /**
      *
-     * @return Collection
+     * @return \BO\Zmsdldb\Collection\Authorities
      * @psalm-api
      */
     public function readSearchResultList(mixed $query, string $service_csv = '')

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -40,6 +40,7 @@ class Location extends Base
     public function fetchList(bool|string $service_csv = false)
     {
         $locationlist = $this->getItemList();
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($service_csv) {
             $locationlist = new Collection(array_filter((array) $locationlist, function ($item) use ($service_csv) {
                 $location = new Entity($item);

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -19,7 +19,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data['data'] as $item) {
@@ -35,7 +35,7 @@ class Location extends Base
      *
      * @return Collection
      */
-    public function fetchList($service_csv = false)
+    public function fetchList(bool $service_csv = false)
     {
         $locationlist = $this->getItemList();
         if ($service_csv) {
@@ -52,7 +52,7 @@ class Location extends Base
      * @return Collection
      * @psalm-api
      */
-    public function fetchFromCsv($location_csv)
+    public function fetchFromCsv(mixed $location_csv)
     {
         $locationlist = new Collection();
         foreach (explode(',', $location_csv) as $location_id) {
@@ -69,7 +69,7 @@ class Location extends Base
      * @return Collection
      * @psalm-api
      */
-    public function readSearchResultList($query, $service_csv = '')
+    public function readSearchResultList(mixed $query, string $service_csv = '')
     {
         $locationlist = $this->fetchList($service_csv);
         $locationlist = new Collection(array_filter((array) $locationlist, function ($item) use ($query) {
@@ -81,7 +81,7 @@ class Location extends Base
     }
 
     /** @psalm-api */
-    public function fetchListByOffice($office)
+    public function fetchListByOffice(mixed $office)
     {
         return $this->access()->fromAuthority()
         ->readListByOfficePath($office)

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -36,8 +36,9 @@ class Location extends Base
     /**
      *
      * @return Collection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function fetchList(bool|string $service_csv = false)
+    public function fetchList(bool|string $service_csv = false, bool $mixLanguages = false)
     {
         $locationlist = $this->getItemList();
         /** @psalm-suppress RiskyTruthyFalsyComparison */
@@ -53,9 +54,11 @@ class Location extends Base
     /**
      *
      * @return Collection
+     * @param bool $mixLanguages unused in file backend, kept for MySQL override compatibility
      * @psalm-api
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function fetchFromCsv(mixed $location_csv)
+    public function fetchFromCsv(mixed $location_csv, bool $mixLanguages = false)
     {
         $locationlist = new Collection();
         foreach (explode(',', $location_csv) as $location_id) {

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -37,7 +37,7 @@ class Location extends Base
      *
      * @return Collection
      */
-    public function fetchList(bool $service_csv = false)
+    public function fetchList(bool|string $service_csv = false)
     {
         $locationlist = $this->getItemList();
         if ($service_csv) {

--- a/zmsdldb/src/Zmsdldb/File/Location.php
+++ b/zmsdldb/src/Zmsdldb/File/Location.php
@@ -12,6 +12,8 @@ use BO\Zmsdldb\Collection\Locations as Collection;
 
 /**
  * Common methods shared by access classes
+ *
+ * @extends Base<Collection, Entity>
  */
 class Location extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Office.php
+++ b/zmsdldb/src/Zmsdldb/File/Office.php
@@ -13,6 +13,7 @@ use BO\Zmsdldb\Collection\Offices as Collection;
 /**
   * Common methods shared by access classes
   *
+  * @extends Base<Collection, Entity>
   */
 class Office extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Office.php
+++ b/zmsdldb/src/Zmsdldb/File/Office.php
@@ -20,7 +20,7 @@ class Office extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data['data']['office'] as $item) {
@@ -36,7 +36,7 @@ class Office extends Base
     }
 
     /** @psalm-api */
-    public function fetchPath($itemId)
+    public function fetchPath(mixed $itemId)
     {
         return $this->fetchId($itemId);
     }

--- a/zmsdldb/src/Zmsdldb/File/Office.php
+++ b/zmsdldb/src/Zmsdldb/File/Office.php
@@ -30,13 +30,13 @@ class Office extends Base
         return $itemList;
     }
 
-    public function fetchList()
+    public function fetchList(): \BO\Zmsdldb\Collection\Base
     {
         return $this->getItemList();
     }
 
     /** @psalm-api */
-    public function fetchPath(mixed $itemId)
+    public function fetchPath(mixed $itemId): \BO\Zmsdldb\Entity\Base|false
     {
         return $this->fetchId($itemId);
     }

--- a/zmsdldb/src/Zmsdldb/File/Office.php
+++ b/zmsdldb/src/Zmsdldb/File/Office.php
@@ -37,7 +37,7 @@ class Office extends Base
     }
 
     /** @psalm-api */
-    public function fetchPath(mixed $itemId): \BO\Zmsdldb\Entity\Base|false
+    public function fetchPath(string $itemId): \BO\Zmsdldb\Entity\Base|false
     {
         return $this->fetchId($itemId);
     }

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -97,7 +97,7 @@ class Service extends Base
                 }
             )
         );
-        return ($relatedList) ? $relatedList : new Collection();
+        return $relatedList;
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -152,17 +152,14 @@ class Service extends Base
     public function fetchListFromTopic(\BO\Zmsdldb\Entity\Topic $topic)
     {
         $itemlist = new Collection();
-        $serviceIds = array();
-        if ($topic) {
-            $serviceIds = $topic->getServiceIds();
-            if ($topic['relation']['navi'] && isset($topic['relation']['childs'])) {
-                foreach ($topic['relation']['childs'] as $child) {
-                    $childtopic = $this->access()
-                        ->fromTopic()
-                        ->fetchPath($child['path']);
-                    if ($childtopic) {
-                        $serviceIds = array_merge($serviceIds, $childtopic->getServiceIds());
-                    }
+        $serviceIds = $topic->getServiceIds();
+        if ($topic['relation']['navi'] && isset($topic['relation']['childs'])) {
+            foreach ($topic['relation']['childs'] as $child) {
+                $childtopic = $this->access()
+                    ->fromTopic()
+                    ->fetchPath($child['path']);
+                if ($childtopic) {
+                    $serviceIds = array_merge($serviceIds, $childtopic->getServiceIds());
                 }
             }
         }

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -64,6 +64,7 @@ class Service extends Base
     {
         #echo '<pre>' . print_r($this,1) . '</pre>';exit;
         $servicelist = $this->getItemList();
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($location_csv) {
             $servicelist = new Collection(array_filter((array) $servicelist, function ($item) use ($location_csv) {
                 $service = new Entity($item);

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -19,7 +19,7 @@ class Service extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data['data'] as $item) {
@@ -37,7 +37,7 @@ class Service extends Base
      * @return Collection
      * @psalm-api
      */
-    public function searchAll($querystring, $service_csv = false, $location_csv = false)
+    public function searchAll(mixed $querystring, bool $service_csv = false, bool $location_csv = false)
     {
         $serviceList = $this->fetchList($location_csv);
         if ($querystring) {
@@ -75,7 +75,7 @@ class Service extends Base
      * @return Collection
      * @psalm-api
      */
-    public function fetchListRelated($service_id)
+    public function fetchListRelated(mixed $service_id)
     {
         $service = $this->fetchId($service_id);
         $serviceList = $this->getItemList();
@@ -97,7 +97,7 @@ class Service extends Base
      *
      * @return Collection
      */
-    public function fetchCombinations($service_csv)
+    public function fetchCombinations(mixed $service_csv)
     {
         return $this->fetchList($this->fetchLocationCsv($service_csv));
     }
@@ -106,7 +106,7 @@ class Service extends Base
      *
      * @return string
      */
-    protected function fetchLocationCsv($service_csv)
+    protected function fetchLocationCsv(mixed $service_csv)
     {
         $locationlist = $this->access()
             ->fromLocation()
@@ -172,7 +172,7 @@ class Service extends Base
      * @return Collection
      * @psalm-api
      */
-    public function readSearchResultList($query, $service_csv = '')
+    public function readSearchResultList(mixed $query, string $service_csv = '')
     {
         $servicelist = $this->fetchCombinations($service_csv);
         $servicelist = new Collection(array_filter((array) $servicelist, function ($item) use ($query) {

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -41,7 +41,7 @@ class Service extends Base
      */
     public function searchAll(mixed $querystring, bool|string $service_csv = false, bool|string $location_csv = false)
     {
-        $serviceList = $this->fetchList($location_csv);
+        $serviceList = new Collection($this->fetchList($location_csv)->getArrayCopy());
         if ($querystring) {
             $serviceList = new Collection(array_filter((array) $serviceList, function ($item) use ($querystring) {
                 $length = (3 < strlen($querystring)) ? strlen($querystring) : 3;
@@ -50,12 +50,11 @@ class Service extends Base
                 return ($nameMatch || $keywordMatch);
             }));
         }
-        $serviceList = $serviceList->sortByName();
+        $serviceList = new Collection($serviceList->sortByName()->getArrayCopy());
         if (!is_string($location_csv)) {
             return $serviceList;
         }
-        $filtered = new Collection($serviceList->getArrayCopy());
-        return $filtered->containsLocation($location_csv);
+        return $serviceList->containsLocation($location_csv);
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -39,7 +39,7 @@ class Service extends Base
      * @return Collection
      * @psalm-api
      */
-    public function searchAll(mixed $querystring, bool $service_csv = false, bool $location_csv = false)
+    public function searchAll(mixed $querystring, bool|string $service_csv = false, bool|string $location_csv = false)
     {
         $serviceList = $this->fetchList($location_csv);
         if ($querystring) {
@@ -60,7 +60,7 @@ class Service extends Base
      *
      * @param false|string $location_csv
      */
-    public function fetchList(string|false $location_csv = false)
+    public function fetchList(bool|string $location_csv = false)
     {
         #echo '<pre>' . print_r($this,1) . '</pre>';exit;
         $servicelist = $this->getItemList();

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -12,6 +12,8 @@ use BO\Zmsdldb\Collection\Services as Collection;
 
 /**
  * Common methods shared by access classes
+ *
+ * @extends Base<Collection, Entity>
  */
 class Service extends Base
 {
@@ -49,6 +51,7 @@ class Service extends Base
             }));
         }
         $serviceList = $serviceList->sortByName();
+        /** @var Collection $serviceList */
         return ($location_csv) ? $serviceList->containsLocation($location_csv) : $serviceList;
     }
 

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -53,7 +53,9 @@ class Service extends Base
         $serviceList = $serviceList->sortByName();
         /** @var Collection $serviceList */
         /** @psalm-suppress RiskyTruthyFalsyComparison */
-        return ($location_csv) ? $serviceList->containsLocation($location_csv) : $serviceList;
+        return is_string($location_csv)
+            ? $serviceList->containsLocation($location_csv)
+            : $serviceList;
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -51,11 +51,11 @@ class Service extends Base
             }));
         }
         $serviceList = $serviceList->sortByName();
-        /** @var Collection $serviceList */
-        /** @psalm-suppress RiskyTruthyFalsyComparison */
-        return is_string($location_csv)
-            ? $serviceList->containsLocation($location_csv)
-            : $serviceList;
+        if (!is_string($location_csv)) {
+            return $serviceList;
+        }
+        $filtered = new Collection($serviceList->getArrayCopy());
+        return $filtered->containsLocation($location_csv);
     }
 
     /**
@@ -67,8 +67,7 @@ class Service extends Base
     {
         #echo '<pre>' . print_r($this,1) . '</pre>';exit;
         $servicelist = $this->getItemList();
-        /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if ($location_csv) {
+        if (is_string($location_csv) && $location_csv !== '') {
             $servicelist = new Collection(array_filter((array) $servicelist, function ($item) use ($location_csv) {
                 $service = new Entity($item);
                 return $service->containsLocation($location_csv);

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -61,7 +61,7 @@ class Service extends Base
     /**
      * @return Collection
      *
-     * @param false|string $location_csv
+     * @param bool|string $location_csv
      */
     public function fetchList(bool|string $location_csv = false)
     {

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -50,7 +50,9 @@ class Service extends Base
                 return ($nameMatch || $keywordMatch);
             }));
         }
-        $serviceList = new Collection($serviceList->sortByName()->getArrayCopy());
+        /** @var array<int|string, Entity> $sortedItems */
+        $sortedItems = $serviceList->sortByName()->getArrayCopy();
+        $serviceList = new Collection($sortedItems);
         if (!is_string($location_csv)) {
             return $serviceList;
         }

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -85,6 +85,9 @@ class Service extends Base
     public function fetchListRelated(mixed $service_id)
     {
         $service = $this->fetchId($service_id);
+        if ($service === false) {
+            return new Collection();
+        }
         $serviceList = $this->getItemList();
 
         $relatedList = new Collection(
@@ -168,7 +171,9 @@ class Service extends Base
             $servicelist = $this->fetchFromCsv($servicelistCSV);
             return $servicelist;
         }
-        return $itemlist->sortByName();
+        /** @var Collection $sorted */
+        $sorted = $itemlist->sortByName();
+        return $sorted;
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/File/Service.php
+++ b/zmsdldb/src/Zmsdldb/File/Service.php
@@ -52,6 +52,7 @@ class Service extends Base
         }
         $serviceList = $serviceList->sortByName();
         /** @var Collection $serviceList */
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         return ($location_csv) ? $serviceList->containsLocation($location_csv) : $serviceList;
     }
 

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -13,6 +13,7 @@ use BO\Zmsdldb\Entity\Setting as Entity;
 /**
   * Common methods shared by access classes
   *
+  * @extends Base<Settings, \BO\Zmsdldb\Entity\Base>
   */
 class Setting extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -26,7 +26,7 @@ class Setting extends Base
     }
 
     /** @psalm-api */
-    public function fetchName(mixed $name): \BO\Zmsdldb\Entity\Base|string|false|null
+    public function fetchName(string $name): \BO\Zmsdldb\Entity\Base|string|false|null
     {
         return $this->fetchId($name);
     }

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -27,7 +27,7 @@ class Setting extends Base
     }
 
     /** @psalm-api */
-    public function fetchName(mixed $name): \BO\Zmsdldb\Entity\Base|false
+    public function fetchName(mixed $name): \BO\Zmsdldb\Entity\Base|string|false|null
     {
         return $this->fetchId($name);
     }

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -20,13 +20,13 @@ class Setting extends Base
      * @return Settings
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         return new Settings($data['data']['settings']);
     }
 
     /** @psalm-api */
-    public function fetchName($name)
+    public function fetchName(mixed $name)
     {
         return $this->fetchId($name);
     }

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -8,7 +8,6 @@
 namespace BO\Zmsdldb\File;
 
 use BO\Zmsdldb\Collection\Settings;
-use BO\Zmsdldb\Entity\Setting as Entity;
 
 /**
   * Common methods shared by access classes

--- a/zmsdldb/src/Zmsdldb/File/Setting.php
+++ b/zmsdldb/src/Zmsdldb/File/Setting.php
@@ -26,7 +26,7 @@ class Setting extends Base
     }
 
     /** @psalm-api */
-    public function fetchName(mixed $name)
+    public function fetchName(mixed $name): \BO\Zmsdldb\Entity\Base|false
     {
         return $this->fetchId($name);
     }

--- a/zmsdldb/src/Zmsdldb/File/Topic.php
+++ b/zmsdldb/src/Zmsdldb/File/Topic.php
@@ -12,6 +12,8 @@ use BO\Zmsdldb\Collection\Topics as Collection;
 
 /**
  * Common methods shared by access classes
+ *
+ * @extends Base<Collection, Entity>
  */
 class Topic extends Base
 {

--- a/zmsdldb/src/Zmsdldb/File/Topic.php
+++ b/zmsdldb/src/Zmsdldb/File/Topic.php
@@ -60,7 +60,7 @@ class Topic extends Base
     }
 
     /**
-     * @return Entity
+     * @return Entity|Collection
      * @psalm-api
      */
     public function readSearchResultList(mixed $querystring)

--- a/zmsdldb/src/Zmsdldb/File/Topic.php
+++ b/zmsdldb/src/Zmsdldb/File/Topic.php
@@ -19,7 +19,7 @@ class Topic extends Base
      * @return Collection
      */
     #[\Override]
-    protected function parseData($data)
+    protected function parseData(mixed $data)
     {
         $itemList = new Collection();
         foreach ($data['data'] as $item) {
@@ -46,7 +46,7 @@ class Topic extends Base
      * @return Entity|false
      * @psalm-api
      */
-    public function fetchPath($topic_path)
+    public function fetchPath(mixed $topic_path)
     {
         $topiclist = $this->fetchList();
         foreach ($topiclist as $topic) {
@@ -61,7 +61,7 @@ class Topic extends Base
      * @return Entity
      * @psalm-api
      */
-    public function readSearchResultList($querystring)
+    public function readSearchResultList(mixed $querystring)
     {
         $topic = new Entity();
         $topic['relation']['locations'] = $this->access()->fromLocation()->readSearchResultList($querystring);

--- a/zmsdldb/src/Zmsdldb/FileAccess.php
+++ b/zmsdldb/src/Zmsdldb/FileAccess.php
@@ -173,6 +173,7 @@ class FileAccess extends AbstractAccess
     public function fetchTopicServicesList(mixed $topic_path): mixed
     {
         trigger_error("Deprecated function fetchTopicServicesList, use fromService()->fetchTopic()");
+        /** @psalm-suppress UndefinedMethod */
         return $this->fromService()->fetchTopicPath($topic_path);
     }
 
@@ -186,6 +187,7 @@ class FileAccess extends AbstractAccess
     public function fetchLocationListByOffice(bool $officepath = false)
     {
         trigger_error("Deprecated function fetchLocationListByOffice, use fromAuthority()->fetchOffice()");
+        /** @psalm-suppress UndefinedMethod */
         return $this->fromAuthority()->fetchOffice($officepath);
     }
 }

--- a/zmsdldb/src/Zmsdldb/FileAccess.php
+++ b/zmsdldb/src/Zmsdldb/FileAccess.php
@@ -170,7 +170,7 @@ class FileAccess extends AbstractAccess
      * @todo refactor: returns services, not topics.
      * @psalm-api
      */
-    public function fetchTopicServicesList(mixed $topic_path)
+    public function fetchTopicServicesList(mixed $topic_path): mixed
     {
         trigger_error("Deprecated function fetchTopicServicesList, use fromService()->fetchTopic()");
         return $this->fromService()->fetchTopicPath($topic_path);

--- a/zmsdldb/src/Zmsdldb/FileAccess.php
+++ b/zmsdldb/src/Zmsdldb/FileAccess.php
@@ -18,11 +18,11 @@ class FileAccess extends AbstractAccess
      * @return self
      */
     public function __construct(
-        $locationJson = null,
-        $serviceJson = null,
-        $topicsJson = null,
-        $authoritiesJson = null,
-        $settingsJson = null
+        mixed $locationJson = null,
+        mixed $serviceJson = null,
+        mixed $topicsJson = null,
+        mixed $authoritiesJson = null,
+        mixed $settingsJson = null
     ) {
         if (null !== $locationJson) {
             $this->loadLocations($locationJson);
@@ -67,7 +67,7 @@ class FileAccess extends AbstractAccess
     /**
      * @psalm-api
      */
-    public function loadLocationsFromPathByLocale($path, $locale): void
+    public function loadLocationsFromPathByLocale(mixed $path, mixed $locale): void
     {
         $this->loadLocations($path . DIRECTORY_SEPARATOR . 'locations_' . $locale . '.json', $locale);
     }
@@ -75,7 +75,7 @@ class FileAccess extends AbstractAccess
     /**
      * @psalm-api
      */
-    public function loadServicesFromPathByLocale($path, $locale): void
+    public function loadServicesFromPathByLocale(mixed $path, mixed $locale): void
     {
         $this->loadServices($path . DIRECTORY_SEPARATOR . 'services_' . $locale . '.json', $locale);
     }
@@ -83,7 +83,7 @@ class FileAccess extends AbstractAccess
     /**
      * @psalm-api
      */
-    public function loadTopicsFromPathByLocale($path, $locale): void
+    public function loadTopicsFromPathByLocale(mixed $path, mixed $locale): void
     {
         $this->loadTopics($path . DIRECTORY_SEPARATOR . 'topic_' . $locale . '.json', $locale);
     }
@@ -91,7 +91,7 @@ class FileAccess extends AbstractAccess
     /**
      * @psalm-api
      */
-    public function loadAuthoritiesFromPathByLocale($path, $locale): void
+    public function loadAuthoritiesFromPathByLocale(mixed $path, mixed $locale): void
     {
         $this->loadAuthorities($path . DIRECTORY_SEPARATOR . 'authority_' . $locale . '.json', $locale);
     }
@@ -99,7 +99,7 @@ class FileAccess extends AbstractAccess
     /**
      * @psalm-api
      */
-    public function loadSettingsFromPath($path): void
+    public function loadSettingsFromPath(mixed $path): void
     {
         $this->loadSettings($path . DIRECTORY_SEPARATOR . 'settings.json');
     }
@@ -170,7 +170,7 @@ class FileAccess extends AbstractAccess
      * @todo refactor: returns services, not topics.
      * @psalm-api
      */
-    public function fetchTopicServicesList($topic_path)
+    public function fetchTopicServicesList(mixed $topic_path)
     {
         trigger_error("Deprecated function fetchTopicServicesList, use fromService()->fetchTopic()");
         return $this->fromService()->fetchTopicPath($topic_path);
@@ -183,7 +183,7 @@ class FileAccess extends AbstractAccess
      * @return \BO\Zmsdldb\Collection\Authorities
      * @psalm-api
      */
-    public function fetchLocationListByOffice($officepath = false)
+    public function fetchLocationListByOffice(bool $officepath = false)
     {
         trigger_error("Deprecated function fetchLocationListByOffice, use fromAuthority()->fetchOffice()");
         return $this->fromAuthority()->fetchOffice($officepath);

--- a/zmsdldb/src/Zmsdldb/FileAccess.php
+++ b/zmsdldb/src/Zmsdldb/FileAccess.php
@@ -184,7 +184,7 @@ class FileAccess extends AbstractAccess
      * @return \BO\Zmsdldb\Collection\Authorities
      * @psalm-api
      */
-    public function fetchLocationListByOffice(bool $officepath = false)
+    public function fetchLocationListByOffice(string|false $officepath = false)
     {
         trigger_error("Deprecated function fetchLocationListByOffice, use fromAuthority()->fetchOffice()");
         /** @psalm-suppress UndefinedMethod */

--- a/zmsdldb/src/Zmsdldb/Helper/DateTime.php
+++ b/zmsdldb/src/Zmsdldb/Helper/DateTime.php
@@ -10,8 +10,8 @@ class DateTime extends \DateTimeImmutable
     public static function getFormatedDates(
         \DateTimeImmutable $timestamp,
         string $pattern = 'MMMM',
-        $locale = 'de_DE',
-        $timezone = 'Europe/Berlin'
+        string $locale = 'de_DE',
+        string $timezone = 'Europe/Berlin'
     ): string|false {
         $dateFormatter = new \IntlDateFormatter(
             $locale,

--- a/zmsdldb/src/Zmsdldb/Helper/Sorter.php
+++ b/zmsdldb/src/Zmsdldb/Helper/Sorter.php
@@ -10,7 +10,7 @@ class Sorter
     /**
      * @todo check against ISO definition
      */
-    public static function toSortableString($string): string
+    public static function toSortableString(mixed $string): string
     {
         $string = strtr($string, array(
             'Ä' => 'Ae',

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -66,6 +66,7 @@ abstract class Base implements Options
                 array_unshift($args, $this->getPDOAccess());
                 /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Base> $ImporterClass */
                 /** @psalm-suppress UnsafeInstantiation */
+                /** @psalm-suppress InvalidStringClass */
                 $instance = new $ImporterClass(...$args);
                 if (!$instance instanceof \BO\Zmsdldb\Importer\MySQL\Base) {
                     throw new \InvalidArgumentException(

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -23,14 +23,14 @@ abstract class Base implements Options
     use PDOTrait;
     use OptionsTrait;
 
-    protected $fileAccess;
+    protected \BO\Zmsdldb\FileAccess $fileAccess;
 
-    protected $localeList = [
+    protected array $localeList = [
         'de',
         'en'
     ];
 
-    protected $importTypes = [
+    protected mixed $importTypes = [
         'Services' => 'Service',
         'Locations' => 'Location',
         'Authorities' => 'Authority',

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -173,7 +173,7 @@ abstract class Base implements Options
     {
         try {
             $importer = $this->getSettingsImporter(
-                $this->fileAccess->fromSetting('de')->getData(),
+                $this->fileAccess->fromSetting()->getData(),
                 'de',
                 $this->getOptions()
             );

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -64,15 +64,17 @@ abstract class Base implements Options
             if (preg_match('/get(?P<importer>[A-Za-z]+)Importer/', $method, $matches)) {
                 $ImporterClass = static::class . '\\' . $matches['importer'];
                 array_unshift($args, $this->getPDOAccess());
-                /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Base> $ImporterClass */
-                /** @psalm-suppress UnsafeInstantiation */
-                /** @psalm-suppress InvalidStringClass */
-                $instance = new $ImporterClass(...$args);
-                if (!$instance instanceof \BO\Zmsdldb\Importer\MySQL\Base) {
+                if (
+                    !class_exists($ImporterClass)
+                    || !is_a($ImporterClass, \BO\Zmsdldb\Importer\MySQL\Base::class, true)
+                ) {
                     throw new \InvalidArgumentException(
                         $ImporterClass . ' must extend \\BO\\Zmsdldb\\Importer\\MySQL\\Base'
                     );
                 }
+                /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Base> $ImporterClass */
+                /** @psalm-suppress UnsafeInstantiation */
+                $instance = new $ImporterClass(...$args);
                 return $instance;
             }
             throw new \BadMethodCallException('Method ' . $method . ' not found!');

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -64,6 +64,7 @@ abstract class Base implements Options
             if (preg_match('/get(?P<importer>[A-Za-z]+)Importer/', $method, $matches)) {
                 $ImporterClass = static::class . '\\' . $matches['importer'];
                 array_unshift($args, $this->getPDOAccess());
+                /** @var class-string<\BO\Zmsdldb\Importer\MySQL\Base> $ImporterClass */
                 /** @psalm-suppress UnsafeInstantiation */
                 $instance = new $ImporterClass(...$args);
                 if (!$instance instanceof \BO\Zmsdldb\Importer\MySQL\Base) {

--- a/zmsdldb/src/Zmsdldb/Importer/Base.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Base.php
@@ -164,7 +164,7 @@ abstract class Base implements Options
 
     /**
      *
-     * @return self
+     * @return void
      * @psalm-api
      */
     protected function importSettings()
@@ -185,7 +185,7 @@ abstract class Base implements Options
 
     /**
      *
-     * @return self
+     * @return void
      * @psalm-api
      */
     protected function importTopics()
@@ -207,7 +207,7 @@ abstract class Base implements Options
 
     /**
      *
-     * @return self
+     * @return void
      * @psalm-api
      */
     protected function importAuthorities()

--- a/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
+++ b/zmsdldb/src/Zmsdldb/Importer/MySQL/Entity/Service.php
@@ -2,8 +2,6 @@
 
 namespace BO\Zmsdldb\Importer\MySQL\Entity;
 
-use Error;
-
 class Service extends Base
 {
     protected array $fieldMapping = [

--- a/zmsdldb/src/Zmsdldb/Importer/Options.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Options.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer;
 
 interface Options
 {
-    const int OPTION_NONE = 0;
-    const int OPTION_CLEAR_ENTITIY_TABLE = 2;
-    const int OPTION_CLEAR_ENTITIY_REFERENCES_TABLES = 4;
+    public const int OPTION_NONE = 0;
+    public const int OPTION_CLEAR_ENTITIY_TABLE = 2;
+    public const int OPTION_CLEAR_ENTITIY_REFERENCES_TABLES = 4;
 }

--- a/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
@@ -4,7 +4,7 @@ namespace BO\Zmsdldb\Importer;
 
 trait OptionsTrait
 {
-    protected $options = 0;
+    protected int $options = 0;
 
     protected function checkOptionFlag(int $optionFlag = 0): mixed
     {

--- a/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
@@ -6,7 +6,7 @@ trait OptionsTrait
 {
     protected $options = 0;
 
-    protected function checkOptionFlag(int $optionFlag = 0)
+    protected function checkOptionFlag(int $optionFlag = 0): mixed
     {
         return $this->options & $optionFlag;
     }

--- a/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/OptionsTrait.php
@@ -6,7 +6,7 @@ trait OptionsTrait
 {
     protected $options = 0;
 
-    protected function checkOptionFlag($optionFlag = 0)
+    protected function checkOptionFlag(int $optionFlag = 0)
     {
         return $this->options & $optionFlag;
     }

--- a/zmsdldb/src/Zmsdldb/Importer/PDOTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/PDOTrait.php
@@ -23,7 +23,7 @@ trait PDOTrait
      * parameters see https://www.php.net/manual/de/pdo.query.php
      * @psalm-api
      */
-    public function query(...$args)
+    public function query(mixed ...$args)
     {
         try {
             return $this->getPDOAccess()->query(...$args);
@@ -37,7 +37,7 @@ trait PDOTrait
      * @psalm-api
      */
 
-    public function exec(...$args)
+    public function exec(mixed ...$args)
     {
         try {
             return $this->getPDOAccess()->exec(...$args);
@@ -50,7 +50,7 @@ trait PDOTrait
      * parameters see https://www.php.net/manual/de/pdo.prepare.php
      * @psalm-api
      */
-    public function prepare(...$args)
+    public function prepare(mixed ...$args)
     {
         try {
             return $this->getPDOAccess()->prepare(...$args);

--- a/zmsdldb/src/Zmsdldb/Importer/PDOTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/PDOTrait.php
@@ -23,7 +23,7 @@ trait PDOTrait
      * parameters see https://www.php.net/manual/de/pdo.query.php
      * @psalm-api
      */
-    public function query(mixed ...$args)
+    public function query(mixed ...$args): mixed
     {
         try {
             return $this->getPDOAccess()->query(...$args);
@@ -37,7 +37,7 @@ trait PDOTrait
      * @psalm-api
      */
 
-    public function exec(mixed ...$args)
+    public function exec(mixed ...$args): mixed
     {
         try {
             return $this->getPDOAccess()->exec(...$args);
@@ -50,7 +50,7 @@ trait PDOTrait
      * parameters see https://www.php.net/manual/de/pdo.prepare.php
      * @psalm-api
      */
-    public function prepare(mixed ...$args)
+    public function prepare(mixed ...$args): mixed
     {
         try {
             return $this->getPDOAccess()->prepare(...$args);
@@ -59,7 +59,7 @@ trait PDOTrait
         }
     }
 
-    public function beginTransaction()
+    public function beginTransaction(): mixed
     {
         try {
             return $this->getPDOAccess()->beginTransaction();
@@ -68,7 +68,7 @@ trait PDOTrait
         }
     }
 
-    public function commit()
+    public function commit(): mixed
     {
         try {
             return $this->getPDOAccess()->commit();
@@ -77,7 +77,7 @@ trait PDOTrait
         }
     }
 
-    public function rollBack()
+    public function rollBack(): mixed
     {
         try {
             return $this->getPDOAccess()->rollBack();
@@ -87,7 +87,7 @@ trait PDOTrait
     }
 
     /** @psalm-api */
-    public function inTransaction()
+    public function inTransaction(): mixed
     {
         try {
             return $this->getPDOAccess()->inTransaction();

--- a/zmsdldb/src/Zmsdldb/Importer/PDOTrait.php
+++ b/zmsdldb/src/Zmsdldb/Importer/PDOTrait.php
@@ -6,7 +6,7 @@ use BO\Zmsdldb\PDOAccess;
 
 trait PDOTrait
 {
-    protected $pdoAccess;
+    protected mixed $pdoAccess;
 
     public function setPDOAccess(PDOAccess $pdoAccess): self
     {

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -6,10 +6,10 @@ define('DEBUG', true);
 
 class Timer
 {
-    protected $start;
-    protected $pause;
-    protected $stop;
-    protected $elapsed;# = 0;
+    protected float $start;
+    protected float|null $pause;
+    protected float|null $stop;
+    protected mixed $elapsed;# = 0;
 
     public function __construct()
     {

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -79,7 +79,7 @@ class Timer
         return $hours . "h:" . $minutes . "m:" . $seconds . "s";
     }
 
-    protected static function roundMicroTime($microTime): float
+    protected static function roundMicroTime(mixed $microTime): float
     {
         return round($microTime, 4, PHP_ROUND_HALF_UP);
     }

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -7,8 +7,8 @@ define('DEBUG', true);
 class Timer
 {
     protected float $start;
-    protected float|null $pause;
-    protected float|null $stop;
+    protected float|null $pause = null;
+    protected float|null $stop = null;
     protected mixed $elapsed;# = 0;
 
     public function __construct()

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -49,7 +49,7 @@ class Timer
         $this->start = Timer::getMicroTime();
     }
 
-    public function getTime()
+    public function getTime(): string
     {
         if (!isset($this->stop)) {
             $this->stop = Timer::getMicroTime();
@@ -58,7 +58,7 @@ class Timer
     }
 
     /** @psalm-api */
-    protected function getLapTime()
+    protected function getLapTime(): string
     {
         return $this->timeToString();
     }

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -9,7 +9,7 @@ class Timer
     protected float $start;
     protected float|null $pause = null;
     protected float|null $stop = null;
-    protected mixed $elapsed;# = 0;
+    protected float $elapsed = 0.0;
 
     public function __construct()
     {

--- a/zmsdldb/src/Zmsdldb/Importer/Timer.php
+++ b/zmsdldb/src/Zmsdldb/Importer/Timer.php
@@ -71,7 +71,7 @@ class Timer
 
     protected function timeToString(): string
     {
-        $seconds = ($this->stop - $this->start) + $this->elapsed;
+        $seconds = ((float) ($this->stop ?? 0) - $this->start) + (float) ($this->elapsed ?? 0);
         $seconds = Timer::roundMicroTime($seconds);
         $hours = floor($seconds / (60 * 60));
         $divisorForMinutes = $seconds % (60 * 60);

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -72,7 +72,7 @@ class ElasticSearch
      * @param String $servicesFile
      *            (optional)
      */
-    public function __construct($importOrLocationFile, $servicesFile = null)
+    public function __construct(mixed $importOrLocationFile, $servicesFile = null)
     {
         if (is_dir($importOrLocationFile)) {
             $this->dldb = new FileAccess();
@@ -223,7 +223,7 @@ class ElasticSearch
      *
      * @return self
      */
-    public function setHost($host)
+    public function setHost(mixed $host)
     {
         $this->host = $host;
         return $this;
@@ -233,7 +233,7 @@ class ElasticSearch
      *
      * @return self
      */
-    public function setPort($port)
+    public function setPort(mixed $port)
     {
         $this->port = $port;
         return $this;
@@ -243,7 +243,7 @@ class ElasticSearch
      *
      * @return self
      */
-    public function setTransport($transport)
+    public function setTransport(mixed $transport)
     {
         $this->transport = $transport;
         return $this;
@@ -254,7 +254,7 @@ class ElasticSearch
      *
      * @return self
      */
-    public function setAlias($alias)
+    public function setAlias(mixed $alias)
     {
         $this->getIndex()->refresh();
         $this->getIndex()->addAlias($alias, true);

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -18,7 +18,7 @@ class ElasticSearch
 
     const string ES_INDEX_DATE = 'Ymd-His';
 
-    protected $localeList = array(
+    protected mixed $localeList = array(
         'de',
         'en'
     );

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -212,6 +212,9 @@ class ElasticSearch
             $this->index = $connection->getIndex(self::ES_INDEX_PREFIX . date(self::ES_INDEX_DATE));
             if (! $this->index->exists()) {
                 $indexSettings = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'ElasticSearch_Index.json');
+                if ($indexSettings === false) {
+                    throw new \RuntimeException('Cannot read ElasticSearch_Index.json');
+                }
                 $indexSettings = json_decode($indexSettings, true);
                 $this->index->create($indexSettings);
             }

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -14,9 +14,9 @@ use BO\Zmsdldb\FileAccess;
  */
 class ElasticSearch
 {
-    const string ES_INDEX_PREFIX = 'dldb-';
+    public const string ES_INDEX_PREFIX = 'dldb-';
 
-    const string ES_INDEX_DATE = 'Ymd-His';
+    public const string ES_INDEX_DATE = 'Ymd-His';
 
     protected mixed $localeList = array(
         'de',

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -99,7 +99,7 @@ class ElasticSearch
 
     /**
      *
-     * @return self
+     * @return array
      */
     protected function readTopics()
     {
@@ -133,7 +133,7 @@ class ElasticSearch
 
     /**
      *
-     * @return self
+     * @return array
      */
     protected function readServices()
     {
@@ -151,7 +151,7 @@ class ElasticSearch
 
     /**
      *
-     * @return self
+     * @return array
      */
     protected function readLocations()
     {
@@ -169,7 +169,7 @@ class ElasticSearch
 
     /**
      *
-     * @return self
+     * @return array
      */
     protected function readAuthorities()
     {

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -54,16 +54,16 @@ class ElasticSearch
     /**
      * The client used to talk to elastic search.
      *
-     * @var \Elastica\Client
+     * @var \Elastica\Client|null
      */
-    protected $connection;
+    protected $connection = null;
 
     /**
      * Index from elastic search
      *
-     * @var \Elastica\Index $index
+     * @var \Elastica\Index|null $index
      */
-    protected $index;
+    protected $index = null;
 
     /**
      * Due to backward compatibility, the first parameter has two possible meanings

--- a/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
+++ b/zmsdldb/src/Zmsdldb/Indexer/ElasticSearch.php
@@ -213,6 +213,7 @@ class ElasticSearch
             if (! $this->index->exists()) {
                 $indexSettings = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'ElasticSearch_Index.json');
                 if ($indexSettings === false) {
+                    $this->index = null;
                     throw new \RuntimeException('Cannot read ElasticSearch_Index.json');
                 }
                 $indexSettings = json_decode($indexSettings, true);

--- a/zmsdldb/src/Zmsdldb/MySQL/Authority.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Authority.php
@@ -30,7 +30,7 @@ class Authority extends Base
             $sqlArgs = [];
 
             /** @psalm-suppress RiskyTruthyFalsyComparison */
-            if (!empty($servicelist)) {
+            if (is_array($servicelist) && $servicelist !== []) {
                 $sqlArgs = ['de',$this->locale];
                 $questionMarks = array_fill(0, count($servicelist), '?');
 

--- a/zmsdldb/src/Zmsdldb/MySQL/Authority.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Authority.php
@@ -22,7 +22,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(bool|array $servicelist = []): Collection
+    public function fetchList(mixed $servicelist = []): Collection
     {
         try {
             $authorityList = new Collection();

--- a/zmsdldb/src/Zmsdldb/MySQL/Authority.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Authority.php
@@ -22,7 +22,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList($servicelist = []): Collection
+    public function fetchList(array $servicelist = []): Collection
     {
         try {
             $authorityList = new Collection();
@@ -145,7 +145,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function readListByOfficePath($officepath): Collection
+    public function readListByOfficePath(mixed $officepath): Collection
     {
         $authorityList = new Collection();
 

--- a/zmsdldb/src/Zmsdldb/MySQL/Authority.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Authority.php
@@ -29,6 +29,7 @@ class Authority extends Base
 
             $sqlArgs = [];
 
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if (!empty($servicelist)) {
                 $sqlArgs = ['de',$this->locale];
                 $questionMarks = array_fill(0, count($servicelist), '?');

--- a/zmsdldb/src/Zmsdldb/MySQL/Authority.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Authority.php
@@ -22,7 +22,7 @@ class Authority extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchList(array $servicelist = []): Collection
+    public function fetchList(bool|array $servicelist = []): Collection
     {
         try {
             $authorityList = new Collection();

--- a/zmsdldb/src/Zmsdldb/MySQL/Link.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Link.php
@@ -14,7 +14,7 @@ use BO\Zmsdldb\Elastic\Link as Base;
 class Link extends Base
 {
     #[\Override]
-    public function readSearchResultList($query): Collection
+    public function readSearchResultList(mixed $query): Collection
     {
         try {
             #$query = '+' . implode(' +', explode(' ', $query));

--- a/zmsdldb/src/Zmsdldb/MySQL/Location.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Location.php
@@ -41,7 +41,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchList($service_csv = false, $mixLanguages = false): Collection
+    public function fetchList(bool $service_csv = false, bool $mixLanguages = false): Collection
     {
         # COALESCE(l2.data_json, l.data_json) AS data_json
         # IF(l2.id, l2.data_json, l.data_json) AS data_json
@@ -94,7 +94,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchListByOffice($office, $mixLanguages = false): Collection
+    public function fetchListByOffice(mixed $office, bool $mixLanguages = false): Collection
     {
         try {
             $sqlArgs = [$this->locale];
@@ -141,7 +141,7 @@ class Location extends Base
      * @return Collection
      */
     #[\Override]
-    public function fetchFromCsv($location_csv, $mixLanguages = false): Collection
+    public function fetchFromCsv(mixed $location_csv, bool $mixLanguages = false): Collection
     {
         try {
             $sqlArgs = [$this->locale];
@@ -183,7 +183,7 @@ class Location extends Base
     }
 
     #[\Override]
-    protected function fetchGeoJsonLocations($category, $getAll): Collection
+    protected function fetchGeoJsonLocations(mixed $category, mixed $getAll): Collection
     {
         try {
             $sqlArgs = [$this->locale, $this->locale, $this->locale];
@@ -242,7 +242,7 @@ class Location extends Base
      * @todo Refactoring required, functions in this class should return entities, not JSON data
      */
     #[\Override]
-    public function fetchGeoJson($category = null, $getAll = false): array
+    public function fetchGeoJson(mixed $category = null, bool $getAll = false): array
     {
         $locationList = $this->fetchGeoJsonLocations($category, $getAll);
         $geoJson = [];
@@ -273,7 +273,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function readSearchResultList($query, $service_csv = null): Collection
+    public function readSearchResultList(mixed $query, mixed $service_csv = null): Collection
     {
         try {
             #$query = '+' . implode(' +', explode(' ', $query));
@@ -313,7 +313,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchLocationsForCompilation($authoritys = [], $locations = []): Collection
+    public function fetchLocationsForCompilation(array $authoritys = [], array $locations = []): Collection
     {
         try {
             $sqlArgs = [$this->locale];

--- a/zmsdldb/src/Zmsdldb/MySQL/Location.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Location.php
@@ -325,11 +325,19 @@ class Location extends Base
             $where = ['l.locale = ?'];
 
             if (!empty($authoritys)) {
-                $where[] = 'l.authority_id IN (' . implode(',', $authoritys) . ')';
+                $placeholders = implode(',', array_fill(0, count($authoritys), '?'));
+                $where[] = 'l.authority_id IN (' . $placeholders . ')';
+                foreach ($authoritys as $authorityId) {
+                    $sqlArgs[] = (int) $authorityId;
+                }
             }
 
             if (!empty($locations)) {
-                $where[] = 'l.id IN (' . implode(',', $locations) . ')';
+                $placeholders = implode(',', array_fill(0, count($locations), '?'));
+                $where[] = 'l.id IN (' . $placeholders . ')';
+                foreach ($locations as $locationId) {
+                    $sqlArgs[] = (int) $locationId;
+                }
             }
 
             $sql .= ' WHERE ' . implode(' AND ', $where);

--- a/zmsdldb/src/Zmsdldb/MySQL/Location.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Location.php
@@ -41,7 +41,7 @@ class Location extends Base
     }
 
     #[\Override]
-    public function fetchList(bool $service_csv = false, bool $mixLanguages = false): Collection
+    public function fetchList(bool|string $service_csv = false, bool $mixLanguages = false): Collection
     {
         # COALESCE(l2.data_json, l.data_json) AS data_json
         # IF(l2.id, l2.data_json, l.data_json) AS data_json

--- a/zmsdldb/src/Zmsdldb/MySQL/Setting.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Setting.php
@@ -16,7 +16,7 @@ use BO\Zmsdldb\File\Setting as Base;
 class Setting extends Base
 {
     #[\Override]
-    public function fetchName($name): ?string
+    public function fetchName(mixed $name): ?string
     {
         try {
             $sql = 'SELECT value FROM setting WHERE name = ?';

--- a/zmsdldb/src/Zmsdldb/MySQL/Setting.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Setting.php
@@ -16,7 +16,7 @@ use BO\Zmsdldb\File\Setting as Base;
 class Setting extends Base
 {
     #[\Override]
-    public function fetchName(mixed $name): ?string
+    public function fetchName(mixed $name): \BO\Zmsdldb\Entity\Base|string|false|null
     {
         try {
             $sql = 'SELECT value FROM setting WHERE name = ?';

--- a/zmsdldb/src/Zmsdldb/MySQL/Topic.php
+++ b/zmsdldb/src/Zmsdldb/MySQL/Topic.php
@@ -43,7 +43,7 @@ class Topic extends Base
      * @return Entity|false
      */
     #[\Override]
-    public function fetchPath($topic_path): Entity|false
+    public function fetchPath(mixed $topic_path): Entity|false
     {
         try {
             $sqlArgs = [$this->locale, $topic_path];
@@ -89,7 +89,7 @@ class Topic extends Base
     }
 
     #[\Override]
-    public function readSearchResultList($querystring): Collection
+    public function readSearchResultList(mixed $querystring): Collection
     {
         try {
             #$querystring = '+' . implode(' +', explode(' ', $querystring));

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -48,7 +48,7 @@ abstract class PDOAccess extends AbstractAccess
             } else {
                 $this->connect($options);
             }
-            $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $this->requirePdo()->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $this->postConnect();
         } catch (\Exception $e) {
             throw $e;
@@ -94,6 +94,14 @@ abstract class PDOAccess extends AbstractAccess
 
     abstract protected function connect(array $options): void;
 
+    protected function requirePdo(): \PDO
+    {
+        if (!$this->pdo instanceof \PDO) {
+            throw new \RuntimeException('PDO connection is not initialized');
+        }
+        return $this->pdo;
+    }
+
     /** @psalm-api */
     public function getConnection(): mixed
     {
@@ -107,7 +115,7 @@ abstract class PDOAccess extends AbstractAccess
     public function query(mixed ...$args): mixed
     {
         try {
-            return $this->pdo->query(...$args);
+            return $this->requirePdo()->query(...$args);
         } catch (\Exception $e) {
             throw $e;
         }
@@ -119,7 +127,7 @@ abstract class PDOAccess extends AbstractAccess
     public function exec(string ...$args): mixed
     {
         try {
-            return $this->pdo->exec(...$args);
+            return $this->requirePdo()->exec(...$args);
         } catch (\Exception $e) {
             throw $e;
         }
@@ -131,7 +139,7 @@ abstract class PDOAccess extends AbstractAccess
     public function prepare(string ...$args): mixed
     {
         try {
-            return $this->pdo->prepare(...$args);
+            return $this->requirePdo()->prepare(...$args);
         } catch (\Exception $e) {
             throw $e;
         }
@@ -146,7 +154,7 @@ abstract class PDOAccess extends AbstractAccess
             if ($this->inTransaction()) {
                 return true;
             }
-            return $this->pdo->beginTransaction();
+            return $this->requirePdo()->beginTransaction();
         } catch (\Exception $e) {
             throw $e;
         }
@@ -157,7 +165,7 @@ abstract class PDOAccess extends AbstractAccess
         try {
             $this->transactionCount--;
             if ($this->transactionCount == 0 && $this->inTransaction()) {
-                return $this->pdo->commit();
+                return $this->requirePdo()->commit();
             } elseif (!$this->inTransaction()) {
                 trigger_error(__METHOD__ . ' no transaction started');
             }
@@ -172,7 +180,7 @@ abstract class PDOAccess extends AbstractAccess
         try {
             $this->transactionCount--;
             if ($this->transactionCount == 0 && $this->inTransaction()) {
-                return $this->pdo->rollBack();
+                return $this->requirePdo()->rollBack();
             } elseif (!$this->inTransaction()) {
                 trigger_error(__METHOD__ . ' no transaction started');
             }
@@ -185,7 +193,7 @@ abstract class PDOAccess extends AbstractAccess
     public function inTransaction(): mixed
     {
         try {
-            return $this->pdo->inTransaction();
+            return $this->requirePdo()->inTransaction();
         } catch (\Exception $e) {
             throw $e;
         }

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -136,7 +136,7 @@ abstract class PDOAccess extends AbstractAccess
     /**
      * parameters see https://www.php.net/manual/de/pdo.prepare.php
      */
-    public function prepare(string ...$args): mixed
+    public function prepare(mixed ...$args): mixed
     {
         try {
             return $this->requirePdo()->prepare(...$args);

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -7,9 +7,9 @@ abstract class PDOAccess extends AbstractAccess
     /**
      * @SuppressWarnings(PHPMD.LongVariable)
      */
-    protected $accessorClassName = [];
+    protected mixed $accessorClassName = [];
 
-    protected $accessorNamesPlural = [
+    protected array $accessorNamesPlural = [
         'Authority' => 'Authorities',
         'Borough' => 'Boroughs',
         'Link' => 'Links',
@@ -20,7 +20,7 @@ abstract class PDOAccess extends AbstractAccess
         'Topic' => 'Topics'
     ];
 
-    protected $pdo;
+    protected PDO|null $pdo;
 
     protected string $engine = 'SQLite';
 
@@ -137,7 +137,7 @@ abstract class PDOAccess extends AbstractAccess
         }
     }
 
-    protected $transactionCount = 0;
+    protected int $transactionCount = 0;
 
     public function beginTransaction(): mixed
     {

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -20,7 +20,7 @@ abstract class PDOAccess extends AbstractAccess
         'Topic' => 'Topics'
     ];
 
-    protected PDO|null $pdo;
+    protected ?\PDO $pdo;
 
     protected string $engine = 'SQLite';
 

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -20,7 +20,7 @@ abstract class PDOAccess extends AbstractAccess
         'Topic' => 'Topics'
     ];
 
-    protected ?\PDO $pdo;
+    protected ?\PDO $pdo = null;
 
     protected string $engine = 'SQLite';
 

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -77,7 +77,7 @@ abstract class PDOAccess extends AbstractAccess
     {
     }
 
-    public function loadAccessor(string $name, string $locale = 'de')
+    public function loadAccessor(string $name, string $locale = 'de'): mixed
     {
         if (isset($this->accessorClassName[$name])) {
             if (null === $this->accessInstance[$locale][$this->accessorClassName[$name]]) {
@@ -95,7 +95,7 @@ abstract class PDOAccess extends AbstractAccess
     abstract protected function connect(array $options): void;
 
     /** @psalm-api */
-    public function getConnection()
+    public function getConnection(): mixed
     {
         return $this->pdo;
     }
@@ -104,7 +104,7 @@ abstract class PDOAccess extends AbstractAccess
      * parameters see https://www.php.net/manual/de/pdo.query.php
      */
 
-    public function query(mixed ...$args)
+    public function query(mixed ...$args): mixed
     {
         try {
             return $this->pdo->query(...$args);
@@ -116,7 +116,7 @@ abstract class PDOAccess extends AbstractAccess
     /**
      * parameters see https://www.php.net/manual/de/pdo.exec.php
      */
-    public function exec(string ...$args)
+    public function exec(string ...$args): mixed
     {
         try {
             return $this->pdo->exec(...$args);
@@ -128,7 +128,7 @@ abstract class PDOAccess extends AbstractAccess
     /**
      * parameters see https://www.php.net/manual/de/pdo.prepare.php
      */
-    public function prepare(string ...$args)
+    public function prepare(string ...$args): mixed
     {
         try {
             return $this->pdo->prepare(...$args);
@@ -139,7 +139,7 @@ abstract class PDOAccess extends AbstractAccess
 
     protected $transactionCount = 0;
 
-    public function beginTransaction()
+    public function beginTransaction(): mixed
     {
         try {
             $this->transactionCount++;
@@ -152,7 +152,7 @@ abstract class PDOAccess extends AbstractAccess
         }
     }
 
-    public function commit()
+    public function commit(): mixed
     {
         try {
             $this->transactionCount--;
@@ -167,7 +167,7 @@ abstract class PDOAccess extends AbstractAccess
         }
     }
 
-    public function rollBack()
+    public function rollBack(): mixed
     {
         try {
             $this->transactionCount--;
@@ -182,7 +182,7 @@ abstract class PDOAccess extends AbstractAccess
         }
     }
 
-    public function inTransaction()
+    public function inTransaction(): mixed
     {
         try {
             return $this->pdo->inTransaction();

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -56,7 +56,7 @@ abstract class PDOAccess extends AbstractAccess
     }
 
     #[\Override]
-    public function __call($method, $args = [])
+    public function __call(mixed $method, array $args = [])
     {
         try {
             return parent::__call($method, $args);
@@ -104,7 +104,7 @@ abstract class PDOAccess extends AbstractAccess
      * parameters see https://www.php.net/manual/de/pdo.query.php
      */
 
-    public function query(...$args)
+    public function query(mixed ...$args)
     {
         try {
             return $this->pdo->query(...$args);

--- a/zmsdldb/src/Zmsdldb/PDOAccess.php
+++ b/zmsdldb/src/Zmsdldb/PDOAccess.php
@@ -83,6 +83,7 @@ abstract class PDOAccess extends AbstractAccess
             if (null === $this->accessInstance[$locale][$this->accessorClassName[$name]]) {
                 $accessorClass = __NAMESPACE__ . '\\' . $this->engine . '\\' . $this->accessorClassName[$name];
 
+                /** @var class-string $accessorClass */
                 $instance = new $accessorClass($this, $locale);
                 $this->accessInstance[$locale][$name] = $instance;
                 $this->accessInstance[$locale][$this->accessorNamesPlural[$name]] = $instance;

--- a/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
+++ b/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
@@ -43,7 +43,11 @@ class Coordinates
         if (!is_readable($file) || !is_file($file)) {
             throw new \Exception("Cannot read file $file");
         }
-        $this->data = json_decode(file_get_contents($file), 1);
+        $json = file_get_contents($file);
+        if ($json === false) {
+            throw new \Exception("Cannot read file $file");
+        }
+        $this->data = json_decode($json, 1);
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
+++ b/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
@@ -16,7 +16,7 @@ class Coordinates
     /**
      * @param Int $plz
      */
-    public function getLatLon($plz)
+    public function getLatLon($plz): mixed
     {
         if (array_key_exists($plz, $this->data)) {
             return $this->data[$plz];
@@ -24,7 +24,7 @@ class Coordinates
         return false;
     }
 
-    public static function zip2LatLon(mixed $plz)
+    public static function zip2LatLon(mixed $plz): mixed
     {
         $coordinates = new self();
         return $coordinates->getLatLon($plz);

--- a/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
+++ b/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
@@ -24,7 +24,7 @@ class Coordinates
         return false;
     }
 
-    public static function zip2LatLon($plz)
+    public static function zip2LatLon(mixed $plz)
     {
         $coordinates = new self();
         return $coordinates->getLatLon($plz);

--- a/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
+++ b/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
@@ -47,7 +47,15 @@ class Coordinates
         if ($json === false) {
             throw new \Exception("Cannot read file $file");
         }
-        $this->data = json_decode($json, true);
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \Exception("Cannot parse file $file", 0, $exception);
+        }
+        if (!is_array($decoded)) {
+            throw new \Exception("Invalid coordinate data in $file");
+        }
+        $this->data = $decoded;
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
+++ b/zmsdldb/src/Zmsdldb/Plz/Coordinates.php
@@ -47,7 +47,7 @@ class Coordinates
         if ($json === false) {
             throw new \Exception("Cannot read file $file");
         }
-        $this->data = json_decode($json, 1);
+        $this->data = json_decode($json, true);
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/SQLiteAccess.php
+++ b/zmsdldb/src/Zmsdldb/SQLiteAccess.php
@@ -9,8 +9,8 @@ namespace BO\Zmsdldb;
 
 class SQLiteAccess extends PDOAccess
 {
-    const string DEFAULT_DATABASE_NAME = 'dldb_frontend_dev';
-    const string DEFAULT_DATABASE_PATH = __DIR__;
+    public const string DEFAULT_DATABASE_NAME = 'dldb_frontend_dev';
+    public const string DEFAULT_DATABASE_PATH = __DIR__;
 
     #[\Override]
     protected function connect(array $options): void

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -204,7 +204,7 @@ class Munich
                 throw new \RuntimeException(
                     'Export JSON parse failed (' . $e->getMessage() . '). '
                     . 'Often means the HTTP response was not JSON (e.g. block page or missing HTTPS_PROXY in cron). '
-                    . 'Body preview: ' . $snippet,
+                    . 'Body preview: ' . (string) $snippet,
                     0,
                     $e
                 );

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
  */
 class Munich
 {
-    const array EXCLUSIVE_LOCATIONS = [
+    public const array EXCLUSIVE_LOCATIONS = [
         //SZE
         54285,
         // Standesamt München - registry office locations (exclusive, don't show alternatives)
@@ -22,7 +22,7 @@ class Munich
         103666, 103633, 101905,
     ];
 
-    const array LOCATION_PRIO_BY_DISPLAY_NAME = [
+    public const array LOCATION_PRIO_BY_DISPLAY_NAME = [
         'Bürgerbüro Ruppertstraße' => 100,
         'Bürgerbüro Orleansplatz' => 90,
         'Bürgerbüro Pasing' => 80,
@@ -41,7 +41,7 @@ class Munich
         'Feuerwache 10 - Riem / Neue Messe' => 1
     ];
 
-    const array DONT_SHOW_LOCATION_BY_SERVICES = [
+    public const array DONT_SHOW_LOCATION_BY_SERVICES = [
         [
             "locations" => [10489], // Bürgerbüro Ruppertstraße
             "services" => [1063453, 1063441, 1080582] // Reisepass, Personalausweis, Vorläufiger Reisepass
@@ -54,12 +54,12 @@ class Munich
 
     // Offices where disabledByServices/DONT_SHOW_LOCATION_BY_SERVICES are interpreted with special
     // "exclusive vs mixed" semantics in the frontend (allowDisabledServicesMix=true).
-    const array LOCATIONS_ALLOW_DISABLED_MIX = [
+    public const array LOCATIONS_ALLOW_DISABLED_MIX = [
         [10489, 10491, 10500, 10502] // Bürgerbüro Ruppertstraße (KVR-II/22) // Bürgerbüro Ruppertstraße (KVR-II/221)
     ];
 
     // Offices that share one Ort but keep pooled calendar capacity (ZMSKVR-1046 Ausbildung).
-    const array LOCATIONS_SHARED_BOOKING = [
+    public const array LOCATIONS_SHARED_BOOKING = [
         [10489, 10503, 10500, 10491] // 10491 now has some of the same services as 10489 10502 10503 which means if it exposes external appointments it must mix them otherwise shows up double.
     ];
 
@@ -76,7 +76,7 @@ class Munich
         1080716
     ];
 
-    const array SERVICE_COMBINATIONS = [
+    public const array SERVICE_COMBINATIONS = [
         //BB
         [10295182],
         [10242339, 1063475, 1063441, 1063453, 10308996, 10224136, 10225205, 10225181, 1063426, 1063428, 10306925, 10225119, 1080843, 1076889, 1078273, 1080582, 10225197, 10224132],

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -138,7 +138,7 @@ class Munich
     ];
 
     protected string $publicUrl;
-    protected Psr\Log\LoggerInterface|null $logger;
+    protected ?LoggerInterface $logger;
 
     public function __construct(string $publicUrl = '', ?LoggerInterface $logger = null)
     {
@@ -156,10 +156,12 @@ class Munich
     private function requestWithOptionalProxy(string $url): Request
     {
         $req = Request::get($url);
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         $proxy = getenv('HTTPS_PROXY') ?: getenv('https_proxy')
             ?: getenv('HTTP_PROXY') ?: getenv('http_proxy');
         if ($proxy !== false && $proxy !== '') {
             $parts = parse_url($proxy);
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if (!empty($parts['host'])) {
                 $port = isset($parts['port']) ? $parts['port'] : 80;
                 $req->useProxy($parts['host'], $port);
@@ -181,6 +183,7 @@ class Munich
             $content = $response->raw_body;
 
             // Extract JSON export URLs using regex and pick the last one (latest)
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if (!preg_match_all('#https://[^"\'\'\s<>]+\\.json#i', $content, $matches) || empty($matches[0])) {
                 throw new \RuntimeException('No JSON export links found on index page');
             }
@@ -232,6 +235,7 @@ class Munich
      */
     public function applySadbOverwrite(array $data, ?string $overwritePath = null): array
     {
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         $path = $overwritePath ?: self::defaultSadbOverwritePath();
         if (!is_readable($path)) {
             $this->logger?->warning('Munich SADB overwrite not readable, skipping merge', ['path' => $path]);
@@ -415,6 +419,7 @@ class Munich
 
         foreach ($data['locations'] ?? [] as $location) {
             $processed = $this->processLocation($location, $mappedServices);
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if ($processed) {
                 $mappedLocations[] = $processed;
             }
@@ -449,6 +454,7 @@ class Munich
     protected function indexServicesByIds(?array $servicesData): array
     {
         $mappedServices = [];
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if ($servicesData) {
             foreach ($servicesData['data'] ?? [] as $service) {
                 $mappedServices[$service['id']] = $service;
@@ -634,6 +640,7 @@ class Munich
     private function calculateSlotTimes(array &$mappedLocation, ?int $durationCommonDivisor): void
     {
         foreach ($mappedLocation['services'] as $key => $service) {
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if ($durationCommonDivisor && isset($service['duration'])) {
                 $mappedLocation['services'][$key]['appointment']['slots'] = (string) ((int)($service['duration'] / $durationCommonDivisor));
             }

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -137,8 +137,8 @@ class Munich
         [10383549, 1064361],
     ];
 
-    protected $publicUrl;
-    protected $logger;
+    protected string $publicUrl;
+    protected Psr\Log\LoggerInterface|null $logger;
 
     public function __construct(string $publicUrl = '', ?LoggerInterface $logger = null)
     {

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -400,7 +400,7 @@ class Munich
             'meta' => [
                 'generated' => $timestamp,
                 'datacount' => count($mappedServices),
-                'hash' => md5(json_encode($mappedServices))
+                'hash' => md5((string) json_encode($mappedServices))
             ]
         ];
     }
@@ -440,7 +440,7 @@ class Munich
                 'meta' => [
                     'generated' => $timestamp,
                     'datacount' => count($servicesList),
-                    'hash' => md5(json_encode($servicesList)),
+                    'hash' => md5((string) json_encode($servicesList)),
                 ],
             ];
         }
@@ -657,7 +657,7 @@ class Munich
             'meta' => [
                 'generated' => date('Y-m-d\TH:i:s'),
                 'datacount' => count($mappedLocations),
-                'hash' => md5(json_encode($mappedLocations))
+                'hash' => md5((string) json_encode($mappedLocations))
             ]
         ];
     }

--- a/zmsdldb/src/Zmsdldb/Transformers/Munich.php
+++ b/zmsdldb/src/Zmsdldb/Transformers/Munich.php
@@ -670,6 +670,7 @@ class Munich
     protected function getServiceCombinations(int $serviceId): array
     {
         foreach (self::SERVICE_COMBINATIONS as $combo) {
+            /** @psalm-suppress TypeDoesNotContainType */
             if (empty($combo)) {
                 continue;
             }

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -37,7 +37,8 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
             new \Twig\TwigFunction('csvAppointmentLocations', array($this, 'csvAppointmentLocations')),
             new \Twig\TwigFunction('getAppointmentForService', array($this, 'getAppointmentForService')),
             new \Twig\TwigFunction('getLocationHintByServiceId', array($this, 'getLocationHintByServiceId')),
-            new \Twig\TwigFunction('isAppointmentBookable', \Closure::fromCallable([$this, 'isAppointmentBookable'])),
+            /** @psalm-suppress InvalidArgument */
+            new \Twig\TwigFunction('isAppointmentBookable', array($this, 'isAppointmentBookable')),
             new \Twig\TwigFunction('kindOfPayment', array($this, 'kindOfPayment')),
             new \Twig\TwigFunction('formatDateTime', array($this, 'formatDateTime')),
             new \Twig\TwigFunction('dateToTS', array($this, 'dateToTS')),

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -105,7 +105,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $active;
     }
 
-    public function getD115OpeningTimes()
+    public function getD115OpeningTimes(): mixed
     {
         $settingsRepository = \App::$repository->fromSetting();
         $openinTimes = $settingsRepository->fetchName('d115.openingTime') ?? \App::D115_DEFAULT_OPENINGTIME;
@@ -113,7 +113,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $openinTimes;
     }
 
-    public function getD115Text()
+    public function getD115Text(): mixed
     {
         $settingsRepository = \App::$repository->fromSetting();
         $text = $settingsRepository->fetchName('d115.messageHtml') ?? \App::D115_DEFAULT_TEXT;
@@ -309,7 +309,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
     public function getAppointmentForLocationFromServiceAppointmentLocations(
         array $serviceAppointmentLocationList,
         mixed $locationId
-    ) {
+    ): mixed {
         if (isset($serviceAppointmentLocationList[$locationId])) {
             $appointment = $serviceAppointmentLocationList[$locationId]['appointment'];
             $appointment['responsibility_hint'] = $serviceAppointmentLocationList[$locationId]['responsibility_hint'];
@@ -319,7 +319,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return false;
     }
 
-    public function getAppointmentForService(mixed $location, mixed $service_id)
+    public function getAppointmentForService(mixed $location, mixed $service_id): mixed
     {
         $servicecompare = explode(',', $service_id);
         foreach ($location['services'] as $service) {
@@ -333,7 +333,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return false;
     }
 
-    public function getLocationHintByServiceId(mixed $location, mixed $service_id)
+    public function getLocationHintByServiceId(mixed $location, mixed $service_id): mixed
     {
         if (isset($location['services'])) {
             foreach ($location['services'] as $service) {
@@ -345,7 +345,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return false;
     }
 
-    public function dayIsBookable(mixed $dateList, mixed $day)
+    public function dayIsBookable(mixed $dateList, mixed $day): mixed
     {
         $result = false;
         if (count($dateList)) {

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -28,6 +28,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return 'dldb';
     }
 
+    /** @psalm-suppress InvalidArgument */
     #[\Override]
     public function getFunctions()
     {
@@ -37,7 +38,6 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
             new \Twig\TwigFunction('csvAppointmentLocations', array($this, 'csvAppointmentLocations')),
             new \Twig\TwigFunction('getAppointmentForService', array($this, 'getAppointmentForService')),
             new \Twig\TwigFunction('getLocationHintByServiceId', array($this, 'getLocationHintByServiceId')),
-            /** @psalm-suppress InvalidArgument */
             new \Twig\TwigFunction('isAppointmentBookable', array($this, 'isAppointmentBookable')),
             new \Twig\TwigFunction('kindOfPayment', array($this, 'kindOfPayment')),
             new \Twig\TwigFunction('formatDateTime', array($this, 'formatDateTime')),

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -98,6 +98,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
 
     public function getD115Enabeld(): bool
     {
+        /** @psalm-suppress UndefinedPropertyFetch */
         $settingsRepository = \App::$repository->fromSetting();
         $active = (bool)($settingsRepository->fetchName('d115.active') ?? true);
 
@@ -107,6 +108,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
 
     public function getD115OpeningTimes(): mixed
     {
+        /** @psalm-suppress UndefinedPropertyFetch */
         $settingsRepository = \App::$repository->fromSetting();
         $openinTimes = $settingsRepository->fetchName('d115.openingTime') ?? \App::D115_DEFAULT_OPENINGTIME;
 
@@ -115,6 +117,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
 
     public function getD115Text(): mixed
     {
+        /** @psalm-suppress UndefinedPropertyFetch */
         $settingsRepository = \App::$repository->fromSetting();
         $text = $settingsRepository->fetchName('d115.messageHtml') ?? \App::D115_DEFAULT_TEXT;
 
@@ -123,6 +126,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
 
     public function getBobbiChatButtonEnabeld(): bool
     {
+        /** @psalm-suppress UndefinedPropertyFetch */
         $settingsRepository = \App::$repository->fromSetting();
         $buttonEnabled = (bool)($settingsRepository->fetchName('frontend.bobbi.chatbutton.enabled') ?? false);
 

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -188,6 +188,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
     public function formatDateTime(mixed $dateString): array
     {
         $dateTime = new \DateTimeImmutable($dateString, new \DateTimeZone('Europe/Berlin'));
+        $formatDate = [];
         $formatDate['date']     = Helper\DateTime::getFormatedDates($dateTime, "EE, dd. MMMM yyyy");
         $formatDate['fulldate'] = Helper\DateTime::getFormatedDates($dateTime, "EEEE, 'den' dd. MMMM yyyy");
         $weekdayNumber = (int) $dateTime->format('N');

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -37,7 +37,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
             new \Twig\TwigFunction('csvAppointmentLocations', array($this, 'csvAppointmentLocations')),
             new \Twig\TwigFunction('getAppointmentForService', array($this, 'getAppointmentForService')),
             new \Twig\TwigFunction('getLocationHintByServiceId', array($this, 'getLocationHintByServiceId')),
-            new \Twig\TwigFunction('isAppointmentBookable', array($this, 'isAppointmentBookable')),
+            new \Twig\TwigFunction('isAppointmentBookable', \Closure::fromCallable([$this, 'isAppointmentBookable'])),
             new \Twig\TwigFunction('kindOfPayment', array($this, 'kindOfPayment')),
             new \Twig\TwigFunction('formatDateTime', array($this, 'formatDateTime')),
             new \Twig\TwigFunction('dateToTS', array($this, 'dateToTS')),

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -187,7 +187,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
      */
     public function formatDateTime(mixed $dateString): array
     {
-        $dateTime = new \DateTimeImmutable($dateString, new \DateTimezone('Europe/Berlin'));
+        $dateTime = new \DateTimeImmutable($dateString, new \DateTimeZone('Europe/Berlin'));
         $formatDate['date']     = Helper\DateTime::getFormatedDates($dateTime, "EE, dd. MMMM yyyy");
         $formatDate['fulldate'] = Helper\DateTime::getFormatedDates($dateTime, "EEEE, 'den' dd. MMMM yyyy");
         $formatDate['weekday']  = ($dateTime->format('N') == 0) ?

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -62,7 +62,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
 
     public function dump(mixed $item): string
     {
-        return '<pre>' . print_r($item, 1) . '</pre>';
+        return '<pre>' . print_r($item, true) . '</pre>';
     }
 
     /**

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -190,9 +190,10 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         $dateTime = new \DateTimeImmutable($dateString, new \DateTimeZone('Europe/Berlin'));
         $formatDate['date']     = Helper\DateTime::getFormatedDates($dateTime, "EE, dd. MMMM yyyy");
         $formatDate['fulldate'] = Helper\DateTime::getFormatedDates($dateTime, "EEEE, 'den' dd. MMMM yyyy");
-        $formatDate['weekday']  = ($dateTime->format('N') == 0) ?
-            $dateTime->format('N') + 6 :
-            $dateTime->format('N') - 1;
+        $weekdayNumber = (int) $dateTime->format('N');
+        $formatDate['weekday']  = ($weekdayNumber == 0) ?
+            $weekdayNumber + 6 :
+            $weekdayNumber - 1;
         $formatDate['weekdayfull'] = Helper\DateTime::getFormatedDates($dateTime, "EEEE");
 
         $time = $dateTime->format('H:i');

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -18,7 +18,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
 {
     private $container;
 
-    public function __construct($container = null)
+    public function __construct(mixed $container = null)
     {
         $this->container = $container;
     }
@@ -60,7 +60,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         );
     }
 
-    public function dump($item): string
+    public function dump(mixed $item): string
     {
         return '<pre>' . print_r($item, 1) . '</pre>';
     }
@@ -69,7 +69,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
      * @return (array|mixed|string)[]
      *
      */
-    public function currentRoute($lang = null): array
+    public function currentRoute(mixed $lang = null): array
     {
         if ($this->container->has('currentRoute')) {
             $routeParams = $this->container->get('currentRouteParams');
@@ -139,7 +139,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return 'gestureHandling: ' . \App::OSM_GESTURE_HANDLING;
     }
 
-    public function formatPhoneNumber($phoneNumber): string|null
+    public function formatPhoneNumber(mixed $phoneNumber): string|null
     {
         preg_match_all('/(^\+)?[\d]+/', $phoneNumber, $matches);
         $number = implode($matches[0]);
@@ -147,7 +147,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $phonenumber;
     }
 
-    public function convertOpeningTimes($name): string
+    public function convertOpeningTimes(mixed $name): string
     {
         $days = array(
             'monday' => 'Montag',
@@ -165,13 +165,13 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
     /**
      * @return false|int
      */
-    public function dateToTS($datetime): int|false
+    public function dateToTS(mixed $datetime): int|false
     {
         $timestamp = ($datetime === (int)$datetime) ? $datetime : strtotime($datetime);
         return $timestamp;
     }
 
-    public function tsToDate($timestamp): string
+    public function tsToDate(mixed $timestamp): string
     {
         $date =  date('Y-m-d', $timestamp);
         return $date;
@@ -181,7 +181,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
      * @return (false|float|int|mixed|string)[]
      *
      */
-    public function formatDateTime($dateString): array
+    public function formatDateTime(mixed $dateString): array
     {
         $dateTime = new \DateTimeImmutable($dateString, new \DateTimezone('Europe/Berlin'));
         $formatDate['date']     = Helper\DateTime::getFormatedDates($dateTime, "EE, dd. MMMM yyyy");
@@ -203,7 +203,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $formatDate;
     }
 
-    public function kindOfPayment($code): string
+    public function kindOfPayment(mixed $code): string
     {
         $result = '';
         if ($code == 0) {
@@ -224,7 +224,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
      * @return (array|mixed)[][]
      *
      */
-    public function azPrefixList($list, $property): array
+    public function azPrefixList(mixed $list, mixed $property): array
     {
         $azList = array();
         foreach ((array)$list as $item) {
@@ -244,7 +244,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $azList;
     }
 
-    protected static function sortFirstChar($string): string
+    protected static function sortFirstChar(mixed $string): string
     {
         $firstChar = mb_substr($string, 0, 1);
         $firstChar = mb_strtoupper($firstChar);
@@ -252,7 +252,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $firstChar;
     }
 
-    protected static function sortByName($left, $right): int
+    protected static function sortByName(mixed $left, mixed $right): int
     {
         return strcmp(
             self::toSortableString(strtolower($left['name'])),
@@ -275,7 +275,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return $string;
     }
 
-    public function csvProperty($list, $property): string
+    public function csvProperty(mixed $list, mixed $property): string
     {
         $propertylist = array();
         foreach ($list as $item) {
@@ -286,7 +286,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return implode(',', array_unique($propertylist));
     }
 
-    public function csvAppointmentLocations($list, $service_id = ''): string
+    public function csvAppointmentLocations(mixed $list, string $service_id = ''): string
     {
         $propertylist = array();
         foreach ($list as $item) {
@@ -308,7 +308,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
      */
     public function getAppointmentForLocationFromServiceAppointmentLocations(
         array $serviceAppointmentLocationList,
-        $locationId
+        mixed $locationId
     ) {
         if (isset($serviceAppointmentLocationList[$locationId])) {
             $appointment = $serviceAppointmentLocationList[$locationId]['appointment'];
@@ -319,7 +319,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return false;
     }
 
-    public function getAppointmentForService($location, $service_id)
+    public function getAppointmentForService(mixed $location, mixed $service_id)
     {
         $servicecompare = explode(',', $service_id);
         foreach ($location['services'] as $service) {
@@ -333,7 +333,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return false;
     }
 
-    public function getLocationHintByServiceId($location, $service_id)
+    public function getLocationHintByServiceId(mixed $location, mixed $service_id)
     {
         if (isset($location['services'])) {
             foreach ($location['services'] as $service) {
@@ -345,7 +345,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension
         return false;
     }
 
-    public function dayIsBookable($dateList, $day)
+    public function dayIsBookable(mixed $dateList, mixed $day)
     {
         $result = false;
         if (count($dateList)) {

--- a/zmsdldb/src/Zmsdldb/TwigExtension.php
+++ b/zmsdldb/src/Zmsdldb/TwigExtension.php
@@ -6,8 +6,6 @@
 
 namespace BO\Zmsdldb;
 
-use Error;
-
 /**
  * Extension for Twig
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)


### PR DESCRIPTION
## Summary
- Clears zmsdldb Psalm `--show-info` notes (GitHub Code Scanning) with one commit per issue type.
- Adds missing param/return/property types, tightens accessor and collection typing, and aligns declared vs actual return types.
- Uses behavior-preserving guards where types were wrong; `@psalm-suppress` only where a strict comparison would change empty-string / `"0"` handling.
- Drops unused `BO\Zmsdldb\Entity\Setting` imports (that class does not exist).

## Test plan
- [ ] Confirm `vendor/bin/psalm --show-info=true` in `zmsdldb` reports no issues
- [ ] Spot-check citizen/file/MySQL DLDB flows (fetch list, search, setting lookup)
- [ ] Confirm GitHub Code Scanning notes under `zmsdldb/` close after merge to `next`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved validation and error handling for database, search, file, and configuration operations.
  - Standardized filtering, sorting, collection handling, locale processing, and search-result behavior across supported backends.
  - Improved multilingual location-query support and input handling.
  - Added clearer contracts throughout data access, import, and template features.

- **Documentation**
  - Expanded inline documentation for collection contents, data structures, and supported return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->