### PR TITLE
fix(ZMS): clear remaining Mellon Psalm notes

### DIFF
--- a/mellon/src/Mellon/Failure/MessageList.php
+++ b/mellon/src/Mellon/Failure/MessageList.php
@@ -10,7 +10,7 @@ namespace BO\Mellon\Failure;
 use BO\Mellon\Valid;
 
 /**
- * @extends \ArrayObject<int|null, Message>
+ * @extends \ArrayObject<array-key, Message>
  */
 class MessageList extends \ArrayObject
 {

--- a/mellon/src/Mellon/Unvalidated.php
+++ b/mellon/src/Mellon/Unvalidated.php
@@ -91,7 +91,7 @@ class Unvalidated extends \BO\Mellon\Parameter
                 if (!$newClass instanceof Valid) {
                     throw new Exception("Validation class $class does not exists");
                 }
-                if ($this->setValid) {
+                if ($this->setValid !== null) {
                     $callback = $this->setValid;
                     $callback($newClass);
                 }

--- a/mellon/src/Mellon/Valid.php
+++ b/mellon/src/Mellon/Valid.php
@@ -72,12 +72,12 @@ class Valid extends \BO\Mellon\Parameter
         }
         if ($message instanceof Failure\MessageList) {
             foreach ($message as $item) {
-                $this->messages[] = $item;
+                $this->messages->append($item);
             }
         } elseif ($message instanceof Failure\Message) {
-            $this->messages[] = $message;
+            $this->messages->append($message);
         } else {
-            $this->messages[] = new Failure\Message($message);
+            $this->messages->append(new Failure\Message($message));
         }
         return $this;
     }

--- a/mellon/src/Mellon/ValidDate.php
+++ b/mellon/src/Mellon/ValidDate.php
@@ -21,7 +21,7 @@ class ValidDate extends Valid
      * @return self
      * @psalm-api
      */
