### PR TITLE
fix(ZMS): restore Cucumber TestNG discovery under Surefire

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -188,3 +188,6 @@ updates:
       time: "04:00"
       timezone: "Europe/Berlin"
     target-branch: "next"
+    ignore:
+      - dependency-name: "org.apache.maven.plugins:maven-surefire-plugin"
+        versions: [">=3.6.0"]

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,15 @@
   ],
 
   "timezone": "Europe/Berlin",
-  "schedule": ["* 0-4 * * *"]
+  "schedule": ["* 0-4 * * *"],
+
+  "packageRules": [
+    {
+      "description": "Surefire 3.6.0 dropped surefire-testng; Cucumber TestNG then discovers 0 scenarios.",
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["org.apache.maven.plugins:maven-surefire-plugin"],
+      "matchFileNames": ["zmsautomation/pom.xml"],
+      "allowedVersions": "<3.6.0"
+    }
+  ]
 }

--- a/zmsautomation/pom.xml
+++ b/zmsautomation/pom.xml
@@ -16,7 +16,9 @@
     <junit.jupiter.version>6.1.3</junit.jupiter.version>
     <restassured.version>6.0.1</restassured.version>
     <assertj.version>3.27.7</assertj.version>
-    <surefire.version>3.6.0</surefire.version>
+    <!-- Surefire 3.6.0 dropped surefire-testng and runs TestNG via JUnit Platform, so Cucumber's
+         scenarios DataProvider runs before @BeforeClass and discovers 0 tests. Stay on 3.5.x. -->
+    <surefire.version>3.5.6</surefire.version>
     <cucumber.version>7.34.7</cucumber.version>
     <testng.version>7.12.0</testng.version>
     <flyway.version>13.5.0</flyway.version>
@@ -141,6 +143,21 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-testng</artifactId>
+                <version>${surefire.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
       <dependencies>
         <dependency>
           <groupId>de.muenchen.ataf</groupId>
@@ -214,6 +231,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-testng</artifactId>
+                <version>${surefire.version}</version>
+              </dependency>
+            </dependencies>
             <configuration>
               <includes>
                 <include>**/ApiTestRunner.java</include>
@@ -296,6 +320,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-testng</artifactId>
+                <version>${surefire.version}</version>
+              </dependency>
+            </dependencies>
             <configuration>
               <includes>
                 <include>**/UiTestRunner.java</include>


### PR DESCRIPTION
## Summary
- Surefire 3.6.0 (PR #3233) dropped `surefire-testng` and runs TestNG through JUnit Platform. Cucumber's `scenarios` DataProvider then runs before `@BeforeClass`, so `testNGCucumberRunner` is still null and every module reports **Tests run: 0**.
- Pin `maven-surefire-plugin` to 3.5.6 and restore the `surefire-testng` provider in the ATAF profiles so feature discovery works again.
- Block Renovate/Dependabot from re-bumping Surefire to 3.6+ until Cucumber TestNG works with the JUnit Platform engine.

Verified in `zms-web`: `mvn test -Pataf-api -Dcucumber.features=src/test/resources/features/rest/zmsapi/status.feature` → `Using configured provider org.apache.maven.surefire.testng.TestNGProvider`, **Tests run: 1**.

## Test plan
- [ ] `cd zmsautomation && mvn test -Pataf-api` discovers and runs API scenarios (not `Tests run: 0`)
- [ ] `cd zmsautomation && mvn test -Pataf-ui` discovers UI scenarios
- [ ] Confirm Surefire log contains `Using configured provider org.apache.maven.surefire.testng.TestNGProvider`