### PR TITLE
fix(ZMS): expose Mellon ValidationException validator

### DIFF
--- a/mellon/src/Mellon/ValidationException.php
+++ b/mellon/src/Mellon/ValidationException.php
@@ -22,4 +22,12 @@ class ValidationException extends \Exception
         $this->validator = $validator;
         return $this;
     }
+
+    /**
+     * @psalm-api
+     */
+    public function getValidator(): ?Valid
+    {
+        return $this->validator;
+    }
 }

--- a/mellon/tests/Mellon/ValidationTest.php
+++ b/mellon/tests/Mellon/ValidationTest.php
@@ -44,4 +44,12 @@ class ValidationTest extends \PHPUnit\Framework\TestCase
         $this->expectException("\BO\Mellon\Exception");
         Validator::value("test")->isString()->aninvalidfunction();
     }
+
+    public function testValidationExceptionKeepsValidator()
+    {
+        $valid = Validator::value("test")->isString();
+        $exception = new \BO\Mellon\ValidationException();
+        $exception->setValidator($valid);
+        $this->assertSame($valid, $exception->getValidator());
+    }
 }


### PR DESCRIPTION
## Summary
- Clear Psalm dead-code alert [46694](https://github.com/it-at-m/eappointment/security/code-scanning/46694) (`PossiblyUnusedProperty` on `ValidationException::$validator`).
- Add `getValidator()` so the stored validator is readable, matching `setValidator()`.

## Test plan
- [ ] Mellon PHPUnit includes `testValidationExceptionKeepsValidator`
- [ ] Psalm `--find-dead-code` no longer reports `ValidationException::$validator`