-    public function isDate($format = 'U', $message = 'no valid date')
+    public function isDate(string $format = 'U', string $message = 'no valid date')
     {
         $this->validated = true;
         if ($this->value) {

--- a/mellon/src/Mellon/ValidDatetime.php
+++ b/mellon/src/Mellon/ValidDatetime.php
@@ -20,7 +20,7 @@ class ValidDatetime extends Valid
         $this->validated = true;
         $date = $this->value;
         if ($date) {
-            if ($format) {
+            if ($format !== false && $format !== '') {
                 $dateTime = DateTime::createFromFormat($format, $date);
             } else {
                     $dateTime = date_create($date);

--- a/mellon/src/Mellon/ValidFile.php
+++ b/mellon/src/Mellon/ValidFile.php
@@ -49,8 +49,9 @@ class ValidFile extends Valid
     {
         if (isset($_FILES[$this->fileName])) {
             if (
-                (! empty($_FILES[$this->fileName]["type"])) &&
-                ($_FILES[$this->fileName]['type'] != $this->acceptableTypes[$type])
+                isset($_FILES[$this->fileName]['type'])
+                && $_FILES[$this->fileName]['type'] !== ''
+                && $_FILES[$this->fileName]['type'] != $this->acceptableTypes[$type]
             ) {
                 $this->setFailure($message);
             }

--- a/mellon/src/Mellon/ValidFile.php
+++ b/mellon/src/Mellon/ValidFile.php
@@ -39,7 +39,12 @@ class ValidFile extends Valid
     {
         $this->fileName = $name;
         $this->validated = true;
-        if (empty($_FILES) || '' == $_FILES[$name]['tmp_name']) {
+        if (
+            $name === ''
+            || empty($_FILES)
+            || !isset($_FILES[$name]['tmp_name'])
+            || $_FILES[$name]['tmp_name'] === ''
+        ) {
             $this->setFailure($message);
         }
         return $this;

--- a/mellon/src/Mellon/ValidMail.php
+++ b/mellon/src/Mellon/ValidMail.php
@@ -17,7 +17,7 @@ class ValidMail extends \BO\Mellon\ValidString
      * For unit tests, it might be necessary to disable DNS checks globally
      * Use \BO\Mellon\ValidMail::$disableDnsChecks = true;
      */
-    public static $disableDnsChecks = false;
+    public static bool $disableDnsChecks = false;
 
     /**
      * Allow only valid mails

--- a/mellon/src/Mellon/ValidMail.php
+++ b/mellon/src/Mellon/ValidMail.php
@@ -52,7 +52,7 @@ class ValidMail extends \BO\Mellon\ValidString
     /**
      * @psalm-api
      */
-    public function hasDNS($message = 'no valid DNS entry found'): static
+    public function hasDNS(string $message = 'no valid DNS entry found'): static
     {
         $this->validated = true;
         if ($this->value && !$this::$disableDnsChecks) {
@@ -68,7 +68,7 @@ class ValidMail extends \BO\Mellon\ValidString
     /**
      * @psalm-api
      */
-    public function hasMX($message = 'no valid DNS entry of type MX found'): static
+    public function hasMX(string $message = 'no valid DNS entry of type MX found'): static
     {
         $this->validated = true;
         if ($this->value) {

--- a/mellon/src/Mellon/ValidMail.php
+++ b/mellon/src/Mellon/ValidMail.php
@@ -56,7 +56,8 @@ class ValidMail extends \BO\Mellon\ValidString
     {
         $this->validated = true;
         if ($this->value && !$this::$disableDnsChecks) {
-            $domain = substr($this->value, strpos($this->value, '@') + 1);
+            $position = strpos((string) $this->value, '@');
+            $domain = substr((string) $this->value, false === $position ? 1 : $position + 1);
             $hasDNS = ($domain) ? $this->checkDnsAny($domain) : false;
             if (false === $hasDNS) {
                 $this->setFailure($message);
@@ -72,7 +73,8 @@ class ValidMail extends \BO\Mellon\ValidString
     {
         $this->validated = true;
         if ($this->value) {
-            $domain = substr($this->value, strpos($this->value, '@') + 1);
+            $position = strpos((string) $this->value, '@');
+            $domain = substr((string) $this->value, false === $position ? 1 : $position + 1);
             $hasMX = checkdnsrr($domain, 'MX');
             if (false === $hasMX) {
                 $this->setFailure($message);

--- a/mellon/src/Mellon/ValidString.php
+++ b/mellon/src/Mellon/ValidString.php
@@ -40,7 +40,7 @@ class ValidString extends Valid
     public function isFreeOf($regex, $message = 'value contains undesired content')
     {
         $this->validated = true;
-        if (preg_match($regex, $this->value)) {
+        if ($regex !== '' && preg_match($regex, (string) $this->value)) {
             $this->setFailure($message);
         }
         return $this;

--- a/mellon/src/Mellon/ValidString.php
+++ b/mellon/src/Mellon/ValidString.php
@@ -19,7 +19,7 @@ class ValidString extends Valid
      *
      * @return self
      */
-    public function isString($message = 'no valid string', $sanitize = true)
+    public function isString(string $message = 'no valid string', bool $sanitize = true)
     {
         $this->isSmallerThan(65536, $message);
         if ($sanitize) {

--- a/mellon/src/Mellon/ValidationException.php
+++ b/mellon/src/Mellon/ValidationException.php
@@ -10,10 +10,9 @@ namespace BO\Mellon;
 class ValidationException extends \Exception
 {
     /**
-     * @var \BO\Mellon\Valid $validator
-     *
+     * @var \BO\Mellon\Valid|null $validator
      */
-    protected $validator = null;
+    protected ?Valid $validator = null;
 
     /**
      * @psalm-api

--- a/mellon/src/Mellon/Validator.php
+++ b/mellon/src/Mellon/Validator.php
@@ -25,16 +25,16 @@ class Validator
     /**
      * Content of STDIN
      *
-     * @var String $input
+     * @var string|null $input
      */
-    protected $input = null;
+    protected ?string $input = null;
 
     /**
       * Singleton instance
       *
-      * @var self $instance
-      */
-    protected static $instance = null;
+     * @var self|null $instance
+     */
+    protected static ?self $instance = null;
 
     /**
      * Always initialize using an array of parameters

--- a/mellon/src/Mellon/Validator.php
+++ b/mellon/src/Mellon/Validator.php
@@ -40,7 +40,7 @@ class Validator
      * Always initialize using an array of parameters
      *
      */
-    public function __construct($parameters, $input = null)
+    public function __construct(mixed $parameters, mixed $input = null)
     {
         $this->setParameters($parameters);
         $this->setInput($input);
@@ -49,7 +49,7 @@ class Validator
     /**
      * @return self
      */
-    public function setParameters($parameters)
+    public function setParameters(mixed $parameters)
     {
         if (!is_array($parameters)) {
             throw new Exception("Array argument required for parameters");
@@ -61,7 +61,7 @@ class Validator
     /**
      * @return self
      */
-    public function setInput($input)
+    public function setInput(mixed $input)
     {
         $this->input = $input;
         return $this;
@@ -100,7 +100,7 @@ class Validator
     /**
      * @return Bool
      */
-    public function hasParameter($name)
+    public function hasParameter(string $name)
     {
         return array_key_exists($name, $this->parameters);
     }

--- a/mellon/src/Mellon/Validator.php
+++ b/mellon/src/Mellon/Validator.php
@@ -81,9 +81,9 @@ class Validator
     }
 
     /**
-     * @return self
+     * @return void
      */
-    public static function resetInstance()
+    public static function resetInstance(): void
     {
         self::$instance = null;
     }

--- a/mellon/src/Mellon/Validator.php
+++ b/mellon/src/Mellon/Validator.php
@@ -25,9 +25,9 @@ class Validator
     /**
      * Content of STDIN
      *
-     * @var string|null $input
+     * @var string|false|null $input
      */
-    protected ?string $input = null;
+    protected string|false|null $input = null;
 
     /**
       * Singleton instance


### PR DESCRIPTION
## Summary
- Clear the remaining 26 Mellon Psalm notes (param/property types, null/false property contracts, and a few guarded runtime checks).
- Keep validator behavior the same for callers, including `new Validator('123')` still throwing a Mellon exception instead of a TypeError.

## Test plan
- [ ] Mellon PHPUnit passes
- [ ] `vendor/bin/psalm --show-info=true` in `mellon` reports no issues
- [ ] Next Psalm code scan for `psalm/project:mellon` drops from 26 results to 0