### PR TITLE
fix(ZMS): clear zmsentities Psalm notes by issue type

### DIFF
--- a/zmsentities/src/Zmsentities/Apikey.php
+++ b/zmsentities/src/Zmsentities/Apikey.php
@@ -34,14 +34,14 @@ class Apikey extends Schema\Entity
      * @return false|int
      *
      */
-    public function getQuotaPositionByRoute($route): int|false
+    public function getQuotaPositionByRoute(mixed $route): int|false
     {
         return (isset($this->quota) && is_array($this->quota)) ?
             array_search($route, array_column($this->quota, 'route'))
             : false;
     }
 
-    public function addQuota($route, $period): static
+    public function addQuota(mixed $route, mixed $period): static
     {
         $this->quota[] = [
             'route' => $route,
@@ -51,7 +51,7 @@ class Apikey extends Schema\Entity
         return $this;
     }
 
-    public function updateQuota($position): static
+    public function updateQuota(mixed $position): static
     {
         $this->quota[$position]['requests']++;
         return $this;

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -90,7 +90,7 @@ class Appointment extends Schema\Entity
 
     public function addSlotCount(int|null $slotCount = null): static
     {
-        if ($slotCount) {
+        if ($slotCount !== null && $slotCount !== 0) {
             $this->slotCount = $slotCount;
         } else {
             $this->slotCount += 1;
@@ -133,7 +133,9 @@ class Appointment extends Schema\Entity
     {
         $time = $this->getStartTime();
         $availability = $this->getAvailability();
-        return ($availability->slotTimeInMinutes)
+        return ($availability->slotTimeInMinutes !== null
+            && $availability->slotTimeInMinutes !== ''
+            && (int) $availability->slotTimeInMinutes !== 0)
           ? $time->modify('+' . ($availability->slotTimeInMinutes * $this->slotCount) . ' minutes')
           : $time;
     }

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -117,9 +117,7 @@ class Appointment extends Schema\Entity
     {
         $date = (new \DateTimeImmutable())->setTimestamp($this->date);
         //$date = \DateTimeImmutable::createFromFormat("U", $this->date);
-        if ($date) {
-            $date = $date->setTimeZone(new \DateTimeZone($timezone));
-        }
+        $date = $date->setTimeZone(new \DateTimeZone($timezone));
         return $date;
     }
 

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -30,7 +30,7 @@ class Appointment extends Schema\Entity
         ];
     }
 
-    public function toDate(string $lang = 'de')
+    public function toDate(string $lang = 'de'): string|false
     {
         // Mittwoch 18. November 2015
         return ($lang == 'en') ? date('l F d, Y', $this->date) : Helper\DateTime::getFormatedDates(
@@ -99,7 +99,7 @@ class Appointment extends Schema\Entity
         return $this;
     }
 
-    public function getSlotCount()
+    public function getSlotCount(): mixed
     {
         return $this->slotCount;
     }
@@ -123,13 +123,13 @@ class Appointment extends Schema\Entity
         return $date;
     }
 
-    public function getStartTime()
+    public function getStartTime(): \DateTimeImmutable
     {
         $time = $this->toDateTime();
         return $time;
     }
 
-    public function getEndTime()
+    public function getEndTime(): mixed
     {
         $time = $this->getStartTime();
         $availability = $this->getAvailability();
@@ -138,7 +138,7 @@ class Appointment extends Schema\Entity
           : $time;
     }
 
-    public function getEndTimeWithCustomSlotTime(mixed $slotTimeInMinutes)
+    public function getEndTimeWithCustomSlotTime(mixed $slotTimeInMinutes): mixed
     {
         $time = $this->getStartTime();
         return $time->modify('+' . ($slotTimeInMinutes * $this->slotCount) . ' minutes');

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -151,7 +151,7 @@ class Appointment extends Schema\Entity
     {
         $appointmentDateTime = \DateTimeImmutable::createFromFormat($format, $dateString);
         if ($appointmentDateTime) {
-            $this->date = $appointmentDateTime->format('U');
+            $this->date = (int) $appointmentDateTime->format('U');
         } else {
             throw new Exception\DateStringWrongFormat(
                 "String " . htmlspecialchars($dateString) . " not format " . htmlspecialchars($format)

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -30,7 +30,7 @@ class Appointment extends Schema\Entity
         ];
     }
 
-    public function toDate($lang = 'de')
+    public function toDate(string $lang = 'de')
     {
         // Mittwoch 18. November 2015
         return ($lang == 'en') ? date('l F d, Y', $this->date) : Helper\DateTime::getFormatedDates(
@@ -39,7 +39,7 @@ class Appointment extends Schema\Entity
         );
     }
 
-    public function toTime($lang = 'de'): string
+    public function toTime(string $lang = 'de'): string
     {
         $suffix = ($lang == 'en') ? ' o\'clock' : ' Uhr';
         return date('H:i', $this->date) . $suffix;
@@ -57,7 +57,7 @@ class Appointment extends Schema\Entity
     /**
      * Modify time for appointment
      */
-    public function setTime($timeString): static
+    public function setTime(mixed $timeString): static
     {
         $dateTime = $this->toDateTime();
         $this->date = $dateTime->modify($timeString)->getTimestamp();
@@ -76,7 +76,7 @@ class Appointment extends Schema\Entity
         return $this;
     }
 
-    public function addScope($scopeId): static
+    public function addScope(mixed $scopeId): static
     {
         $this->getScope()->id = $scopeId;
         return $this;
@@ -113,7 +113,7 @@ class Appointment extends Schema\Entity
         return new Availability($data);
     }
 
-    public function toDateTime($timezone = 'Europe/Berlin'): \DateTimeImmutable
+    public function toDateTime(string $timezone = 'Europe/Berlin'): \DateTimeImmutable
     {
         $date = (new \DateTimeImmutable())->setTimestamp($this->date);
         //$date = \DateTimeImmutable::createFromFormat("U", $this->date);
@@ -138,13 +138,13 @@ class Appointment extends Schema\Entity
           : $time;
     }
 
-    public function getEndTimeWithCustomSlotTime($slotTimeInMinutes)
+    public function getEndTimeWithCustomSlotTime(mixed $slotTimeInMinutes)
     {
         $time = $this->getStartTime();
         return $time->modify('+' . ($slotTimeInMinutes * $this->slotCount) . ' minutes');
     }
 
-    public function setDateByString(string $dateString, $format = 'Y-m-d H:i'): static
+    public function setDateByString(string $dateString, string $format = 'Y-m-d H:i'): static
     {
         $appointmentDateTime = \DateTimeImmutable::createFromFormat($format, $dateString);
         if ($appointmentDateTime) {

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -7,7 +7,7 @@ use BO\Zmsentities\Helper\Property;
 /**
  * Schema-backed entity (ArrayObject::ARRAY_AS_PROPS); document dynamic keys for Psalm.
  *
- * @property int $date
+ * @property int|string $date
  */
 class Appointment extends Schema\Entity
 {
@@ -33,7 +33,7 @@ class Appointment extends Schema\Entity
     public function toDate(string $lang = 'de'): string|false
     {
         // Mittwoch 18. November 2015
-        return ($lang == 'en') ? date('l F d, Y', $this->date) : Helper\DateTime::getFormatedDates(
+        return ($lang == 'en') ? date('l F d, Y', (int) $this->date) : Helper\DateTime::getFormatedDates(
             $this->toDateTime(),
             'EEEE dd. MMMM yyyy'
         );
@@ -42,7 +42,7 @@ class Appointment extends Schema\Entity
     public function toTime(string $lang = 'de'): string
     {
         $suffix = ($lang == 'en') ? ' o\'clock' : ' Uhr';
-        return date('H:i', $this->date) . $suffix;
+        return date('H:i', (int) $this->date) . $suffix;
     }
 
     public function hasTime(): bool
@@ -115,7 +115,7 @@ class Appointment extends Schema\Entity
 
     public function toDateTime(string $timezone = 'Europe/Berlin'): \DateTimeImmutable
     {
-        $date = (new \DateTimeImmutable())->setTimestamp($this->date);
+        $date = (new \DateTimeImmutable())->setTimestamp((int) $this->date);
         //$date = \DateTimeImmutable::createFromFormat("U", $this->date);
         if ($timezone === '') {
             $timezone = 'Europe/Berlin';
@@ -151,7 +151,7 @@ class Appointment extends Schema\Entity
     {
         $appointmentDateTime = \DateTimeImmutable::createFromFormat($format, $dateString);
         if ($appointmentDateTime) {
-            $this->date = (int) $appointmentDateTime->format('U');
+            $this->date = $appointmentDateTime->format('U');
         } else {
             throw new Exception\DateStringWrongFormat(
                 "String " . htmlspecialchars($dateString) . " not format " . htmlspecialchars($format)

--- a/zmsentities/src/Zmsentities/Appointment.php
+++ b/zmsentities/src/Zmsentities/Appointment.php
@@ -117,6 +117,9 @@ class Appointment extends Schema\Entity
     {
         $date = (new \DateTimeImmutable())->setTimestamp($this->date);
         //$date = \DateTimeImmutable::createFromFormat("U", $this->date);
+        if ($timezone === '') {
+            $timezone = 'Europe/Berlin';
+        }
         $date = $date->setTimeZone(new \DateTimeZone($timezone));
         return $date;
     }

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -44,13 +44,13 @@ class Availability extends Schema\Entity
 
     /**
      * Performance costs for modifying time are high, cache the calculated value
-     * @var \DateTimeImmutable $startTimeCache
+     * @var Helper\DateTime $startTimeCache
      */
     protected $startTimeCache;
 
     /**
      * Performance costs for modifying time are high, cache the calculated value
-     * @var \DateTimeImmutable $endTimeCache
+     * @var Helper\DateTime $endTimeCache
      */
     protected $endTimeCache;
 
@@ -325,7 +325,7 @@ class Availability extends Schema\Entity
     /**
      * Get DateTimeInterface for start time of availability
      *
-     * @return \DateTimeInterface
+     * @return Helper\DateTime
      */
     public function getStartDateTime()
     {
@@ -340,7 +340,7 @@ class Availability extends Schema\Entity
     /**
      * Get DateTimeInterface for end time of availability
      *
-     * @return \DateTimeInterface
+     * @return Helper\DateTime
      */
     public function getEndDateTime()
     {
@@ -369,7 +369,7 @@ class Availability extends Schema\Entity
      *
      * @param \DateTimeInterface $now relative time to compare booking settings
      *
-     * @return \DateTimeInterface
+     * @return Helper\DateTime
      */
     public function getBookableStart(\DateTimeInterface $now)
     {
@@ -393,7 +393,7 @@ class Availability extends Schema\Entity
      *
      * @param \DateTimeInterface $now relative time to compare booking settings
      *
-     * @return \DateTimeInterface
+     * @return Helper\DateTime
      */
     public function getBookableEnd(\DateTimeInterface $now)
     {
@@ -426,7 +426,7 @@ class Availability extends Schema\Entity
         if (!$this->hasDay($bookableDate)) {
             return false;
         }
-        $bookableCurrentTime = $bookableDate->modify($now->format('H:i:s'));
+        $bookableCurrentTime = Helper\DateTime::create($bookableDate)->modify($now->format('H:i:s'));
         Helper\DateTime::create($bookableDate)->getTimestamp() + Helper\DateTime::create($now)->getSecondsOfDay();
         $startDate = $this->getBookableStart($now)->modify('00:00:00');
 
@@ -463,6 +463,7 @@ class Availability extends Schema\Entity
         if ($stopTime->getTimestamp() < $now->getTimestamp()) {
             return false;
         }
+        $startTime = Helper\DateTime::create($startTime);
         do {
             if ($this->hasDate($startTime, $now)) {
                 return true;
@@ -476,13 +477,13 @@ class Availability extends Schema\Entity
     {
         $errorList = [];
 
-        $startTime = (clone $startDate)->setTime(0, 0);
+        $startTime = Helper\DateTime::create($startDate)->setTime(0, 0);
         $isFuture = ($kind && $kind === 'future');
 
         if (
             !$isFuture &&
             $selectedDate->getTimestamp() > $today->getTimestamp() &&
-            $startTime->getTimestamp() > (clone $selectedDate)->setTime(0, 0)->getTimestamp()
+            $startTime->getTimestamp() > Helper\DateTime::create($selectedDate)->setTime(0, 0)->getTimestamp()
         ) {
             $errorList[] = [
                 'type' => 'startTimeFuture',
@@ -600,13 +601,17 @@ class Availability extends Schema\Entity
         $startDate = $this->getStartDateTime();
         $startHour = (int) $startDate->format('H');
         $startMinute = (int) $startDate->format('i');
-        $endDateTime = (clone $endDate)->setTime($endHour, $endMinute);
-        $startDateTime = (clone $startDate)->setTime($startHour, $startMinute);
+        $endDateTime = Helper\DateTime::create($endDate)->setTime($endHour, $endMinute);
+        $startDateTime = Helper\DateTime::create($startDate)->setTime($startHour, $startMinute);
         $endTimestamp = $endDateTime->getTimestamp();
         $startTimestamp = $startDateTime->getTimestamp();
         $isOrigin = ($kind && $kind === 'origin');
 
-        if (!$isOrigin && $selectedDate->getTimestamp() > $today->getTimestamp() && $endDate < (clone $selectedDate)->setTime(0, 0)) {
+        if (
+            !$isOrigin
+            && $selectedDate->getTimestamp() > $today->getTimestamp()
+            && $endDate < Helper\DateTime::create($selectedDate)->setTime(0, 0)
+        ) {
             $errorList[] = [
                 'type' => 'endTimeFuture',
                 'message' => "Das Enddatum der Öffnungszeit muss nach dem " . $yesterday->format('d.m.Y') . " liegen."

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -980,7 +980,7 @@ class Availability extends Schema\Entity
             $info .= " each " . $this['repeat']['weekOfMonth'] . ". weekOfMonth";
         }
         $info .= " on ";
-        $weekdays = array_filter($this['weekday'], function ($value) {
+        $weekdays = array_filter($this['weekday'], function (mixed $value) {
             return $value > 0;
         });
         $info .= implode(',', array_keys($weekdays));

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -44,13 +44,13 @@ class Availability extends Schema\Entity
 
     /**
      * Performance costs for modifying time are high, cache the calculated value
-     * @var Helper\DateTime $startTimeCache
+     * @var Helper\DateTime|null $startTimeCache
      */
     protected $startTimeCache;
 
     /**
      * Performance costs for modifying time are high, cache the calculated value
-     * @var Helper\DateTime $endTimeCache
+     * @var Helper\DateTime|null $endTimeCache
      */
     protected $endTimeCache;
 

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -237,7 +237,7 @@ class Availability extends Schema\Entity
         return true;
     }
 
-    public function getAvailableSecondsPerDay(string $type = "intern")
+    public function getAvailableSecondsPerDay(string $type = "intern"): mixed
     {
         $start = $this->getStartDateTime()->getSecondsOfDay();
         $end = $this->getEndDateTime()->getSecondsOfDay();
@@ -704,7 +704,7 @@ class Availability extends Schema\Entity
         return $slotList;
     }
 
-    public function getSlotTimeInMinutes()
+    public function getSlotTimeInMinutes(): mixed
     {
         return $this['slotTimeInMinutes'];
     }

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -237,7 +237,7 @@ class Availability extends Schema\Entity
         return true;
     }
 
-    public function getAvailableSecondsPerDay($type = "intern")
+    public function getAvailableSecondsPerDay(string $type = "intern")
     {
         $start = $this->getStartDateTime()->getSecondsOfDay();
         $end = $this->getEndDateTime()->getSecondsOfDay();

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -999,11 +999,11 @@ class Availability extends Schema\Entity
      *
      */
     #[\Override]
-    public function offsetSet(mixed $index, mixed $value): void
+    public function offsetSet(mixed $key, mixed $value): void
     {
         $this->startTimeCache = null;
         $this->endTimeCache = null;
-        parent::offsetSet($index, $value);
+        parent::offsetSet($key, $value);
     }
 
     /**

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -211,7 +211,7 @@ class Availability extends Schema\Entity
     {
         $dateTime = $appointment->toDateTime();
         $isOpenedStart = $this->isOpened($dateTime, false);
-        $duration = $this->slotTimeInMinutes * $appointment->slotCount;
+        $duration = (int) $this->slotTimeInMinutes * $appointment->slotCount;
         $endTime = $dateTime->modify("+" . $duration . "minutes")
             ->modify("-1 second"); // To allow the last slot for an appointment
         $isOpenedEnd = $this->isOpened($endTime, false);
@@ -724,7 +724,7 @@ class Availability extends Schema\Entity
         $start = $this->getStartDateTime()->getSecondsOfDay();
         $end = $this->getEndDateTime()->getSecondsOfDay();
         $minutesPerDay = floor(($end - $start) / 60);
-        if ($minutesPerDay % $this->slotTimeInMinutes > 0) {
+        if ($minutesPerDay % (int) $this->slotTimeInMinutes > 0) {
             $conflict = new Process();
             $conflict->status = 'conflict';
             $appointment = $conflict->getFirstAppointment();

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -538,7 +538,7 @@ class Availability extends Schema\Entity
         });
         $foundWeekdays = [];
 
-        $currentDate = clone $startDate;
+        $currentDate = Helper\DateTime::create($startDate);
         while ($currentDate <= $endDate) {
             $weekDayName = self::$weekdayNameList[$currentDate->format('w')];
             if (in_array($weekDayName, $selectedWeekdays)) {

--- a/zmsentities/src/Zmsentities/Availability.php
+++ b/zmsentities/src/Zmsentities/Availability.php
@@ -689,9 +689,9 @@ class Availability extends Schema\Entity
     /**
      * Creates a list of slots available on a valid day
      *
-     * @return Array of arrays with the keys time, public, intern
+     * @return Collection\SlotList
      */
-    public function getSlotList()
+    public function getSlotList(): Collection\SlotList
     {
         $startTime = Helper\DateTime::create($this['startTime']);
         $stopTime = Helper\DateTime::create($this['endTime']);
@@ -717,9 +717,9 @@ class Availability extends Schema\Entity
     /**
      * Get problems on configuration of this availability
      *
-     * @return Collection\ProcessList with processes in status "conflict"
+     * @return Process|false with processes in status "conflict"
      */
-    public function getConflict()
+    public function getConflict(): Process|false
     {
         $start = $this->getStartDateTime()->getSecondsOfDay();
         $end = $this->getEndDateTime()->getSecondsOfDay();

--- a/zmsentities/src/Zmsentities/Calendar.php
+++ b/zmsentities/src/Zmsentities/Calendar.php
@@ -293,8 +293,8 @@ class Calendar extends Schema\Entity
      */
     public function getMonthList(): Collection\MonthList
     {
-        $firstDay = $this->getFirstDay()->modify('first day of this month')->modify('00:00:00');
-        $lastDay = $this->getLastDay()->modify('last day of this month')->modify('23:59:59');
+        $firstDay = Helper\DateTime::create($this->getFirstDay())->modify('first day of this month')->modify('00:00:00');
+        $lastDay = Helper\DateTime::create($this->getLastDay())->modify('last day of this month')->modify('23:59:59');
         $currentDate = $firstDay;
         if ($firstDay->getTimestamp() > $lastDay->getTimestamp()) {
             // switch first and last day if necessary
@@ -344,8 +344,8 @@ class Calendar extends Schema\Entity
     {
         $entity = clone $this;
 
-        $firstDay = $this->getFirstDay()->modify('first day of this month')->modify('00:00:00');
-        $lastDay = $this->getLastDay()->modify('last day of this month')->modify('23:59:59');
+        $firstDay = Helper\DateTime::create($this->getFirstDay())->modify('first day of this month')->modify('00:00:00');
+        $lastDay = Helper\DateTime::create($this->getLastDay())->modify('last day of this month')->modify('23:59:59');
         $currentDate = $firstDay;
         $dayList = new Collection\DayList($entity->days);
 

--- a/zmsentities/src/Zmsentities/Calendar.php
+++ b/zmsentities/src/Zmsentities/Calendar.php
@@ -137,9 +137,9 @@ class Calendar extends Schema\Entity
     /**
      * Returns a list of associated scope ids
      *
-     * @return array
+     * @return Collection\ScopeList
      */
-    public function getScopeList()
+    public function getScopeList(): Collection\ScopeList
     {
         $scopeList = new \BO\Zmsentities\Collection\ScopeList();
         if (isset($this->scopes)) {
@@ -154,9 +154,9 @@ class Calendar extends Schema\Entity
     /**
      * Returns a list of associated request entities
      *
-     * @return array
+     * @return Collection\RequestList
      */
-    public function getRequestList()
+    public function getRequestList(): Collection\RequestList
     {
         $requestList = new \BO\Zmsentities\Collection\RequestList();
         foreach ($this->requests as $request) {
@@ -169,9 +169,9 @@ class Calendar extends Schema\Entity
     /**
      * Returns a list of associated provider ids
      *
-     * @return array
+     * @return Collection\ProviderList
      */
-    public function getProviderList()
+    public function getProviderList(): Collection\ProviderList
     {
         $providerList = new \BO\Zmsentities\Collection\ProviderList();
         foreach ($this->providers as $provider) {

--- a/zmsentities/src/Zmsentities/Calendar.php
+++ b/zmsentities/src/Zmsentities/Calendar.php
@@ -32,7 +32,7 @@ class Calendar extends Schema\Entity
         ];
     }
 
-    public function addDates($date, \DateTimeInterface $now, $timeZone): static
+    public function addDates(mixed $date, \DateTimeInterface $now, mixed $timeZone): static
     {
         $validDate = \BO\Mellon\Validator::value($date)->isDate();
         $date = (! $validDate->hasFailed()) ? $validDate->getValue() : $now->format('U');
@@ -47,7 +47,7 @@ class Calendar extends Schema\Entity
      *
      * @return $this
      */
-    public function addFirstAndLastDay($date, $timeZone)
+    public function addFirstAndLastDay(mixed $date, mixed $timeZone)
     {
         $timeZone = new \DateTimeZone($timeZone);
         $dateTime = Helper\DateTime::create()->setTimezone($timeZone)->setTimestamp($date);
@@ -71,7 +71,7 @@ class Calendar extends Schema\Entity
      *
      * @return $this
      */
-    public function addProvider($source, $idList)
+    public function addProvider(mixed $source, mixed $idList)
     {
         foreach (explode(',', $idList) as $id) {
             if ($id) {
@@ -89,7 +89,7 @@ class Calendar extends Schema\Entity
      *
      * @return $this
      */
-    public function addCluster($idList)
+    public function addCluster(mixed $idList)
     {
         foreach (explode(',', $idList) as $id) {
             $cluster = new Cluster();
@@ -104,7 +104,7 @@ class Calendar extends Schema\Entity
      *
      * @return $this
      */
-    public function addRequest($source, $requestList)
+    public function addRequest(mixed $source, mixed $requestList)
     {
         foreach (explode(',', $requestList) as $id) {
             if ($id) {
@@ -122,7 +122,7 @@ class Calendar extends Schema\Entity
      *
      * @return $this
      */
-    public function addScope($scopeList)
+    public function addScope(mixed $scopeList)
     {
         foreach (explode(',', $scopeList) as $id) {
             if ($id) {
@@ -194,7 +194,7 @@ class Calendar extends Schema\Entity
      *
      * @return bool
      */
-    public function hasDay($year, $month, $dayNumber)
+    public function hasDay(mixed $year, mixed $month, mixed $dayNumber)
     {
         return $this->getDayList()->hasDay($year, $month, $dayNumber);
     }
@@ -204,7 +204,7 @@ class Calendar extends Schema\Entity
      *
      * @return \ArrayObject
      */
-    public function getDay($year, $month, $dayNumber)
+    public function getDay(mixed $year, mixed $month, mixed $dayNumber)
     {
         return $this->getDayList()->getDay($year, $month, $dayNumber);
     }
@@ -251,7 +251,7 @@ class Calendar extends Schema\Entity
         return $dateTime->modify('00:00:00');
     }
 
-    public function getLastDay($createIfNotProvided = true)
+    public function getLastDay(bool $createIfNotProvided = true)
     {
         if (! $createIfNotProvided && ! isset($this['lastDay'])) {
             return null;
@@ -271,7 +271,7 @@ class Calendar extends Schema\Entity
         return $dateTime->modify('23:59:59');
     }
 
-    public function setLastDayTime($date): static
+    public function setLastDayTime(mixed $date): static
     {
         $day = new Day();
         $day->setDateTime($date);
@@ -279,7 +279,7 @@ class Calendar extends Schema\Entity
         return $this;
     }
 
-    public function setFirstDayTime($date): static
+    public function setFirstDayTime(mixed $date): static
     {
         $day = new Day();
         $day->setDateTime($date);

--- a/zmsentities/src/Zmsentities/Calendar.php
+++ b/zmsentities/src/Zmsentities/Calendar.php
@@ -183,10 +183,12 @@ class Calendar extends Schema\Entity
 
     public function getDayList(): Collection\DayList
     {
-        if (!$this->days instanceof Collection\DayList) {
-            $this->days = new Collection\DayList($this->days);
+        $days = $this->days;
+        if (!$days instanceof Collection\DayList) {
+            $days = new Collection\DayList($days);
+            $this->days = $days;
         }
-        return $this->days->setSortByDate();
+        return $days->setSortByDate();
     }
 
     /**

--- a/zmsentities/src/Zmsentities/Calendar.php
+++ b/zmsentities/src/Zmsentities/Calendar.php
@@ -181,7 +181,7 @@ class Calendar extends Schema\Entity
         return $providerList;
     }
 
-    public function getDayList()
+    public function getDayList(): Collection\DayList
     {
         if (!$this->days instanceof Collection\DayList) {
             $this->days = new Collection\DayList($this->days);
@@ -209,12 +209,12 @@ class Calendar extends Schema\Entity
         return $this->getDayList()->getDay($year, $month, $dayNumber);
     }
 
-    public function getDayByDateTime(\DateTimeInterface $datetime)
+    public function getDayByDateTime(\DateTimeInterface $datetime): mixed
     {
         return $this->getDayList()->getDayByDateTime($datetime);
     }
 
-    public function getDateTimeFromDate(array $date)
+    public function getDateTimeFromDate(array $date): \BO\Zmsentities\Helper\DateTime
     {
         $day = (isset($date['day'])) ? $date['day'] : 1;
         $date = Helper\DateTime::createFromFormat('Y-m-d', $date['year'] . '-' . $date['month'] . '-' . $day);
@@ -235,7 +235,7 @@ class Calendar extends Schema\Entity
         return true;
     }
 
-    public function getFirstDay()
+    public function getFirstDay(): mixed
     {
         if (isset($this['firstDay'])) {
             $dateTime = $this->getDateTimeFromDate(
@@ -251,7 +251,7 @@ class Calendar extends Schema\Entity
         return $dateTime->modify('00:00:00');
     }
 
-    public function getLastDay(bool $createIfNotProvided = true)
+    public function getLastDay(bool $createIfNotProvided = true): mixed
     {
         if (! $createIfNotProvided && ! isset($this['lastDay'])) {
             return null;

--- a/zmsentities/src/Zmsentities/Calldisplay.php
+++ b/zmsentities/src/Zmsentities/Calldisplay.php
@@ -141,11 +141,9 @@ class Calldisplay extends Schema\Entity
     {
         $scopeList = new Collection\ScopeList();
         $scopeIds = explode(',', $scopeIds);
-        if ($scopeIds) {
-            foreach ($scopeIds as $scopeId) {
-                $scope = new Scope(array('id' => $scopeId));
-                $scopeList->addEntity($scope);
-            }
+        foreach ($scopeIds as $scopeId) {
+            $scope = new Scope(array('id' => $scopeId));
+            $scopeList->addEntity($scope);
         }
         return $scopeList;
     }
@@ -154,11 +152,9 @@ class Calldisplay extends Schema\Entity
     {
         $clusterList = new Collection\ClusterList();
         $clusterIds = explode(',', $clusterIds);
-        if ($clusterIds) {
-            foreach ($clusterIds as $clusterId) {
-                $cluster = new Cluster(array('id' => $clusterId));
-                $clusterList->addEntity($cluster);
-            }
+        foreach ($clusterIds as $clusterId) {
+            $cluster = new Cluster(array('id' => $clusterId));
+            $clusterList->addEntity($cluster);
         }
         return $clusterList;
     }

--- a/zmsentities/src/Zmsentities/Calldisplay.php
+++ b/zmsentities/src/Zmsentities/Calldisplay.php
@@ -148,6 +148,9 @@ class Calldisplay extends Schema\Entity
         $scopeList = new Collection\ScopeList();
         $scopeIds = explode(',', $scopeIds);
         foreach ($scopeIds as $scopeId) {
+            if ($scopeId === '') {
+                continue;
+            }
             $scope = new Scope(array('id' => $scopeId));
             $scopeList->addEntity($scope);
         }
@@ -159,6 +162,9 @@ class Calldisplay extends Schema\Entity
         $clusterList = new Collection\ClusterList();
         $clusterIds = explode(',', $clusterIds);
         foreach ($clusterIds as $clusterId) {
+            if ($clusterId === '') {
+                continue;
+            }
             $cluster = new Cluster(array('id' => $clusterId));
             $clusterList->addEntity($cluster);
         }

--- a/zmsentities/src/Zmsentities/Calldisplay.php
+++ b/zmsentities/src/Zmsentities/Calldisplay.php
@@ -61,7 +61,7 @@ class Calldisplay extends Schema\Entity
         return $this;
     }
 
-    public function getFullScopeList()
+    public function getFullScopeList(): \BO\Zmsentities\Collection\ScopeList
     {
         $scopeList = $this->getScopeList();
         foreach ($this->clusters as $cluster) {

--- a/zmsentities/src/Zmsentities/Calldisplay.php
+++ b/zmsentities/src/Zmsentities/Calldisplay.php
@@ -105,9 +105,15 @@ class Calldisplay extends Schema\Entity
     {
         $name = '';
         if (1 == $this->getScopeList()->count()) {
-            $name = "s_" . $this->getScopeList()->getFirst()->id . "_bild";
+            $scope = $this->getScopeList()->getFirst();
+            if ($scope !== null) {
+                $name = "s_" . $scope->id . "_bild";
+            }
         } elseif (1 == $this->getClusterList()->count()) {
-            $name = "c_" . $this->getClusterList()->getFirst()->id . "_bild";
+            $cluster = $this->getClusterList()->getFirst();
+            if ($cluster !== null) {
+                $name = "c_" . $cluster->id . "_bild";
+            }
         }
         return $name;
     }

--- a/zmsentities/src/Zmsentities/Calldisplay.php
+++ b/zmsentities/src/Zmsentities/Calldisplay.php
@@ -33,7 +33,7 @@ class Calldisplay extends Schema\Entity
         ];
     }
 
-    public function withResolvedCollections($input): static
+    public function withResolvedCollections(mixed $input): static
     {
         $input =  (is_object($input)) ? $input->getArrayCopy() : $input;
         if (Property::__keyExists('scopelist', $input)) {
@@ -55,7 +55,7 @@ class Calldisplay extends Schema\Entity
         return (0 < $this->getClusterList()->count());
     }
 
-    public function setServerTime($timestamp): static
+    public function setServerTime(mixed $timestamp): static
     {
         $this->serverTime = $timestamp;
         return $this;
@@ -137,7 +137,7 @@ class Calldisplay extends Schema\Entity
         return $calldisplay;
     }
 
-    protected function getScopeListFromCsv($scopeIds = ''): Collection\ScopeList
+    protected function getScopeListFromCsv(string $scopeIds = ''): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         $scopeIds = explode(',', $scopeIds);
@@ -150,7 +150,7 @@ class Calldisplay extends Schema\Entity
         return $scopeList;
     }
 
-    protected function getClusterListFromCsv($clusterIds = ''): Collection\ClusterList
+    protected function getClusterListFromCsv(string $clusterIds = ''): Collection\ClusterList
     {
         $clusterList = new Collection\ClusterList();
         $clusterIds = explode(',', $clusterIds);

--- a/zmsentities/src/Zmsentities/Client.php
+++ b/zmsentities/src/Zmsentities/Client.php
@@ -37,7 +37,7 @@ class Client extends Schema\Entity
         return ($this->toProperty()->telephone->get()) ? true : false;
     }
 
-    public function getEmailSendCount()
+    public function getEmailSendCount(): mixed
     {
         return $this->toProperty()->emailSendCount->get();
     }

--- a/zmsentities/src/Zmsentities/Closure.php
+++ b/zmsentities/src/Zmsentities/Closure.php
@@ -21,7 +21,7 @@ class Closure extends Schema\Entity
         ];
     }
 
-    public function setTimestampFromDateformat($fromFormat = 'd.m.Y'): static
+    public function setTimestampFromDateformat(string $fromFormat = 'd.m.Y'): static
     {
         $dateTime = \DateTimeImmutable::createFromFormat($fromFormat, $this->date, new \DateTimeZone('UTC'));
         if ($dateTime) {
@@ -40,7 +40,7 @@ class Closure extends Schema\Entity
      *
      * @return bool
      */
-    public function isNewerThan(\DateTimeInterface $dateTime, $filterByAvailability = null, $now = null)
+    public function isNewerThan(\DateTimeInterface $dateTime, mixed $filterByAvailability = null, mixed $now = null)
     {
         if ($filterByAvailability && !$this->isAffectingAvailability($filterByAvailability, $now)) {
             return false;

--- a/zmsentities/src/Zmsentities/Cluster.php
+++ b/zmsentities/src/Zmsentities/Cluster.php
@@ -21,12 +21,12 @@ class Cluster extends Schema\Entity implements Useraccount\AccessInterface
         ];
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return $this->toProperty()->name->get();
     }
 
-    public function getScopesWorkstationCount()
+    public function getScopesWorkstationCount(): mixed
     {
         $workstationCount = 0;
         if ($this->toProperty()->scopes->get()) {
@@ -41,7 +41,7 @@ class Cluster extends Schema\Entity implements Useraccount\AccessInterface
     /**
      * @return bool
      */
-    public function hasAccess(Useraccount $useraccount)
+    public function hasAccess(Useraccount $useraccount): bool
     {
         if ($useraccount->hasPermissions(['superuser'])) {
             return true;

--- a/zmsentities/src/Zmsentities/Collection/AppointmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/AppointmentList.php
@@ -15,7 +15,7 @@ class AppointmentList extends Base
     {
         foreach ($this as $item) {
             if ($item['date'] == $date) {
-                return $item instanceof Appointment ? $item : new Appointment($item);
+                return $item;
             }
         }
         return false;

--- a/zmsentities/src/Zmsentities/Collection/AppointmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/AppointmentList.php
@@ -15,7 +15,8 @@ class AppointmentList extends Base
     {
         foreach ($this as $item) {
             if ($item['date'] == $date) {
-                return $item;
+                /** @psalm-suppress RedundantCondition Runtime arrays can bypass ENTITY_CLASS. */
+                return $item instanceof Appointment ? $item : new Appointment($item);
             }
         }
         return false;

--- a/zmsentities/src/Zmsentities/Collection/AppointmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/AppointmentList.php
@@ -11,7 +11,7 @@ class AppointmentList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Appointment';
 
-    public function getByDate($date): Appointment|false
+    public function getByDate(mixed $date): Appointment|false
     {
         foreach ($this as $item) {
             if ($item['date'] == $date) {
@@ -21,7 +21,7 @@ class AppointmentList extends Base
         return false;
     }
 
-    public function hasDateScope($date, $scopeId): bool
+    public function hasDateScope(mixed $date, mixed $scopeId): bool
     {
         $item = $this->getByDate($date);
         if ($item && $item->toProperty()->scope->id->get() == $scopeId) {

--- a/zmsentities/src/Zmsentities/Collection/AppointmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/AppointmentList.php
@@ -40,7 +40,7 @@ class AppointmentList extends Base
         return false;
     }
 
-    public function getCalculatedSlotCount()
+    public function getCalculatedSlotCount(): mixed
     {
         $slotCount = 0;
         foreach ($this as $appointmentItem) {

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -244,30 +244,30 @@ class AvailabilityList extends Base
     }
 
     /**
-     * @return integer
+     * @return array
      */
-    public function getSummerizedSlotCount()
+    public function getSummerizedSlotCount(): array
     {
-        return array_reduce($this->getArrayCopy(), function ($carry, $item) {
+        $slotCounts = [];
+        foreach ($this as $item) {
             $itemId = ($item->id) ? $item->id : $item->tempId;
-            $maxSlots = (int) $item->getSlotList()->getSummerizedSlot()->intern;
-            $carry[$itemId] = $maxSlots;
-            return $carry;
-        }, []);
+            $slotCounts[$itemId] = (int) $item->getSlotList()->getSummerizedSlot()->intern;
+        }
+        return $slotCounts;
     }
 
     /**
-     * @return integer
+     * @return array
      */
-    public function getCalculatedSlotCount(\BO\Zmsentities\Collection\ProcessList $processList)
+    public function getCalculatedSlotCount(\BO\Zmsentities\Collection\ProcessList $processList): array
     {
-        return array_reduce($this->getArrayCopy(), function ($carry, $item) use ($processList) {
+        $slotCounts = [];
+        foreach ($this as $item) {
             $itemId = $item->id;
             $listWithAvailability = $processList->withAvailability($item);
-            $busySlots = $listWithAvailability->getAppointmentList()->getCalculatedSlotCount();
-            $carry[$itemId] = $busySlots;
-            return $carry;
-        }, []);
+            $slotCounts[$itemId] = $listWithAvailability->getAppointmentList()->getCalculatedSlotCount();
+        }
+        return $slotCounts;
     }
 
 

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -94,7 +94,7 @@ class AvailabilityList extends Base
         return $list->withOutDoubles();
     }
 
-    public function getAvailableSecondsOnDateTime(\DateTimeInterface $dateTime, $type = "intern")
+    public function getAvailableSecondsOnDateTime(\DateTimeInterface $dateTime, string $type = "intern")
     {
         $seconds = 0;
         foreach ($this->withType('appointment')->withDateTime($dateTime) as $availability) {
@@ -106,7 +106,7 @@ class AvailabilityList extends Base
     /*
      * is opened on a day -> not specified by a time
      */
-    public function isOpenedByDate(\DateTimeInterface $dateTime, $type = false): bool
+    public function isOpenedByDate(\DateTimeInterface $dateTime, string|false $type = false): bool
     {
         foreach ($this as $availability) {
             if ($availability->isOpenedOnDate($dateTime, $type)) {
@@ -119,7 +119,7 @@ class AvailabilityList extends Base
     /*
      * is opened on a day with specified time
      */
-    public function isOpened(\DateTimeInterface $dateTime, $type = "openinghours"): bool
+    public function isOpened(\DateTimeInterface $dateTime, string $type = "openinghours"): bool
     {
         foreach ($this as $availability) {
             if ($availability->isOpened($dateTime, $type)) {
@@ -150,7 +150,7 @@ class AvailabilityList extends Base
         return $slotList;
     }
 
-    public function getSlotListByType($type): SlotList
+    public function getSlotListByType(mixed $type): SlotList
     {
         $slotList = new SlotList();
         foreach ($this as $availability) {
@@ -163,7 +163,7 @@ class AvailabilityList extends Base
         return $slotList;
     }
 
-    public function getConflicts($startDate, $endDate): ProcessList
+    public function getConflicts(mixed $startDate, mixed $endDate): ProcessList
     {
         $processList = new ProcessList();
         foreach ($this as $availability) {
@@ -217,8 +217,8 @@ class AvailabilityList extends Base
         \DateTimeImmutable $endDate,
         \DateTimeImmutable $selectedDate,
         string $kind,
-        $startInDays,
-        $endInDays,
+        mixed $startInDays,
+        mixed $endInDays,
         array $weekday
     ): array {
         $errorList = [];

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -281,12 +281,13 @@ class AvailabilityList extends Base
     }
 
     /**
-     * @return self
+     * @return static
      */
     #[\Override]
     public function withLessData(array $keepArray = [])
     {
-        $list = new self();
+        /** @psalm-suppress UnsafeGenericInstantiation */
+        $list = new static();
         foreach ($this as $availability) {
             $list->addEntity(clone $availability->withLessData($keepArray));
         }

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -82,7 +82,7 @@ class AvailabilityList extends Base
     public function withDateTimeInRange(\DateTimeInterface $startDateTime, \DateTimeInterface $endDateTime): mixed
     {
         $list = new self();
-        $currentDateTime = clone $startDateTime;
+        $currentDateTime = \BO\Zmsentities\Helper\DateTime::create($startDateTime);
         while ($currentDateTime <= $endDateTime) {
             foreach ($this as $availability) {
                 if ($availability->isOpenedOnDate($currentDateTime)) {

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -168,14 +168,15 @@ class AvailabilityList extends Base
         $processList = new ProcessList();
         foreach ($this as $availability) {
             $conflict = $availability->getConflict();
-            $currentDate = $startDate;
-            while ($currentDate <= $endDate) {
+            $currentDate = \BO\Zmsentities\Helper\DateTime::create($startDate);
+            $endDateTime = \BO\Zmsentities\Helper\DateTime::create($endDate);
+            while ($currentDate <= $endDateTime) {
                 if ($availability->isOpenedOnDate($currentDate)) {
                     if ($conflict) {
                         $conflictOnDay = clone $conflict;
                         // to avoid overwrite time settings from availability getConflict lets modify
                         $appointmentTime = $conflictOnDay->getFirstAppointment()->getStartTime()->format('H:i');
-                        $newDate = clone $currentDate;
+                        $newDate = \BO\Zmsentities\Helper\DateTime::create($currentDate);
                         $conflictOnDay->getFirstAppointment()->setDateTime($newDate->modify($appointmentTime));
                         $processList->addEntity($conflictOnDay);
                     }

--- a/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
+++ b/zmsentities/src/Zmsentities/Collection/AvailabilityList.php
@@ -16,7 +16,7 @@ class AvailabilityList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Availability';
 
-    public function getMaxWorkstationCount()
+    public function getMaxWorkstationCount(): mixed
     {
         $max = 0;
         foreach ($this as $availability) {
@@ -79,7 +79,7 @@ class AvailabilityList extends Base
         return $list;
     }
 
-    public function withDateTimeInRange(\DateTimeInterface $startDateTime, \DateTimeInterface $endDateTime)
+    public function withDateTimeInRange(\DateTimeInterface $startDateTime, \DateTimeInterface $endDateTime): mixed
     {
         $list = new self();
         $currentDateTime = clone $startDateTime;
@@ -94,7 +94,7 @@ class AvailabilityList extends Base
         return $list->withOutDoubles();
     }
 
-    public function getAvailableSecondsOnDateTime(\DateTimeInterface $dateTime, string $type = "intern")
+    public function getAvailableSecondsOnDateTime(\DateTimeInterface $dateTime, string $type = "intern"): mixed
     {
         $seconds = 0;
         foreach ($this->withType('appointment')->withDateTime($dateTime) as $availability) {

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -130,28 +130,28 @@ class Base extends \ArrayObject implements \JsonSerializable
         return null;
     }
 
-    /**
-     * @param T $entity
-     *
-     */
     public function addEntity(\BO\Zmsentities\Schema\Entity $entity): static
     {
+        /** @var T $entity */
         $this->append($entity);
         return $this;
     }
 
     /**
      * @param int|string|null $index
-     * @param T $value
+     * @param Entity|array $value
      */
     #[\Override]
     public function offsetSet(mixed $index, mixed $value): void
     {
         $className = $this::ENTITY_CLASS;
         if (is_a($value, $className)) {
+            /** @var T $value */
             parent::offsetSet($index, $value);
         } elseif (is_array($value)) {
-            parent::offsetSet($index, new $className($value));
+            /** @var T $entity */
+            $entity = new $className($value);
+            parent::offsetSet($index, $entity);
         } else {
             $given = get_debug_type($value);
             throw new \Exception('Invalid entity ' . $given . ' for collection ' . __CLASS__);
@@ -176,6 +176,9 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * @param Base<T> $list
+     */
     public function addList(Base $list): static
     {
         foreach ($list as $item) {

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -310,7 +310,7 @@ class Base extends \ArrayObject implements \JsonSerializable
     }
 
     /**
-     * @return Int
+     * @return int|null
      */
     public function getResolveLevel()
     {

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -83,7 +83,7 @@ class Base extends \ArrayObject implements \JsonSerializable
 
     public function sortByCustomKey(string $key): static
     {
-        $this->uasort(function ($a, $b) use ($key) {
+        $this->uasort(function ($a, $b) use ($key): mixed {
             return ($a[$key] - $b[$key]);
         });
         return $this;

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -31,6 +31,7 @@ class Base extends \ArrayObject implements \JsonSerializable
 
     public function __construct(object|array $array = [], int $flags = 0, string $iteratorClass = "ArrayIterator")
     {
+        /** @var class-string<\ArrayIterator> $iteratorClass */
         parent::__construct($array, $flags, $iteratorClass);
     }
 
@@ -172,6 +173,9 @@ class Base extends \ArrayObject implements \JsonSerializable
             } else {
                 $className = $this::ENTITY_CLASS;
                 $entity = new $className($item);
+                if (!$entity instanceof Entity) {
+                    throw new \Exception('Invalid entity ' . get_debug_type($entity) . ' for collection ' . __CLASS__);
+                }
                 $entity->setResolveLevel($this->getResolveLevel());
                 $this->addEntity($entity);
             }

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -25,7 +25,7 @@ class Base extends \ArrayObject implements \JsonSerializable
     public const string ENTITY_CLASS = '';
 
     /**
-     * @var Int $resolveLevel indicator on data integrity
+     * @var int|null $resolveLevel indicator on data integrity
      */
     protected $resolveLevel = null;
 

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -146,11 +146,14 @@ class Base extends \ArrayObject implements \JsonSerializable
     {
         $className = $this::ENTITY_CLASS;
         if (is_a($value, $className)) {
-            /** @var T $value */
-            parent::offsetSet($index, $value);
+            /** @var T $entity */
+            $entity = $value;
+            /** @psalm-suppress PossiblyNullArgument */
+            parent::offsetSet($index, $entity);
         } elseif (is_array($value)) {
             /** @var T $entity */
             $entity = new $className($value);
+            /** @psalm-suppress PossiblyNullArgument */
             parent::offsetSet($index, $entity);
         } else {
             $given = get_debug_type($value);

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -268,6 +268,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         /** @psalm-suppress UnsafeGenericInstantiation */
         $list = new static();
         foreach ($this as $key => $item) {
+            /** @psalm-suppress TooManyArguments */
             $list[$key] = $item->withLessData($keepArray);
         }
         return $list;

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -249,6 +249,7 @@ class Base extends \ArrayObject implements \JsonSerializable
      */
     public function withValueFor(mixed $param, mixed $newValue): static
     {
+        /** @psalm-suppress UnsafeGenericInstantiation */
         $list = new static();
         foreach ($this as $entry) {
             $list[] = $entry->withProperty($param, $newValue);
@@ -264,6 +265,7 @@ class Base extends \ArrayObject implements \JsonSerializable
      */
     public function withLessData(array $keepArray = [])
     {
+        /** @psalm-suppress UnsafeGenericInstantiation */
         $list = new static();
         foreach ($this as $key => $item) {
             $list[$key] = $item->withLessData($keepArray);
@@ -331,6 +333,7 @@ class Base extends \ArrayObject implements \JsonSerializable
      */
     public function withResolveLevel($resolveLevel)
     {
+        /** @psalm-suppress UnsafeGenericInstantiation */
         $collection = new static();
         foreach ($this as $entity) {
             $reduced = $entity->withResolveLevel($resolveLevel);
@@ -345,10 +348,12 @@ class Base extends \ArrayObject implements \JsonSerializable
      */
     public function chunk(mixed $length): array
     {
+        /** @psalm-suppress UnsafeGenericInstantiation */
         $chunks = [new static()];
         $id = 0;
         foreach ($this as $entry) {
             if (! isset($chunks[floor($id / $length)])) {
+                /** @psalm-suppress UnsafeGenericInstantiation */
                 $chunks[floor($id / $length)] = new static();
             }
 

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -153,7 +153,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         } elseif (is_array($value)) {
             parent::offsetSet($index, new $className($value));
         } else {
-            $given = is_object($value) ? $value::class : gettype($value);
+            $given = get_debug_type($value);
             throw new \Exception('Invalid entity ' . $given . ' for collection ' . __CLASS__);
         }
     }
@@ -324,9 +324,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         $collection = new static();
         foreach ($this as $entity) {
             $reduced = $entity->withResolveLevel($resolveLevel);
-            if (null !== $reduced) {
-                $collection[] = $reduced;
-            }
+            $collection[] = $reduced;
         }
         return $collection;
     }

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -130,10 +130,14 @@ class Base extends \ArrayObject implements \JsonSerializable
      */
     public function addEntity(\BO\Zmsentities\Schema\Entity $entity): static
     {
-        $this->offsetSet(null, $entity);
+        $this->append($entity);
         return $this;
     }
 
+    /**
+     * @param int|string|null $index
+     * @param T $value
+     */
     #[\Override]
     public function offsetSet(mixed $index, mixed $value): void
     {

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -318,7 +318,7 @@ class Base extends \ArrayObject implements \JsonSerializable
     }
 
     /**
-     * @param Int $resolveLevel
+     * @param int|null $resolveLevel
      * @return self
      */
     public function setResolveLevel($resolveLevel)

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -17,6 +17,7 @@ use BO\Zmsentities\Schema\Entity;
  *
  * @template T of Entity
  * @extends \ArrayObject<int|string, T>
+ * @psalm-consistent-constructor
  */
 class Base extends \ArrayObject implements \JsonSerializable
 {
@@ -27,6 +28,11 @@ class Base extends \ArrayObject implements \JsonSerializable
      * @var Int $resolveLevel indicator on data integrity
      */
     protected $resolveLevel = null;
+
+    public function __construct(object|array $array = [], int $flags = 0, string $iteratorClass = "ArrayIterator")
+    {
+        parent::__construct($array, $flags, $iteratorClass);
+    }
 
     /**
      * @return T|null

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -82,7 +82,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $this;
     }
 
-    public function sortByCustomStringKey($key): static
+    public function sortByCustomStringKey(mixed $key): static
     {
         $this->uasort(function ($a, $b) use ($key) {
             return strcmp(
@@ -100,7 +100,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         }
     }
 
-    public function hasEntity($primary): bool
+    public function hasEntity(mixed $primary): bool
     {
         foreach ($this as $entity) {
             if (isset($entity->{$entity::PRIMARY}) && $primary == $entity->{$entity::PRIMARY}) {
@@ -148,7 +148,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         }
     }
 
-    public function addData($mergeData): static
+    public function addData(mixed $mergeData): static
     {
         foreach ($mergeData as $item) {
             if ($item instanceof Entity) {
@@ -192,7 +192,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return implode(',', $this->getIds());
     }
 
-    public function getCsvForProperty($propertyName, $csvSeperator = ','): string
+    public function getCsvForProperty(mixed $propertyName, string $csvSeperator = ','): string
     {
         $list = [];
         foreach ($this as $entry) {
@@ -203,7 +203,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return implode($csvSeperator, $list);
     }
 
-    public function getCsvForPropertyList(array $propertyList, $propertySeperator = '', $csvSeperator = ','): string
+    public function getCsvForPropertyList(array $propertyList, string $propertySeperator = '', string $csvSeperator = ','): string
     {
         $list = [];
         foreach ($this as $entry) {
@@ -227,7 +227,7 @@ class Base extends \ArrayObject implements \JsonSerializable
      * Change a parameter on all entries
      *
      */
-    public function withValueFor($param, $newValue): static
+    public function withValueFor(mixed $param, mixed $newValue): static
     {
         $list = new static();
         foreach ($this as $entry) {
@@ -251,7 +251,7 @@ class Base extends \ArrayObject implements \JsonSerializable
         return $list;
     }
 
-    public function setJsonCompressLevel($jsonCompressLevel): void
+    public function setJsonCompressLevel(mixed $jsonCompressLevel): void
     {
         foreach ($this as $item) {
             $item->setJsonCompressLevel($jsonCompressLevel);
@@ -325,7 +325,7 @@ class Base extends \ArrayObject implements \JsonSerializable
      * @return static[]
      *
      */
-    public function chunk($length): array
+    public function chunk(mixed $length): array
     {
         $chunks = [new static()];
         $id = 0;

--- a/zmsentities/src/Zmsentities/Collection/Base.php
+++ b/zmsentities/src/Zmsentities/Collection/Base.php
@@ -352,12 +352,13 @@ class Base extends \ArrayObject implements \JsonSerializable
         $chunks = [new static()];
         $id = 0;
         foreach ($this as $entry) {
-            if (! isset($chunks[floor($id / $length)])) {
+            $chunkIndex = (int) floor($id / $length);
+            if (! isset($chunks[$chunkIndex])) {
                 /** @psalm-suppress UnsafeGenericInstantiation */
-                $chunks[floor($id / $length)] = new static();
+                $chunks[$chunkIndex] = new static();
             }
 
-            $chunks[floor($id / $length)][] = $entry;
+            $chunks[$chunkIndex][] = $entry;
 
             $id++;
         }

--- a/zmsentities/src/Zmsentities/Collection/ClosureList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClosureList.php
@@ -9,12 +9,12 @@ class ClosureList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Closure';
 
-    public function hasEntityByDate($date): bool
+    public function hasEntityByDate(string|\DateTimeInterface $date): bool
     {
         return $this->getByDate($date) ? true : false;
     }
 
-    public function getByDate($date): \BO\Zmsentities\Closure|false
+    public function getByDate(mixed $date): \BO\Zmsentities\Closure|false
     {
         $date = (new \BO\Zmsentities\Helper\DateTime($date))->format('Y-m-d');
         foreach ($this as $entity) {
@@ -25,7 +25,7 @@ class ClosureList extends Base
         return false;
     }
 
-    public function getEntityByName($name): \BO\Zmsentities\Closure|null
+    public function getEntityByName(mixed $name): \BO\Zmsentities\Closure|null
     {
         $result = null;
         foreach ($this as $entity) {
@@ -36,7 +36,7 @@ class ClosureList extends Base
         return $result;
     }
 
-    public function withTimestampFromDateformat($fromFormat = 'd.m.Y'): self
+    public function withTimestampFromDateformat(string $fromFormat = 'd.m.Y'): self
     {
         $collection = new self();
         foreach ($this as $data) {
@@ -51,7 +51,7 @@ class ClosureList extends Base
     /**
      * @return true
      */
-    public function testDatesInYear($year): bool
+    public function testDatesInYear(mixed $year): bool
     {
         foreach ($this as $data) {
             $entity = new \BO\Zmsentities\Closure($data); // if source is an array
@@ -79,7 +79,7 @@ class ClosureList extends Base
      *
      * @return bool
      */
-    public function isNewerThan(\DateTimeInterface $dateTime, $filterByAvailability = null, $now = null)
+    public function isNewerThan(\DateTimeInterface $dateTime, mixed $filterByAvailability = null, mixed $now = null)
     {
         foreach ($this as $closure) {
             if ($closure->isNewerThan($dateTime, $filterByAvailability, $now)) {

--- a/zmsentities/src/Zmsentities/Collection/ClosureList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClosureList.php
@@ -14,9 +14,9 @@ class ClosureList extends Base
         return $this->getByDate($date) ? true : false;
     }
 
-    public function getByDate(mixed $date): \BO\Zmsentities\Closure|false
+    public function getByDate(string|\DateTimeInterface $date): \BO\Zmsentities\Closure|false
     {
-        $date = (new \BO\Zmsentities\Helper\DateTime($date))->format('Y-m-d');
+        $date = \BO\Zmsentities\Helper\DateTime::create($date)->format('Y-m-d');
         foreach ($this as $entity) {
             if ($entity->getDateTime()->format('Y-m-d') == $date) {
                 return $entity;

--- a/zmsentities/src/Zmsentities/Collection/ClusterList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClusterList.php
@@ -9,7 +9,7 @@ class ClusterList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Cluster';
 
-    public function hasScope($scopeId): bool
+    public function hasScope(mixed $scopeId): bool
     {
         foreach ($this as $entity) {
             foreach ($entity['scopes'] as $scope) {

--- a/zmsentities/src/Zmsentities/Collection/ClusterList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClusterList.php
@@ -26,7 +26,7 @@ class ClusterList extends Base
     {
         $clusterList = new self();
         foreach ($this as $cluster) {
-            if ($cluster && ! $clusterList->hasEntity($cluster->id)) {
+            if (! $clusterList->hasEntity($cluster->id)) {
                 $clusterList->addEntity($cluster);
             }
         }

--- a/zmsentities/src/Zmsentities/Collection/ClusterList.php
+++ b/zmsentities/src/Zmsentities/Collection/ClusterList.php
@@ -26,7 +26,8 @@ class ClusterList extends Base
     {
         $clusterList = new self();
         foreach ($this as $cluster) {
-            if (! $clusterList->hasEntity($cluster->id)) {
+            /** @psalm-suppress RedundantConditionGivenDocblockType Constructor storage can include null. */
+            if ($cluster instanceof \BO\Zmsentities\Cluster && ! $clusterList->hasEntity($cluster->id)) {
                 $clusterList->addEntity($cluster);
             }
         }

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -138,10 +138,12 @@ class DayList extends Base implements JsonUnindexed
     public function withDaysInDateRange(\DateTimeInterface $startDate, \DateTimeInterface $endDate): self
     {
         $list = new self();
+        $rangeStart = \BO\Zmsentities\Helper\DateTime::create($startDate)->modify('00:00:00');
+        $rangeEnd = \BO\Zmsentities\Helper\DateTime::create($endDate)->modify('23:59:59');
         foreach ($this as $day) {
             if (
-                $day->toDateTime() >= $startDate->modify('00:00:00') &&
-                $day->toDateTime() <= $endDate->modify('23:59:59')
+                $day->toDateTime() >= $rangeStart &&
+                $day->toDateTime() <= $rangeEnd
             ) {
                 $list->addEntity($day);
             }
@@ -152,6 +154,7 @@ class DayList extends Base implements JsonUnindexed
     public function withDaysFromPeriod(\DateTimeInterface $startDate, \DateTimeInterface $endDate): self
     {
         $list = new self();
+        $startDate = \BO\Zmsentities\Helper\DateTime::create($startDate);
         do {
             $day = (new Day())->setDateTime($startDate);
             $list->addEntity($day);

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -65,7 +65,7 @@ class DayList extends Base implements JsonUnindexed
         $dayList = new self();
         $lastDay = $currentDate->format('t');
         for ($dayNumber = 1; $dayNumber <= $lastDay; $dayNumber++) {
-            $day = str_pad($dayNumber, 2, '0', STR_PAD_LEFT);
+            $day = str_pad((string) $dayNumber, 2, '0', STR_PAD_LEFT);
             $entity = $this->getDay($currentDate->format('Y'), $currentDate->format('m'), $day);
             $dayList->addEntity($entity);
         }

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -11,6 +11,12 @@ class DayList extends Base implements JsonUnindexed
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Day';
 
+    #[\Override]
+    public function getArrayCopy(): array
+    {
+        return parent::getArrayCopy();
+    }
+
     /**
      * ATTENTION: Performance critical, keep highly optimized
      *

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -54,7 +54,7 @@ class DayList extends Base implements JsonUnindexed
     }
 
 
-    public function hasDay($year, $month, $dayNumber): bool
+    public function hasDay(mixed $year, mixed $month, mixed $dayNumber): bool
     {
         $day = $this->getDay($year, $month, $dayNumber, false);
         return ($day === null) ? false : true;
@@ -72,7 +72,7 @@ class DayList extends Base implements JsonUnindexed
         return $dayList->sortByCustomKey('day');
     }
 
-    public function setStatusByType($slotType, \DateTimeInterface $dateTime): static
+    public function setStatusByType(mixed $slotType, \DateTimeInterface $dateTime): static
     {
         foreach ($this as $day) {
             $day->getWithStatus($slotType, $dateTime);
@@ -105,7 +105,7 @@ class DayList extends Base implements JsonUnindexed
         return $this;
     }
 
-    public function setSort($property = 'day'): static
+    public function setSort(string $property = 'day'): static
     {
         $this->uasort(function ($dayA, $dayB) use ($property) {
             return strnatcmp($dayA[$property], $dayB[$property]);

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -43,12 +43,12 @@ class DayList extends Base implements JsonUnindexed
         return null;
     }
 
-    public function getDayByDateTime(\DateTimeInterface $datetime)
+    public function getDayByDateTime(\DateTimeInterface $datetime): \BO\Zmsentities\Day|null
     {
         return $this->getDay($datetime->format('Y'), $datetime->format('m'), $datetime->format('d'));
     }
 
-    public function getDayByDay(\BO\Zmsentities\Day $day)
+    public function getDayByDay(\BO\Zmsentities\Day $day): \BO\Zmsentities\Day|null
     {
         return $this->getDay($day->year, $day->month, $day->day);
     }
@@ -60,7 +60,7 @@ class DayList extends Base implements JsonUnindexed
         return ($day === null) ? false : true;
     }
 
-    public function withAssociatedDays(\DateTimeInterface $currentDate)
+    public function withAssociatedDays(\DateTimeInterface $currentDate): \BO\Zmsentities\Collection\Base
     {
         $dayList = new self();
         $lastDay = $currentDate->format('t');
@@ -124,7 +124,7 @@ class DayList extends Base implements JsonUnindexed
         return false;
     }
 
-    public function getFirstBookableDay()
+    public function getFirstBookableDay(): mixed
     {
         foreach ($this as $day) {
             $day = new Day($day);

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -68,7 +68,7 @@ class DayList extends Base implements JsonUnindexed
         return ($day === null) ? false : true;
     }
 
-    public function withAssociatedDays(\DateTimeInterface $currentDate): \BO\Zmsentities\Collection\Base
+    public function withAssociatedDays(\DateTimeInterface $currentDate): self
     {
         $dayList = new self();
         $lastDay = $currentDate->format('t');
@@ -77,7 +77,8 @@ class DayList extends Base implements JsonUnindexed
             $entity = $this->getDay($currentDate->format('Y'), $currentDate->format('m'), $day);
             $dayList->addEntity($entity);
         }
-        return $dayList->sortByCustomKey('day');
+        $dayList->sortByCustomKey('day');
+        return $dayList;
     }
 
     public function setStatusByType(mixed $slotType, \DateTimeInterface $dateTime): static

--- a/zmsentities/src/Zmsentities/Collection/DayList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayList.php
@@ -13,6 +13,8 @@ class DayList extends Base implements JsonUnindexed
 
     /**
      * ATTENTION: Performance critical, keep highly optimized
+     *
+     * @return ($createDay is true ? Day : Day|null)
      */
     public function getDay(string $year, string $month, string $dayNumber, bool $createDay = true): Day|null
     {
@@ -43,12 +45,12 @@ class DayList extends Base implements JsonUnindexed
         return null;
     }
 
-    public function getDayByDateTime(\DateTimeInterface $datetime): \BO\Zmsentities\Day|null
+    public function getDayByDateTime(\DateTimeInterface $datetime): \BO\Zmsentities\Day
     {
         return $this->getDay($datetime->format('Y'), $datetime->format('m'), $datetime->format('d'));
     }
 
-    public function getDayByDay(\BO\Zmsentities\Day $day): \BO\Zmsentities\Day|null
+    public function getDayByDay(\BO\Zmsentities\Day $day): \BO\Zmsentities\Day
     {
         return $this->getDay($day->year, $day->month, $day->day);
     }

--- a/zmsentities/src/Zmsentities/Collection/DayoffList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayoffList.php
@@ -9,12 +9,12 @@ class DayoffList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Dayoff';
 
-    public function hasEntityByDate($date): bool
+    public function hasEntityByDate(string|\DateTimeInterface $date): bool
     {
         return $this->getByDate($date) ? true : false;
     }
 
-    public function getByDate($date): \BO\Zmsentities\Dayoff|false
+    public function getByDate(mixed $date): \BO\Zmsentities\Dayoff|false
     {
         $date = (new \BO\Zmsentities\Helper\DateTime($date))->format('Y-m-d');
         foreach ($this as $entity) {
@@ -25,7 +25,7 @@ class DayoffList extends Base
         return false;
     }
 
-    public function getEntityByName($name): \BO\Zmsentities\Dayoff|null
+    public function getEntityByName(mixed $name): \BO\Zmsentities\Dayoff|null
     {
         $result = null;
         foreach ($this as $entity) {
@@ -36,7 +36,7 @@ class DayoffList extends Base
         return $result;
     }
 
-    public function withTimestampFromDateformat($fromFormat = 'd.m.Y'): self
+    public function withTimestampFromDateformat(string $fromFormat = 'd.m.Y'): self
     {
         $collection = new self();
         foreach ($this as $data) {
@@ -51,7 +51,7 @@ class DayoffList extends Base
     /**
      * @return true
      */
-    public function testDatesInYear($year): bool
+    public function testDatesInYear(mixed $year): bool
     {
         foreach ($this as $data) {
             $entity = new \BO\Zmsentities\Dayoff($data); // if source is an array
@@ -79,7 +79,7 @@ class DayoffList extends Base
      *
      * @return bool
      */
-    public function isNewerThan(\DateTimeInterface $dateTime, $filterByAvailability = null, $now = null)
+    public function isNewerThan(\DateTimeInterface $dateTime, mixed $filterByAvailability = null, mixed $now = null)
     {
         foreach ($this as $dayoff) {
             if ($dayoff->isNewerThan($dateTime, $filterByAvailability, $now)) {

--- a/zmsentities/src/Zmsentities/Collection/DayoffList.php
+++ b/zmsentities/src/Zmsentities/Collection/DayoffList.php
@@ -14,9 +14,9 @@ class DayoffList extends Base
         return $this->getByDate($date) ? true : false;
     }
 
-    public function getByDate(mixed $date): \BO\Zmsentities\Dayoff|false
+    public function getByDate(string|\DateTimeInterface $date): \BO\Zmsentities\Dayoff|false
     {
-        $date = (new \BO\Zmsentities\Helper\DateTime($date))->format('Y-m-d');
+        $date = \BO\Zmsentities\Helper\DateTime::create($date)->format('Y-m-d');
         foreach ($this as $entity) {
             if ($entity->getDateTime()->format('Y-m-d') == $date) {
                 return $entity;

--- a/zmsentities/src/Zmsentities/Collection/DepartmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/DepartmentList.php
@@ -21,7 +21,7 @@ class DepartmentList extends Base implements JsonUnindexed
         return $departmentList;
     }
 
-    public function getUniqueScopeList()
+    public function getUniqueScopeList(): \BO\Zmsentities\Collection\ScopeList
     {
         $scopeList = new ScopeList();
         $clusterList = $this->getUniqueClusterList();
@@ -41,7 +41,7 @@ class DepartmentList extends Base implements JsonUnindexed
         return $scopeList->withUniqueScopes();
     }
 
-    public function getUniqueClusterList()
+    public function getUniqueClusterList(): \BO\Zmsentities\Collection\ClusterList
     {
         $clusterList = new ClusterList();
         foreach ($this as $department) {

--- a/zmsentities/src/Zmsentities/Collection/DepartmentList.php
+++ b/zmsentities/src/Zmsentities/Collection/DepartmentList.php
@@ -11,6 +11,12 @@ class DepartmentList extends Base implements JsonUnindexed
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Department';
 
+    #[\Override]
+    public function getArrayCopy(): array
+    {
+        return parent::getArrayCopy();
+    }
+
     public function withOutClusterDuplicates(): self
     {
         $departmentList = new self();

--- a/zmsentities/src/Zmsentities/Collection/JsonUnindexed.php
+++ b/zmsentities/src/Zmsentities/Collection/JsonUnindexed.php
@@ -8,4 +8,5 @@ namespace BO\Zmsentities\Collection;
  */
 interface JsonUnindexed
 {
+    public function getArrayCopy(): array;
 }

--- a/zmsentities/src/Zmsentities/Collection/MailList.php
+++ b/zmsentities/src/Zmsentities/Collection/MailList.php
@@ -9,7 +9,7 @@ class MailList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Mail';
 
-    public function withProcess($processId): self
+    public function withProcess(mixed $processId): self
     {
         $list = new self();
         foreach ($this as $mail) {

--- a/zmsentities/src/Zmsentities/Collection/OrganisationList.php
+++ b/zmsentities/src/Zmsentities/Collection/OrganisationList.php
@@ -9,7 +9,7 @@ class OrganisationList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Organisation';
 
-    public function getByDepartmentId($departmentId): self
+    public function getByDepartmentId(mixed $departmentId): self
     {
         $organisationList = new self();
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/OwnerList.php
+++ b/zmsentities/src/Zmsentities/Collection/OwnerList.php
@@ -9,7 +9,7 @@ class OwnerList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Owner';
 
-    public function getOrganisationsByOwnerId($entityId)
+    public function getOrganisationsByOwnerId(mixed $entityId)
     {
         $organisationList = new OrganisationList();
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/OwnerList.php
+++ b/zmsentities/src/Zmsentities/Collection/OwnerList.php
@@ -9,7 +9,7 @@ class OwnerList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Owner';
 
-    public function getOrganisationsByOwnerId(mixed $entityId)
+    public function getOrganisationsByOwnerId(mixed $entityId): mixed
     {
         $organisationList = new OrganisationList();
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -57,7 +57,7 @@ class ProcessList extends Base
     public function sortByAppointmentDate(): static
     {
         $this->uasort(function ($a, $b) {
-            return ($a->getFirstAppointment()->date - $b->getFirstAppointment()->date);
+            return ((int) $a->getFirstAppointment()->date - (int) $b->getFirstAppointment()->date);
         });
         return $this;
     }

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -47,8 +47,8 @@ class ProcessList extends Base
     {
         $this->uasort(function ($a, $b) {
             return strcmp(
-                Sorter::toSortableString(ucfirst($a->scope->contact['name'] ?? '')),
-                Sorter::toSortableString(ucfirst($b->scope->contact['name'] ?? ''))
+                Sorter::toSortableString(ucfirst($a->scope['contact']['name'] ?? '')),
+                Sorter::toSortableString(ucfirst($b->scope['contact']['name'] ?? ''))
             );
         });
         return $this;
@@ -283,7 +283,7 @@ class ProcessList extends Base
         $processList = new static();
         $scopeKeyList = [];
         foreach ($this as $process) {
-            $scopeKey = $process->scope->id . '-';
+            $scopeKey = $process->scope['id'] . '-';
             if ($oncePerHour) {
                 $scopeKey .= $process->getFirstAppointment()->toDateTime()->format('H');
             } else {

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -398,7 +398,7 @@ class ProcessList extends Base
         return $collection;
     }
 
-    public function withoutProcessByStatus(Process $process, string $status): mixed
+    public function withoutProcessByStatus(Process $process, string $status): static
     {
         $collection = clone $this;
         $collection = (1 <= $collection->count() && ! Messaging::isEmptyProcessListAllowed($status)) ?

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -140,7 +140,7 @@ class ProcessList extends Base
         return $list;
     }
 
-    public function getScopeList()
+    public function getScopeList(): \BO\Zmsentities\Collection\ScopeList
     {
         $list = new ScopeList();
         foreach ($this as $process) {
@@ -151,7 +151,7 @@ class ProcessList extends Base
         return $list->withUniqueScopes();
     }
 
-    public function getRequestList()
+    public function getRequestList(): \BO\Zmsentities\Collection\RequestList
     {
         $list = new RequestList();
         foreach ($this as $process) {
@@ -392,7 +392,7 @@ class ProcessList extends Base
         return $collection;
     }
 
-    public function withoutProcessByStatus(Process $process, string $status)
+    public function withoutProcessByStatus(Process $process, string $status): mixed
     {
         $collection = clone $this;
         $collection = (1 <= $collection->count() && ! Messaging::isEmptyProcessListAllowed($status)) ?

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -24,7 +24,7 @@ class ProcessList extends Base
         foreach ($this as $process) {
             $appointment = $process->getFirstAppointment();
             $formattedDate = $appointment['date'];
-            if ($format) {
+            if ($format !== null && $format !== '') {
                 $formattedDate = $appointment->toDateTime()->format($format);
             }
             $list[$formattedDate][] = clone $process;

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -382,9 +382,12 @@ class ProcessList extends Base
      */
     public function testProcessListLength(self|Process $processList, bool $isEmptyAllowed = false): ProcessList
     {
-        $collection = ($processList instanceof Process) ?
-            (new self())->addEntity($processList) :
-            $processList;
+        if ($processList instanceof Process) {
+            $collection = new self();
+            $collection->addEntity($processList);
+        } else {
+            $collection = $processList;
+        }
 
         if (0 === $collection->count() && ! $isEmptyAllowed) {
             throw new \BO\Zmsentities\Exception\ProcessListEmpty();

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -91,8 +91,8 @@ class ProcessList extends Base
 
     public function sortByTimeKey(): static
     {
-        $this->uksort(function ($a, $b) {
-            return ($a - $b);
+        $this->uksort(function ($a, $b): mixed {
+            return ((int) $a - (int) $b);
         });
         return $this;
     }

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -32,7 +32,7 @@ class ProcessList extends Base
         return $list;
     }
 
-    public function withRequest($requestId): self
+    public function withRequest(mixed $requestId): self
     {
         $list = new self();
         foreach ($this as $process) {
@@ -175,7 +175,7 @@ class ProcessList extends Base
         return $appointmentList;
     }
 
-    public function setTempAppointmentToProcess($dateTime, $scopeId): static
+    public function setTempAppointmentToProcess(mixed $dateTime, mixed $scopeId): static
     {
         $addedAppointment = false;
         $appointment = (new \BO\Zmsentities\Appointment())->addDate($dateTime->getTimestamp())->addScope($scopeId);
@@ -194,7 +194,7 @@ class ProcessList extends Base
         return $this;
     }
 
-    public function toQueueList($now): QueueList
+    public function toQueueList(mixed $now): QueueList
     {
         $queueList = new QueueList();
         foreach ($this as $process) {
@@ -278,7 +278,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withUniqueScope($oncePerHour = false): static
+    public function withUniqueScope(bool $oncePerHour = false): static
     {
         $processList = new static();
         $scopeKeyList = [];
@@ -333,7 +333,7 @@ class ProcessList extends Base
         return $processList;
     }
 
-    public function withOutProcessId($processId): static
+    public function withOutProcessId(mixed $processId): static
     {
         $processList = new static();
         foreach ($this as $process) {
@@ -377,7 +377,10 @@ class ProcessList extends Base
         return $collection;
     }
 
-    public function testProcessListLength($processList, bool $isEmptyAllowed = false): ProcessList
+    /**
+     * @param Process|self $processList
+     */
+    public function testProcessListLength(self|Process $processList, bool $isEmptyAllowed = false): ProcessList
     {
         $collection = ($processList instanceof Process) ?
             (new self())->addEntity($processList) :
@@ -389,7 +392,7 @@ class ProcessList extends Base
         return $collection;
     }
 
-    public function withoutProcessByStatus(Process $process, $status)
+    public function withoutProcessByStatus(Process $process, string $status)
     {
         $collection = clone $this;
         $collection = (1 <= $collection->count() && ! Messaging::isEmptyProcessListAllowed($status)) ?

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -64,7 +64,7 @@ class ProcessList extends Base
 
     public function sortByArrivalTime(): static
     {
-        $this->uasort(function ($a, $b) {
+        $this->uasort(function ($a, $b): mixed {
             return ($a->queue['arrivalTime'] - $b->queue['arrivalTime']);
         });
         return $this;
@@ -72,7 +72,7 @@ class ProcessList extends Base
 
     public function sortByEstimatedWaitingTime(): static
     {
-        $this->uasort(function ($a, $b) {
+        $this->uasort(function ($a, $b): mixed {
             return ($a->queue['waitingTimeEstimate'] - $b->queue['waitingTimeEstimate']);
         });
         return $this;

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -263,6 +263,9 @@ class ProcessList extends Base
             $dateTime = $processListByDate[0]->getFirstAppointment()->toDateTime();
             $slotList = $availabilityList->withType('appointment')->withDateTime($dateTime)->getSlotList();
             foreach ($processListByDate as $process) {
+                if (!$process instanceof Process) {
+                    continue;
+                }
                 try {
                     $slotList->withSlotsForAppointment($process->getFirstAppointment());
                     if (!$slotList->removeAppointment($process->getFirstAppointment())) {

--- a/zmsentities/src/Zmsentities/Collection/ProcessList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProcessList.php
@@ -232,7 +232,7 @@ class ProcessList extends Base
     {
         $processList = new static();
         foreach ($this as $process) {
-            if ($process->scope->hasEmailFrom()) {
+            if ($process->getCurrentScope()->hasEmailFrom()) {
                 $entity = clone $process;
                 $processList->addEntity($entity);
             }

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -61,7 +61,7 @@ class ProviderList extends Base
     {
         $list = new self();
         foreach ($this as $provider) {
-            if ($provider && ! $list->hasEntity($provider->id)) {
+            if (! $list->hasEntity($provider->id)) {
                 $list->addEntity($provider);
             }
         }

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -86,7 +86,7 @@ class ProviderList extends Base
         return $list;
     }
 
-    public function sortById()
+    public function sortById(): \BO\Zmsentities\Collection\Base
     {
         $list = clone $this;
         $list->uasort(function ($a, $b) {

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -76,7 +76,7 @@ class ProviderList extends Base
                 if (is_string($provider->data)) {
                     $provider->data = json_decode($provider->data);
                 } elseif (is_array($provider->data)) {
-                    $provider->data = json_decode(json_encode($provider->data, JSON_FORCE_OBJECT));
+                    $provider->data = json_decode((string) json_encode($provider->data, JSON_FORCE_OBJECT));
                 }
             } else {
                 unset($provider['data']);

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -51,7 +51,10 @@ class ProviderList extends Base
         $providerIds = explode(',', $providerIdCsv);
         foreach ($providerIds as $providerId) {
             if (in_array($providerId, $this->getIds())) {
-                $collection->addEntity($this->getEntity($providerId));
+                $entity = $this->getEntity($providerId);
+                if ($entity !== null) {
+                    $collection->addEntity($entity);
+                }
             }
         }
         return $collection;

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -64,7 +64,8 @@ class ProviderList extends Base
     {
         $list = new self();
         foreach ($this as $provider) {
-            if (! $list->hasEntity($provider->id)) {
+            /** @psalm-suppress RedundantConditionGivenDocblockType Constructor storage can include null. */
+            if ($provider instanceof \BO\Zmsentities\Provider && ! $list->hasEntity($provider->id)) {
                 $list->addEntity($provider);
             }
         }

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -9,7 +9,7 @@ class ProviderList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Provider';
 
-    public function hasProvider($providerIdCsv): bool
+    public function hasProvider(mixed $providerIdCsv): bool
     {
         $providerFound = false;
         $providerIds = explode(',', $providerIdCsv);
@@ -21,7 +21,7 @@ class ProviderList extends Base
         return $providerFound;
     }
 
-    public function hasProviderStrict($providerIdCsv): bool
+    public function hasProviderStrict(mixed $providerIdCsv): bool
     {
         $providerIds = explode(',', $providerIdCsv);
         foreach ($providerIds as $providerId) {
@@ -32,7 +32,7 @@ class ProviderList extends Base
         return true;
     }
 
-    public function hasRequest($requestIdCsv): bool
+    public function hasRequest(mixed $requestIdCsv): bool
     {
         $requestIds = explode(',', $requestIdCsv);
         foreach ($this as $entity) {
@@ -45,7 +45,7 @@ class ProviderList extends Base
         return false;
     }
 
-    public function withMatchingByList($providerIdCsv): self
+    public function withMatchingByList(mixed $providerIdCsv): self
     {
         $collection = new self();
         $providerIds = explode(',', $providerIdCsv);

--- a/zmsentities/src/Zmsentities/Collection/ProviderList.php
+++ b/zmsentities/src/Zmsentities/Collection/ProviderList.php
@@ -92,7 +92,7 @@ class ProviderList extends Base
     public function sortById(): \BO\Zmsentities\Collection\Base
     {
         $list = clone $this;
-        $list->uasort(function ($a, $b) {
+        $list->uasort(function ($a, $b): mixed {
             return ($a['id'] - $b['id']);
         });
         return (new self())->addList($list);

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -26,11 +26,11 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
 
     public const int DEFAULT_PRIORITY_WITH_APPOINTMENT = 2;
 
-    protected $processTimeAverage;
+    protected mixed $processTimeAverage = null;
 
-    protected $workstationCount;
+    protected mixed $workstationCount = null;
 
-    protected $fromProcessList = false;
+    protected bool $fromProcessList = false;
 
     public function setWaitingTimePreferences(mixed $processTimeAverage, mixed $workstationCount): static
     {

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -32,7 +32,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
 
     protected $fromProcessList = false;
 
-    public function setWaitingTimePreferences($processTimeAverage, $workstationCount): static
+    public function setWaitingTimePreferences(mixed $processTimeAverage, mixed $workstationCount): static
     {
         if ($processTimeAverage <= 0) {
             throw new \Exception("QueueList::withEstimatedWaitingTime() requires processTimeAverage");
@@ -59,10 +59,10 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
     }
 
     public function withEstimatedWaitingTime(
-        $processTimeAverage,
-        $workstationCount,
+        int $processTimeAverage,
+        int $workstationCount,
         \DateTimeInterface $dateTime,
-        $createFake = true
+        bool $createFake = true
     ) {
         $this->setWaitingTimePreferences($processTimeAverage, $workstationCount);
         $queueFull = $this->withWaitingTime($dateTime);
@@ -199,7 +199,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function getEstimatedWaitingTime($processTimeAverage, $workstationCount, \DateTimeInterface $dateTime): array
+    public function getEstimatedWaitingTime(mixed $processTimeAverage, mixed $workstationCount, \DateTimeInterface $dateTime): array
     {
         $queueList = $this->withFakeWaitingnumber($dateTime);
         $queueList = $queueList
@@ -247,7 +247,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return null;
     }
 
-    public function getNextProcess(\DateTimeInterface $dateTime, $exclude = null)
+    public function getNextProcess(\DateTimeInterface $dateTime, mixed $exclude = null)
     {
         if (is_array($exclude)) {
             $excludeNumbers = $exclude;
@@ -275,7 +275,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return null;
     }
 
-    public function getQueuePositionByNumber($number): int|null
+    public function getQueuePositionByNumber(mixed $number): int|null
     {
         $list = array_values($this->getArrayCopy());
         foreach ($list as $key => $entity) {

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -205,6 +205,12 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         $queueList = $queueList
           ->withEstimatedWaitingTime($processTimeAverage, $workstationCount, $dateTime);
         $newEntity = $queueList->getFakeOrLastWaitingnumber();
+        if (!$newEntity instanceof \BO\Zmsentities\Queue) {
+            return [
+                'amountBefore' => 0,
+                'waitingTimeEstimate' => 0,
+            ];
+        }
         $dataOfFackedEntity = array(
             'amountBefore' => $queueList->getQueuePositionByNumber($newEntity->number),
             'waitingTimeEstimate' => $newEntity->waitingTimeEstimate

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -59,8 +59,8 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
     }
 
     public function withEstimatedWaitingTime(
-        int $processTimeAverage,
-        int $workstationCount,
+        mixed $processTimeAverage,
+        mixed $workstationCount,
         \DateTimeInterface $dateTime,
         bool $createFake = true
     ): \BO\Zmsentities\Collection\QueueList {

--- a/zmsentities/src/Zmsentities/Collection/QueueList.php
+++ b/zmsentities/src/Zmsentities/Collection/QueueList.php
@@ -48,12 +48,12 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $this;
     }
 
-    public function getProcessTimeAverage()
+    public function getProcessTimeAverage(): mixed
     {
         return $this->processTimeAverage;
     }
 
-    public function getWorkstationCount()
+    public function getWorkstationCount(): mixed
     {
         return $this->workstationCount ? $this->workstationCount : 1;
     }
@@ -63,7 +63,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         int $workstationCount,
         \DateTimeInterface $dateTime,
         bool $createFake = true
-    ) {
+    ): \BO\Zmsentities\Collection\QueueList {
         $this->setWaitingTimePreferences($processTimeAverage, $workstationCount);
         $queueFull = $this->withWaitingTime($dateTime);
         $queueWithWaitingTime = $queueFull->withStatus(self::STATUS_CALLED);
@@ -171,7 +171,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function withSortedWaitingTime()
+    public function withSortedWaitingTime(): \BO\Zmsentities\Collection\Base
     {
         $queueList = $this;
         return $queueList->sortByCustomKey('waitingTimeEstimate');
@@ -227,7 +227,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return $queueList;
     }
 
-    public function getFakeOrLastWaitingnumber()
+    public function getFakeOrLastWaitingnumber(): \BO\Zmsentities\Schema\Entity|false
     {
         $entity = $this->getQueueByNumber(self::FAKE_WAITINGNUMBER);
         if (!$entity) {
@@ -247,7 +247,7 @@ class QueueList extends Base implements \BO\Zmsentities\Helper\NoSanitize
         return null;
     }
 
-    public function getNextProcess(\DateTimeInterface $dateTime, mixed $exclude = null)
+    public function getNextProcess(\DateTimeInterface $dateTime, mixed $exclude = null): mixed
     {
         if (is_array($exclude)) {
             $excludeNumbers = $exclude;

--- a/zmsentities/src/Zmsentities/Collection/RequestList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestList.php
@@ -91,7 +91,7 @@ class RequestList extends Base
                 if (is_string($request->data)) {
                     $request->data = json_decode($request->data);
                 } elseif (is_array($request->data)) {
-                    $request->data = json_decode(json_encode($request->data, JSON_FORCE_OBJECT));
+                    $request->data = json_decode((string) json_encode($request->data, JSON_FORCE_OBJECT));
                 }
             } else {
                 unset($request['data']);

--- a/zmsentities/src/Zmsentities/Collection/RequestList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestList.php
@@ -56,7 +56,10 @@ class RequestList extends Base
                 );
             }
             while ($counter-- > 0) {
-                $requestList[] = $this->getEntity($requestId);
+                $entity = $this->getEntity($requestId);
+                if ($entity !== null) {
+                    $requestList[] = $entity;
+                }
             }
         }
         return $requestList;

--- a/zmsentities/src/Zmsentities/Collection/RequestList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestList.php
@@ -42,7 +42,7 @@ class RequestList extends Base
     /**
      * Filter the request list and return a new list with appropriate numbers of requests
      *
-     * @param array $countlist - a list with the request.id as number and a count as value
+     * @param array $countList - a list with the request.id as number and a count as value
      *
      * @return RequestList
      */

--- a/zmsentities/src/Zmsentities/Collection/RequestList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestList.php
@@ -46,7 +46,7 @@ class RequestList extends Base
      *
      * @return RequestList
      */
-    public function withCountList($countList)
+    public function withCountList(mixed $countList)
     {
         $requestList = new self();
         foreach ($countList as $requestId => $counter) {

--- a/zmsentities/src/Zmsentities/Collection/RequestRelationList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestRelationList.php
@@ -9,7 +9,7 @@ class RequestRelationList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\RequestRelation';
 
-    public function hasRequest($requestIdCsv): bool
+    public function hasRequest(mixed $requestIdCsv): bool
     {
         $requestIdCsv = explode(',', $requestIdCsv);
         foreach ($requestIdCsv as $requestId) {
@@ -20,7 +20,7 @@ class RequestRelationList extends Base
         return true;
     }
 
-    public function hasProvider($providerIdCsv): bool
+    public function hasProvider(mixed $providerIdCsv): bool
     {
         $providerIdCsv = explode(',', $providerIdCsv);
         foreach ($providerIdCsv as $providerId) {
@@ -55,7 +55,7 @@ class RequestRelationList extends Base
         return $providerList->withUniqueProvider();
     }
 
-    public function getFilteredByRequestAndProvider($requestList, $providerList): self
+    public function getFilteredByRequestAndProvider(mixed $requestList, mixed $providerList): self
     {
         $list = new self();
         foreach ($requestList as $request) {

--- a/zmsentities/src/Zmsentities/Collection/RequestRelationList.php
+++ b/zmsentities/src/Zmsentities/Collection/RequestRelationList.php
@@ -31,7 +31,7 @@ class RequestRelationList extends Base
         return true;
     }
 
-    public function getRequestList()
+    public function getRequestList(): \BO\Zmsentities\Collection\RequestList
     {
         $requestList = new RequestList();
         foreach ($this as $item) {
@@ -43,7 +43,7 @@ class RequestRelationList extends Base
         return $requestList->withUniqueRequests();
     }
 
-    public function getProviderList()
+    public function getProviderList(): \BO\Zmsentities\Collection\ProviderList
     {
         $providerList = new ProviderList();
         foreach ($this as $item) {

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -163,7 +163,7 @@ class ScopeList extends Base
         return $this;
     }
 
-    public function getRequiredSlotsByScope(Scope $scope)
+    public function getRequiredSlotsByScope(Scope $scope): mixed
     {
         if (isset($this->slotsByID[$scope->id])) {
             return $this->slotsByID[$scope->id];
@@ -182,7 +182,7 @@ class ScopeList extends Base
         return $isOpened;
     }
 
-    public function getProviderList()
+    public function getProviderList(): \BO\Zmsentities\Collection\ProviderList
     {
         $list = new ProviderList();
         foreach ($this as $scope) {

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -111,12 +111,13 @@ class ScopeList extends Base
     }
 
     /**
-     * @return self
+     * @return static
      */
     #[\Override]
     public function withLessData(array $keepArray = [])
     {
-        $scopeList = new self();
+        /** @psalm-suppress UnsafeGenericInstantiation */
+        $scopeList = new static();
         foreach ($this as $scope) {
             $scopeList->addEntity(clone $scope->withLessData($keepArray));
         }

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -19,7 +19,7 @@ class ScopeList extends Base
     *
     * @return \DateTimeImmutable $date
     */
-    public function getShortestBookableStart($now)
+    public function getShortestBookableStart(mixed $now)
     {
         $date = $now;
         foreach ($this as $scope) {
@@ -34,7 +34,7 @@ class ScopeList extends Base
     *
     * @return \DateTimeImmutable $date
     */
-    public function getGreatestBookableEnd($now)
+    public function getGreatestBookableEnd(mixed $now)
     {
         $date = $now;
         foreach ($this as $scope) {
@@ -49,7 +49,7 @@ class ScopeList extends Base
     *
     * @return \DateTimeImmutable $date, null
     */
-    public function getShortestBookableStartOnOpenedScope($now)
+    public function getShortestBookableStartOnOpenedScope(mixed $now)
     {
         $date = null;
         foreach ($this as $scope) {
@@ -67,7 +67,7 @@ class ScopeList extends Base
     *
     * @return \DateTimeImmutable $date
     */
-    public function getGreatestBookableEndOnOpenedScope($now)
+    public function getGreatestBookableEndOnOpenedScope(mixed $now)
     {
         $date = null;
         foreach ($this as $scope) {
@@ -80,7 +80,7 @@ class ScopeList extends Base
         return $date;
     }
 
-    public function withoutDublicates($scopeList = null): self
+    public function withoutDublicates(mixed $scopeList = null): self
     {
         $collection = new self();
         foreach ($this as $scope) {
@@ -102,7 +102,7 @@ class ScopeList extends Base
         return $scopeList;
     }
 
-    public function addScopeList($scopeList): static
+    public function addScopeList(mixed $scopeList): static
     {
         foreach ($scopeList as $scope) {
             $this->addEntity($scope);
@@ -140,7 +140,7 @@ class ScopeList extends Base
         return $this;
     }
 
-    public function withProviderID($source, $providerID): self
+    public function withProviderID(mixed $source, mixed $providerID): self
     {
         $list = new ScopeList();
         foreach ($this as $scope) {
@@ -151,7 +151,7 @@ class ScopeList extends Base
         return $list;
     }
 
-    public function addRequiredSlots($source, $providerID, $slotsRequired): static
+    public function addRequiredSlots(mixed $source, mixed $providerID, mixed $slotsRequired): static
     {
         $scopeList = $this->withProviderID($source, $providerID);
         foreach ($scopeList as $scope) {

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -47,7 +47,7 @@ class ScopeList extends Base
     /**
     * Get shortest bookable start date of a opened scope in scopelist
     *
-    * @return \DateTimeImmutable $date, null
+    * @return \DateTimeInterface|null
     */
     public function getShortestBookableStartOnOpenedScope(mixed $now)
     {
@@ -65,7 +65,7 @@ class ScopeList extends Base
     /**
     * Get longest bookable end date of a opened scope in scopelist
     *
-    * @return \DateTimeImmutable $date
+    * @return \DateTimeInterface|null
     */
     public function getGreatestBookableEndOnOpenedScope(mixed $now)
     {

--- a/zmsentities/src/Zmsentities/Collection/ScopeList.php
+++ b/zmsentities/src/Zmsentities/Collection/ScopeList.php
@@ -12,7 +12,7 @@ class ScopeList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Scope';
 
-    protected $slotsByID = [];
+    protected array $slotsByID = [];
 
     /**
     * Get shortest bookable start date of a scope in scopelist

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -18,10 +18,10 @@ class SlotList extends Base
      * @param array $slotA
      * @param array $slotB
      *
-     * @return array $slotA modified
+     * @return static
      *
      */
-    public function takeLowerSlotValue(int $indexA, int $indexB)
+    public function takeLowerSlotValue(int $indexA, int $indexB): static
     {
         $slotA = $this[$indexA];
         $slotB = $this[$indexB];

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -94,7 +94,7 @@ class SlotList extends Base
                 "$appointment does not fit in $this"
             );
         }
-        if (0 < $takeFollowingSlot && $extendSlotList) {
+        if (0 < $takeFollowingSlot) {
             $slotList = $this->extendList($slotList, $currentSlot, $appointment);
         }
         return $slotList;

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -45,7 +45,7 @@ class SlotList extends Base
         return $this;
     }
 
-    public function isAvailableForAll($slotType): bool
+    public function isAvailableForAll(mixed $slotType): bool
     {
         foreach ($this as $slot) {
             if ($slot[$slotType] < 1) {
@@ -72,7 +72,7 @@ class SlotList extends Base
      * Get all slots for an appointment
      *
      */
-    public function withSlotsForAppointment(\BO\Zmsentities\Appointment $appointment, $extendSlotList = false)
+    public function withSlotsForAppointment(\BO\Zmsentities\Appointment $appointment, bool $extendSlotList = false)
     {
         $slotList = new SlotList();
         $takeFollowingSlot = 0;
@@ -154,7 +154,10 @@ class SlotList extends Base
         return $containsAppointment;
     }
 
-    public function getSlot($index): Slot|null
+    /**
+     * @param int|string $index
+     */
+    public function getSlot(string|int $index): Slot|null
     {
         $index = intval($index);
         if (!isset($this[$index])) {
@@ -163,7 +166,7 @@ class SlotList extends Base
         return $this[$index];
     }
 
-    public function getSummerizedSlot($slot = null): Slot
+    public function getSummerizedSlot(mixed $slot = null): Slot
     {
         $sum = ($slot instanceof Slot) ? $slot : new Slot();
         $sum->type = Slot::SUM;
@@ -193,12 +196,12 @@ class SlotList extends Base
     }
 
     public function getFreeProcesses(
-        $selectedDate,
+        mixed $selectedDate,
         \BO\Zmsentities\Scope $scope,
         \BO\Zmsentities\Availability $availability,
-        $slotType,
-        $requests,
-        $slotsRequired
+        mixed $slotType,
+        mixed $requests,
+        mixed $slotsRequired
     ): ProcessList {
         $processList = new ProcessList();
         foreach ($this as $slot) {
@@ -231,7 +234,7 @@ class SlotList extends Base
         return $processList;
     }
 
-    public function withReducedSlots($slotsRequired): static
+    public function withReducedSlots(mixed $slotsRequired): static
     {
         $slotList = clone $this;
         if ($slotsRequired > 1) {

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -102,6 +102,9 @@ class SlotList extends Base
 
     public function extendList(self $slotList, Slot|null $prevSlot, \BO\Zmsentities\Appointment $appointment): \BO\Zmsentities\Collection\SlotList
     {
+        if ($prevSlot === null) {
+            return $slotList;
+        }
         $slotMinutes = (string) (int) $appointment->getAvailability()->slotTimeInMinutes;
         $startTime = \BO\Zmsentities\Helper\DateTime::create(
             $appointment->toDateTime()->format('Y-m-d') . ' ' . $prevSlot->time

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -23,9 +23,9 @@ class SlotList extends Base
      */
     public function takeLowerSlotValue(int $indexA, int $indexB): static
     {
-        $slotA = $this[$indexA];
-        $slotB = $this[$indexB];
-        if (null !== $slotA && null !== $slotB) {
+        if ($this->offsetExists($indexA) && $this->offsetExists($indexB)) {
+            $slotA = $this[$indexA];
+            $slotB = $this[$indexB];
             $slotA->type = Slot::REDUCED;
             foreach (['public', 'intern'] as $type) {
                 $slotA[$type] = $slotA[$type] < $slotB[$type] ? $slotA[$type] : $slotB[$type];

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -72,7 +72,7 @@ class SlotList extends Base
      * Get all slots for an appointment
      *
      */
-    public function withSlotsForAppointment(\BO\Zmsentities\Appointment $appointment, bool $extendSlotList = false)
+    public function withSlotsForAppointment(\BO\Zmsentities\Appointment $appointment, bool $extendSlotList = false): mixed
     {
         $slotList = new SlotList();
         $takeFollowingSlot = 0;
@@ -100,7 +100,7 @@ class SlotList extends Base
         return $slotList;
     }
 
-    public function extendList(self $slotList, Slot|null $prevSlot, \BO\Zmsentities\Appointment $appointment)
+    public function extendList(self $slotList, Slot|null $prevSlot, \BO\Zmsentities\Appointment $appointment): \BO\Zmsentities\Collection\SlotList
     {
         $startTime = \BO\Zmsentities\Helper\DateTime::create(
             $appointment->toDateTime()->format('Y-m-d') . ' ' . $prevSlot->time

--- a/zmsentities/src/Zmsentities/Collection/SlotList.php
+++ b/zmsentities/src/Zmsentities/Collection/SlotList.php
@@ -102,15 +102,16 @@ class SlotList extends Base
 
     public function extendList(self $slotList, Slot|null $prevSlot, \BO\Zmsentities\Appointment $appointment): \BO\Zmsentities\Collection\SlotList
     {
+        $slotMinutes = (string) (int) $appointment->getAvailability()->slotTimeInMinutes;
         $startTime = \BO\Zmsentities\Helper\DateTime::create(
             $appointment->toDateTime()->format('Y-m-d') . ' ' . $prevSlot->time
-        )->modify('+' . $appointment->getAvailability()->slotTimeInMinutes . 'minute');
+        )->modify('+' . $slotMinutes . 'minute');
         $stopTime = $appointment->getEndTime();
         do {
             $slot = clone $prevSlot;
             $slot->setTime($startTime);
             $slotList[] = $slot;
-            $startTime = $startTime->modify('+' . $appointment->getAvailability()->slotTimeInMinutes . 'minute');
+            $startTime = $startTime->modify('+' . $slotMinutes . 'minute');
             // Only add a slot, if at least a minute is left, otherwise do not ("<" instead "<=")
         } while ($startTime->getTimestamp() < $stopTime->getTimestamp());
         return $slotList;

--- a/zmsentities/src/Zmsentities/Collection/TicketprinterList.php
+++ b/zmsentities/src/Zmsentities/Collection/TicketprinterList.php
@@ -9,7 +9,7 @@ class TicketprinterList extends Base
 {
     public const string ENTITY_CLASS = '\BO\Zmsentities\Ticketprinter';
 
-    public function getEntityByHash($hash): \BO\Zmsentities\Ticketprinter|null
+    public function getEntityByHash(mixed $hash): \BO\Zmsentities\Ticketprinter|null
     {
         $result = null;
         foreach ($this as $entity) {

--- a/zmsentities/src/Zmsentities/Collection/UseraccountList.php
+++ b/zmsentities/src/Zmsentities/Collection/UseraccountList.php
@@ -20,7 +20,7 @@ class UseraccountList extends Base
         return $collection;
     }
 
-    public function withAccessByWorkstation($workstation): self
+    public function withAccessByWorkstation(mixed $workstation): self
     {
         $collection = new self();
         $departmentList = $workstation->getDepartmentList();

--- a/zmsentities/src/Zmsentities/Config.php
+++ b/zmsentities/src/Zmsentities/Config.php
@@ -37,22 +37,22 @@ class Config extends Schema\Entity
         ];
     }
 
-    public function hasType($type): bool
+    public function hasType(mixed $type): bool
     {
         return (isset($this[$type])) ? true : false;
     }
 
-    public function hasPreference($type, $key): bool
+    public function hasPreference(mixed $type, mixed $key): bool
     {
         return ($this->hasType($type) && isset($this[$type][$key])) ? true : false;
     }
 
-    public function getPreference($type, $key)
+    public function getPreference(mixed $type, mixed $key)
     {
         return $this->toProperty()->$type->$key->get();
     }
 
-    public function setPreference($type, $key, $value): static
+    public function setPreference(mixed $type, mixed $key, mixed $value): static
     {
         $preference = $this->toProperty()->$type->$key->get();
         if (null !== $preference) {

--- a/zmsentities/src/Zmsentities/Config.php
+++ b/zmsentities/src/Zmsentities/Config.php
@@ -47,7 +47,7 @@ class Config extends Schema\Entity
         return ($this->hasType($type) && isset($this[$type][$key])) ? true : false;
     }
 
-    public function getPreference(mixed $type, mixed $key)
+    public function getPreference(mixed $type, mixed $key): mixed
     {
         return $this->toProperty()->$type->$key->get();
     }

--- a/zmsentities/src/Zmsentities/Day.php
+++ b/zmsentities/src/Zmsentities/Day.php
@@ -59,7 +59,7 @@ class Day extends Schema\Entity
     /**
      * @return bool TRUE or FALSE if one or more appointments, if no appointments for $slotType were defined, than NULL
      */
-    public function hasAppointmentsByType($slotType)
+    public function hasAppointmentsByType(mixed $slotType)
     {
         $freeAppointmentCount = $this->toProperty()->freeAppointments->{$slotType}->get();
         $allAppointmentCount = $this->toProperty()->allAppointments->{$slotType}->get();
@@ -85,7 +85,7 @@ class Day extends Schema\Entity
      *
      * @return \ArrayObject or String
      */
-    public function getWithStatus($slotType, \DateTimeInterface $now)
+    public function getWithStatus(mixed $slotType, \DateTimeInterface $now)
     {
         $hasAppointments = $this->hasAppointmentsByType($slotType);
         if ($this->status != self::RESTRICTED && $hasAppointments !== null) {
@@ -118,7 +118,7 @@ class Day extends Schema\Entity
         return $this::getCalculatedDayHash($this->day, $this->month, $this->year);
     }
 
-    public static function getCalculatedDayHash($dayNumber, $month, $year): string
+    public static function getCalculatedDayHash(string|int $dayNumber, string|int $month, string|int $year): string
     {
         $dateHash = str_pad($dayNumber, 2, '0', STR_PAD_LEFT)
             . "-"

--- a/zmsentities/src/Zmsentities/Day.php
+++ b/zmsentities/src/Zmsentities/Day.php
@@ -120,9 +120,9 @@ class Day extends Schema\Entity
 
     public static function getCalculatedDayHash(string|int $dayNumber, string|int $month, string|int $year): string
     {
-        $dateHash = str_pad($dayNumber, 2, '0', STR_PAD_LEFT)
+        $dateHash = str_pad((string) $dayNumber, 2, '0', STR_PAD_LEFT)
             . "-"
-            . str_pad($month, 2, '0', STR_PAD_LEFT)
+            . str_pad((string) $month, 2, '0', STR_PAD_LEFT)
             . "-$year";
         return $dateHash;
     }

--- a/zmsentities/src/Zmsentities/Day.php
+++ b/zmsentities/src/Zmsentities/Day.php
@@ -50,7 +50,7 @@ class Day extends Schema\Entity
         return $this;
     }
 
-    public function toDateTime()
+    public function toDateTime(): \BO\Zmsentities\Helper\DateTime
     {
         $date = Helper\DateTime::createFromFormat('Y-m-d', $this['year'] . '-' . $this['month'] . '-' . $this['day']);
         return Helper\DateTime::create($date);
@@ -113,7 +113,7 @@ class Day extends Schema\Entity
     /**
      * Returns an unique string hash per day optimized for b-trees
      */
-    public function getDayHash()
+    public function getDayHash(): string
     {
         return $this::getCalculatedDayHash($this->day, $this->month, $this->year);
     }

--- a/zmsentities/src/Zmsentities/Day.php
+++ b/zmsentities/src/Zmsentities/Day.php
@@ -57,9 +57,9 @@ class Day extends Schema\Entity
     }
 
     /**
-     * @return bool TRUE or FALSE if one or more appointments, if no appointments for $slotType were defined, than NULL
+     * @return bool|null TRUE or FALSE if one or more appointments, if no appointments for $slotType were defined, than NULL
      */
-    public function hasAppointmentsByType(mixed $slotType)
+    public function hasAppointmentsByType(mixed $slotType): bool|null
     {
         $freeAppointmentCount = $this->toProperty()->freeAppointments->{$slotType}->get();
         $allAppointmentCount = $this->toProperty()->allAppointments->{$slotType}->get();

--- a/zmsentities/src/Zmsentities/Dayoff.php
+++ b/zmsentities/src/Zmsentities/Dayoff.php
@@ -21,7 +21,7 @@ class Dayoff extends Schema\Entity
         ];
     }
 
-    public function setTimestampFromDateformat($fromFormat = 'd.m.Y'): static
+    public function setTimestampFromDateformat(string $fromFormat = 'd.m.Y'): static
     {
         $dateTime = \DateTimeImmutable::createFromFormat($fromFormat, $this->date, new \DateTimeZone('UTC'));
         if ($dateTime) {
@@ -40,7 +40,7 @@ class Dayoff extends Schema\Entity
      *
      * @return bool
      */
-    public function isNewerThan(\DateTimeInterface $dateTime, $filterByAvailability = null, $now = null)
+    public function isNewerThan(\DateTimeInterface $dateTime, mixed $filterByAvailability = null, mixed $now = null)
     {
         if ($filterByAvailability && !$this->isAffectingAvailability($filterByAvailability, $now)) {
             return false;

--- a/zmsentities/src/Zmsentities/Department.php
+++ b/zmsentities/src/Zmsentities/Department.php
@@ -55,7 +55,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         return $this->dayoff;
     }
 
-    public function getClusterByScopeId($scopeId)
+    public function getClusterByScopeId(mixed $scopeId)
     {
         $selectedCluster = false;
         if (isset($this->clusters)) {

--- a/zmsentities/src/Zmsentities/Department.php
+++ b/zmsentities/src/Zmsentities/Department.php
@@ -32,7 +32,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         return ($this->toProperty()->email->isAvailable() && $this->toProperty()->email->get());
     }
 
-    public function getContactPerson()
+    public function getContactPerson(): mixed
     {
         return $this->toProperty()->contact->name->get();
     }
@@ -55,7 +55,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
         return $this->dayoff;
     }
 
-    public function getClusterByScopeId(mixed $scopeId)
+    public function getClusterByScopeId(mixed $scopeId): mixed
     {
         $selectedCluster = false;
         if (isset($this->clusters)) {
@@ -141,7 +141,7 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
      * @return bool
      */
     #[\Override]
-    public function hasAccess(Useraccount $useraccount)
+    public function hasAccess(Useraccount $useraccount): bool
     {
         return $useraccount->isSuperUser() || $useraccount->hasDepartment($this->id);
     }

--- a/zmsentities/src/Zmsentities/Department.php
+++ b/zmsentities/src/Zmsentities/Department.php
@@ -80,7 +80,10 @@ class Department extends Schema\Entity implements Useraccount\AccessInterface
     {
         $department = clone $this;
         if ($this->offsetExists('scopes') && $this->scopes) {
-            $scopeList = clone $this->scopes;
+            $scopes = $this->scopes;
+            $scopeList = $scopes instanceof Collection\ScopeList
+                ? clone $scopes
+                : new Collection\ScopeList($scopes);
             $department->scopes = new Collection\ScopeList();
             $removeScopeList = new Collection\ScopeList();
             if ($department->toProperty()->clusters->get()) {

--- a/zmsentities/src/Zmsentities/EventLog.php
+++ b/zmsentities/src/Zmsentities/EventLog.php
@@ -67,7 +67,7 @@ class EventLog extends Schema\Entity
      * {@inheritDoc}
      */
     #[\Override]
-    public function addData($mergeData): static
+    public function addData(mixed $mergeData): static
     {
         if (isset($mergeData['creationDateTime']) && is_string($mergeData['creationDateTime'])) {
             $mergeData['creationDateTime'] = new DateTime($mergeData['creationDateTime']);

--- a/zmsentities/src/Zmsentities/EventLog.php
+++ b/zmsentities/src/Zmsentities/EventLog.php
@@ -76,7 +76,8 @@ class EventLog extends Schema\Entity
             $mergeData['expirationDateTime'] = new DateTime($mergeData['expirationDateTime']);
         }
 
-        return parent::addData($mergeData);
+        parent::addData($mergeData);
+        return $this;
     }
 
     #[\Override]

--- a/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
+++ b/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
@@ -45,9 +45,10 @@ class SchemaValidation extends \Exception
             $this->data[$pointer]['failed'] = 1;
             $this->data[$pointer]['data'] = $error->data() !== null ? $error->data()->value() : null;
 
+            $encodedMessages = json_encode($this->data[$pointer]['messages'], JSON_UNESCAPED_SLASHES);
             $this->message .= ($this->message ? " | " : "")
                 . '[property ' . $pointer . '] '
-                . (json_encode($this->data[$pointer]['messages'], JSON_UNESCAPED_SLASHES) ?: '');
+                . ($encodedMessages !== false ? $encodedMessages : '');
         }
         return $this;
     }

--- a/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
+++ b/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
@@ -37,7 +37,7 @@ class SchemaValidation extends \Exception
 
             $message = $error->message();
             foreach ($error->args() as $key => $value) {
-                $message = str_replace("{" . $key . "}", json_encode($value, JSON_UNESCAPED_SLASHES), $message);
+                $message = str_replace("{" . $key . "}", (string) json_encode($value, JSON_UNESCAPED_SLASHES), $message);
             }
 
             $this->data[$pointer]['messages'][$error->keyword()] = $message;

--- a/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
+++ b/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
@@ -21,7 +21,7 @@ class SchemaValidation extends \Exception
         return $this;
     }
 
-    public function setSchemaName($schemaName): static
+    public function setSchemaName(string $schemaName): static
     {
         $this->schemaName = $schemaName . '.json';
         $this->template = $schemaName;

--- a/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
+++ b/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
@@ -47,7 +47,7 @@ class SchemaValidation extends \Exception
 
             $this->message .= ($this->message ? " | " : "")
                 . '[property ' . $pointer . '] '
-                . json_encode($this->data[$pointer]['messages'], JSON_UNESCAPED_SLASHES);
+                . (json_encode($this->data[$pointer]['messages'], JSON_UNESCAPED_SLASHES) ?: '');
         }
         return $this;
     }

--- a/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
+++ b/zmsentities/src/Zmsentities/Exception/SchemaValidation.php
@@ -9,11 +9,11 @@ class SchemaValidation extends \Exception
 {
     protected $code = 400;
 
-    public $data = [];
+    public array $data = [];
 
-    protected $schemaName = '';
+    protected string $schemaName = '';
 
-    public $template;
+    public string $template = '';
 
     public function setValidationError(array $validationErrorList): static
     {

--- a/zmsentities/src/Zmsentities/Exception/ScopeMissingProvider.php
+++ b/zmsentities/src/Zmsentities/Exception/ScopeMissingProvider.php
@@ -9,5 +9,5 @@ class ScopeMissingProvider extends \Exception
 {
     protected $code = 500;
 
-    public $data = [];
+    public array $data = [];
 }

--- a/zmsentities/src/Zmsentities/Exception/TemplateNotFound.php
+++ b/zmsentities/src/Zmsentities/Exception/TemplateNotFound.php
@@ -11,5 +11,5 @@ class TemplateNotFound extends \Exception
 
     protected $message = 'The requested template does not exist';
 
-    public $data;
+    public mixed $data = null;
 }

--- a/zmsentities/src/Zmsentities/Exception/UserAccountAccessRightsFailed.php
+++ b/zmsentities/src/Zmsentities/Exception/UserAccountAccessRightsFailed.php
@@ -11,5 +11,5 @@ class UserAccountAccessRightsFailed extends \Exception
 
     protected $message = 'Level of user rights are low, access rejected';
 
-    public $templatedata = null;
+    public mixed $templatedata = null;
 }

--- a/zmsentities/src/Zmsentities/Exception/UserAccountMissingRights.php
+++ b/zmsentities/src/Zmsentities/Exception/UserAccountMissingRights.php
@@ -9,5 +9,5 @@ class UserAccountMissingRights extends \Exception
 {
     protected $code = 403;
 
-    public $templatedata = null;
+    public mixed $templatedata = null;
 }

--- a/zmsentities/src/Zmsentities/Exception/WorkstationProcessMatchScopeFailed.php
+++ b/zmsentities/src/Zmsentities/Exception/WorkstationProcessMatchScopeFailed.php
@@ -9,7 +9,7 @@ class WorkstationProcessMatchScopeFailed extends \Exception
 {
     protected $code = 403;
 
-    public $data;
+    public mixed $data = null;
 
     protected $message = "Workstation is not allowed to edit the process,
         process scope does not match with workstation cluster/scope";

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -116,7 +116,7 @@ class Exchange extends Schema\Entity
                 $calculatePosition = $this->getPositionByName($name);
                 foreach ($this->data as $item) {
                     foreach ($item as $position => $data) {
-                        if (is_numeric($data) && $calculatePosition == $position) {
+                        if (is_numeric($data) && $calculatePosition == $position && is_numeric($totals[$position])) {
                             $totals[$position] += $data;
                         }
                     }

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -68,8 +68,10 @@ class Exchange extends Schema\Entity
         if (!is_array($values) && !$values instanceof \Traversable) {
             throw new \Exception("Values have to be of type array");
         }
-        $valueCount = is_array($values) ? count($values) : iterator_count($values);
-        if (count($this->dictionary) != $valueCount) {
+        if (!is_array($values)) {
+            $values = iterator_to_array($values);
+        }
+        if (count($this->dictionary) != count($values)) {
             throw new \Exception("Mismatching dictionary settings for values (count mismatch)");
         }
         $this->data[] = $values;

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -379,9 +379,7 @@ class Exchange extends Schema\Entity
             }
 
             foreach ($list as $key => $row) {
-                if ($row instanceof Exchange) {
-                    $list[$key] = $row->getGroupedHashSet($fields, $hashfields);
-                }
+                $list[$key] = $row->getGroupedHashSet($fields, $hashfields);
             }
         } else {
             return $this->getHashData($hashfields, true);

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -58,7 +58,7 @@ class Exchange extends Schema\Entity
     }
 
     /**
-     * @param (float|int|string)[] $values
+     * @param mixed $values
      *
      *
      * @return void
@@ -68,7 +68,8 @@ class Exchange extends Schema\Entity
         if (!is_array($values) && !$values instanceof \Traversable) {
             throw new \Exception("Values have to be of type array");
         }
-        if (count($this->dictionary) != count($values)) {
+        $valueCount = is_array($values) ? count($values) : iterator_count($values);
+        if (count($this->dictionary) != $valueCount) {
             throw new \Exception("Mismatching dictionary settings for values (count mismatch)");
         }
         $this->data[] = $values;

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -36,7 +36,7 @@ class Exchange extends Schema\Entity
         ];
     }
 
-    public function setPeriod(\DateTimeInterface $firstDay, \DateTimeInterface $lastDay, $period = 'day'): static
+    public function setPeriod(\DateTimeInterface $firstDay, \DateTimeInterface $lastDay, string $period = 'day'): static
     {
         $this->firstDay = (new Day())->setDateTime($firstDay);
         $this->lastDay = (new Day())->setDateTime($lastDay);
@@ -44,7 +44,7 @@ class Exchange extends Schema\Entity
         return $this;
     }
 
-    public function addDictionaryEntry($variable, $type = 'string', $description = '', $reference = ''): static
+    public function addDictionaryEntry(mixed $variable, string $type = 'string', string $description = '', string $reference = ''): static
     {
         $position = count($this['dictionary']);
         $this['dictionary'][$position] = [
@@ -105,7 +105,7 @@ class Exchange extends Schema\Entity
         return false;
     }
 
-    public function withCalculatedTotals(array $keysToCalculate = ['count'], $dateName = 'name'): static
+    public function withCalculatedTotals(array $keysToCalculate = ['count'], string $dateName = 'name'): static
     {
         $entity = clone $this;
         $namePosition = $this->getPositionByName($dateName);
@@ -146,7 +146,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function withRequestsSum($keysToCalculate = ['requestscount']): static
+    public function withRequestsSum(mixed $keysToCalculate = ['requestscount']): static
     {
         $entity = clone $this;
         $sum = [];
@@ -164,7 +164,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function withAverage($keyToCalculate): static
+    public function withAverage(mixed $keyToCalculate): static
     {
         $entity = clone $this;
         $average = [];

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -93,7 +93,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function getPositionByName(string $name)
+    public function getPositionByName(string $name): mixed
     {
         if (isset($this->dictionary)) {
             foreach ($this->dictionary as $entry) {
@@ -303,7 +303,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function getCalculatedTotals()
+    public function getCalculatedTotals(): mixed
     {
         foreach (array_reverse($this->data) as $item) {
             foreach ($item as $data) {
@@ -354,7 +354,7 @@ class Exchange extends Schema\Entity
         return $entity;
     }
 
-    public function getGroupedHashSet(array $fields, array $hashfields)
+    public function getGroupedHashSet(array $fields, array $hashfields): mixed
     {
         $list = [];
         if (count($fields)) {

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -175,8 +175,8 @@ class Exchange extends Schema\Entity
                 continue;
             }
 
-            $average[$name . '_sum'] = 0;
-            $average[$name . '_count'] = 0;
+            $sum = 0;
+            $count = 0;
 
             foreach ($entry as $dateItem) {
                 if (!is_array($dateItem) && !($dateItem instanceof \Traversable)) {
@@ -190,13 +190,15 @@ class Exchange extends Schema\Entity
                         continue;
                     }
 
-                    $average[$name . '_sum'] += $value;
-                    $average[$name . '_count']++;
+                    $sum += $value;
+                    $count++;
                 }
             }
 
-            $average[$name] = $average[$name . '_count'] > 0
-                ? round($average[$name . '_sum'] / $average[$name . '_count'], 2)
+            $average[$name . '_sum'] = $sum;
+            $average[$name . '_count'] = $count;
+            $average[$name] = $count > 0
+                ? round($sum / $count, 2)
                 : null;
         }
 

--- a/zmsentities/src/Zmsentities/Exchange.php
+++ b/zmsentities/src/Zmsentities/Exchange.php
@@ -69,7 +69,7 @@ class Exchange extends Schema\Entity
             throw new \Exception("Values have to be of type array");
         }
         if (!is_array($values)) {
-            $values = iterator_to_array($values);
+            $values = iterator_to_array($values, false);
         }
         if (count($this->dictionary) != count($values)) {
             throw new \Exception("Mismatching dictionary settings for values (count mismatch)");

--- a/zmsentities/src/Zmsentities/Helper/DateTime.php
+++ b/zmsentities/src/Zmsentities/Helper/DateTime.php
@@ -20,7 +20,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
             }
             $dateTime = $dateTime->setTimestamp($time->getTimestamp());
         } else {
-            $dateTime = new self($time, $timezone);
+            $dateTime = new self($time === false ? 'now' : $time, $timezone);
         }
         return $dateTime;
     }

--- a/zmsentities/src/Zmsentities/Helper/DateTime.php
+++ b/zmsentities/src/Zmsentities/Helper/DateTime.php
@@ -85,7 +85,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         $year = ($year) ? $year : date('Y');
         $dateTimeMarch = new \DateTime($year . '-03-01', new \DateTimeZone('Europe/Berlin'));
         $lastSunday = $dateTimeMarch->modify('Last Sunday of March');
-        return $lastSunday->setTime('02', '00', '00');
+        return $lastSunday->setTime(2, 0, 0);
     }
 
     public static function getSummerTimeEndDateTime(mixed $year = null): \DateTime
@@ -93,7 +93,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         $year = ($year) ? $year : date('Y');
         $dateTimeOctober = new \DateTime($year . '-10-01', new \DateTimeZone('Europe/Berlin'));
         $lastSunday = $dateTimeOctober->modify('Last Sunday of October');
-        return $lastSunday->setTime('03', '00', '00');
+        return $lastSunday->setTime(3, 0, 0);
     }
 
     public function __toString(): string

--- a/zmsentities/src/Zmsentities/Helper/DateTime.php
+++ b/zmsentities/src/Zmsentities/Helper/DateTime.php
@@ -39,7 +39,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $weekOfMonth;
     }
 
-    public function isWeekOfMonth($number): bool
+    public function isWeekOfMonth(mixed $number): bool
     {
         return (int)$this->getWeekOfMonth() === (int)$number;
     }
@@ -66,8 +66,8 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
     public static function getFormatedDates(
         \DateTimeInterface $date,
         string $pattern = 'MMMM',
-        $locale = 'de_DE',
-        $timezone = 'Europe/Berlin'
+        string $locale = 'de_DE',
+        string $timezone = 'Europe/Berlin'
     ): string|false {
         $dateFormatter = new \IntlDateFormatter(
             $locale,
@@ -80,7 +80,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $dateFormatter->format($date->getTimestamp());
     }
 
-    public static function getSummerTimeStartDateTime($year = null): \DateTime
+    public static function getSummerTimeStartDateTime(mixed $year = null): \DateTime
     {
         $year = ($year) ? $year : date('Y');
         $dateTimeMarch = new \DateTime($year . '-03-01', new \DateTimeZone('Europe/Berlin'));
@@ -88,7 +88,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return $lastSunday->setTime('02', '00', '00');
     }
 
-    public static function getSummerTimeEndDateTime($year = null): \DateTime
+    public static function getSummerTimeEndDateTime(mixed $year = null): \DateTime
     {
         $year = ($year) ? $year : date('Y');
         $dateTimeOctober = new \DateTime($year . '-10-01', new \DateTimeZone('Europe/Berlin'));

--- a/zmsentities/src/Zmsentities/Helper/DateTime.php
+++ b/zmsentities/src/Zmsentities/Helper/DateTime.php
@@ -34,7 +34,7 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
         return 1 + ($week < $firstWeekOfMonth ? $week : $week - $firstWeekOfMonth);
         */
 
-        $dayOfMonth = $this->format('j');
+        $dayOfMonth = (int) $this->format('j');
         $weekOfMonth = ceil($dayOfMonth / 7);
         return $weekOfMonth;
     }
@@ -53,9 +53,9 @@ class DateTime extends \DateTimeImmutable implements \JsonSerializable
 
     public function getSecondsOfDay(): int|float
     {
-        $hours = $this->format('G');
-        $minutes = $this->format('i');
-        $seconds = $this->format('s');
+        $hours = (int) $this->format('G');
+        $minutes = (int) $this->format('i');
+        $seconds = (int) $this->format('s');
         return $hours * 3600 + $minutes * 60 + $seconds;
     }
 

--- a/zmsentities/src/Zmsentities/Helper/Delegate.php
+++ b/zmsentities/src/Zmsentities/Helper/Delegate.php
@@ -18,7 +18,7 @@ class Delegate
         return $this->entity;
     }
 
-    public function setter(...$propertyPath): callable
+    public function setter(mixed ...$propertyPath): callable
     {
         $entity = $this->getEntity();
 

--- a/zmsentities/src/Zmsentities/Helper/Delegate.php
+++ b/zmsentities/src/Zmsentities/Helper/Delegate.php
@@ -22,7 +22,7 @@ class Delegate
     {
         $entity = $this->getEntity();
 
-        return function ($newValue) use ($propertyPath, $entity): Entity {
+        return function (mixed $newValue) use ($propertyPath, $entity): Entity {
             self::setValueAtPath($entity, $propertyPath, $newValue);
 
             return $entity;

--- a/zmsentities/src/Zmsentities/Helper/Delegate.php
+++ b/zmsentities/src/Zmsentities/Helper/Delegate.php
@@ -32,6 +32,9 @@ class Delegate
     private static function setValueAtPath(mixed &$container, array $propertyPath, mixed $newValue): void
     {
         $property = array_shift($propertyPath);
+        if ($property === null) {
+            return;
+        }
         if ($propertyPath === []) {
             $container[$property] = $newValue;
 

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -103,9 +103,10 @@ class Messaging
     {
         $templatePath = TemplateFinder::getTemplatePath();
         $customTemplatesPath = 'custom_templates/';
+        $envPath = getenv("ZMS_CUSTOM_TEMPLATES_PATH");
 
-        if (getenv("ZMS_CUSTOM_TEMPLATES_PATH")) {
-            $customTemplatesPath = getenv("ZMS_CUSTOM_TEMPLATES_PATH");
+        if (is_string($envPath) && $envPath !== '') {
+            $customTemplatesPath = $envPath;
         }
 
         $initialTemplatePaths = [];
@@ -206,7 +207,7 @@ class Messaging
             'processList' => $collection->sortByAppointmentDate(),
             'config' => $config,
             'initiator' => $initiator,
-            'appointmentLink' => base64_encode(json_encode([
+            'appointmentLink' => base64_encode((string) json_encode([
                 'id' => $mainProcess ? $mainProcess->id : '',
                 'authKey' => $mainProcess ? $mainProcess->authKey : ''
             ]))

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -144,7 +144,7 @@ class Messaging
         mixed $initiator = null,
         string $status = 'appointment',
         mixed $templateProvider = false
-    ) {
+    ): string {
         $parameters = self::generateMailParameters($processList, $config, $initiator, $status);
 
         (new ProcessList())->testProcessListLength($processList, self::isEmptyProcessListAllowed($status));
@@ -229,7 +229,7 @@ class Messaging
         return $message;
     }
 
-    protected static function getTemplate(string $type, string $status)
+    protected static function getTemplate(string $type, string $status): mixed
     {
         $template = null;
         if (Property::__keyExists($type, self::$templates)) {
@@ -290,7 +290,7 @@ class Messaging
         mixed $now = false,
         mixed $templateProvider = false,
         string $message = '' // Pass $message from getMailIcs, or query if not set
-    ) {
+    ): string {
         // If $message is not provided, retrieve it from the getMailContent query
         if (empty($message)) {
             $message = self::getMailContent($process, $config, null, $status, $templateProvider);

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -250,7 +250,7 @@ class Messaging
     ): string {
         $appointment = $process->getFirstAppointment();
         $parameters = [
-            'date' => $appointment ? $appointment->toDateTime()->format('U') : null,
+            'date' => $appointment->toDateTime()->format('U'),
             'client' => $process->getFirstClient(),
             'process' => $process,
             'config' => $config,

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -24,12 +24,12 @@ use Twig\Extra\Intl\IntlExtension;
  */
 class Messaging
 {
-    public static $icsRequiredForStatus = [
+    public static array $icsRequiredForStatus = [
         'confirmed',
         'appointment'
     ];
 
-    public static $allowEmptyProcesses = [
+    public static array $allowEmptyProcesses = [
         'overview'
     ];
 
@@ -54,7 +54,7 @@ class Messaging
         return (in_array($status, self::$allowEmptyProcesses));
     }
 
-    protected static $templates = array(
+    protected static array $templates = array(
         'mail' => array(
             'queued' => 'mail_queued.twig',
             'appointment' => 'mail_confirmation.twig',

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -36,7 +36,7 @@ class Messaging
     public static function isIcsRequired(
         \BO\Zmsentities\Config $config,
         \BO\Zmsentities\Process $process,
-        $status
+        mixed $status
     ): bool {
         $client = $process->getFirstClient();
         $noAttachmentDomains = $config->toProperty()->notifications->noAttachmentDomains->get();
@@ -49,7 +49,7 @@ class Messaging
         return (in_array($status, self::$icsRequiredForStatus));
     }
 
-    public static function isEmptyProcessListAllowed($status): bool
+    public static function isEmptyProcessListAllowed(string $status): bool
     {
         return (in_array($status, self::$allowEmptyProcesses));
     }
@@ -81,7 +81,7 @@ class Messaging
         return self::createTwigEnvironment(self::filesystemLoader());
     }
 
-    protected static function dbTwigView($templateProvider): Environment
+    protected static function dbTwigView(mixed $templateProvider): Environment
     {
         $loader = new \Twig\Loader\ChainLoader([
             new \Twig\Loader\ArrayLoader($templateProvider->getTemplates()),
@@ -126,7 +126,7 @@ class Messaging
         return $loader;
     }
 
-    public static function getMailContentPreview($templateContent, $process): string
+    public static function getMailContentPreview(mixed $templateContent, mixed $process): string
     {
         $parameters = self::generateMailParameters(
             $process,
@@ -141,9 +141,9 @@ class Messaging
     public static function getMailContent(
         Process|ProcessList $processList,
         Config $config,
-        $initiator = null,
-        $status = 'appointment',
-        $templateProvider = false
+        mixed $initiator = null,
+        string $status = 'appointment',
+        mixed $templateProvider = false
     ) {
         $parameters = self::generateMailParameters($processList, $config, $initiator, $status);
 
@@ -172,7 +172,7 @@ class Messaging
      * @return ((int|mixed)[][]|Client|Process|\DateTimeImmutable|mixed|null|string)[]
      *
      */
-    public static function generateMailParameters(Process|ProcessList $processList, Config $config, $initiator, string $status): array
+    public static function generateMailParameters(Process|ProcessList $processList, Config $config, mixed $initiator, string $status): array
     {
         $collection = (new ProcessList())
             ->testProcessListLength($processList, self::isEmptyProcessListAllowed($status));
@@ -229,7 +229,7 @@ class Messaging
         return $message;
     }
 
-    protected static function getTemplate(string $type, $status)
+    protected static function getTemplate(string $type, string $status)
     {
         $template = null;
         if (Property::__keyExists($type, self::$templates)) {
@@ -243,9 +243,9 @@ class Messaging
     public static function getMailSubject(
         Process $process,
         Config $config,
-        $initiator = null,
-        $status = 'appointment',
-        $templateProvider = null
+        mixed $initiator = null,
+        string $status = 'appointment',
+        mixed $templateProvider = null
     ): string {
         $appointment = $process->getFirstAppointment();
         $parameters = [
@@ -271,10 +271,10 @@ class Messaging
     public static function getMailIcs(
         Process $process,
         Config $config,
-        $status = 'appointment',
-        $initiator = null,
-        $now = false,
-        $templateProvider = false
+        string $status = 'appointment',
+        mixed $initiator = null,
+        mixed $now = false,
+        mixed $templateProvider = false
     ): \BO\Zmsentities\Ics {
         $ics = new \BO\Zmsentities\Ics();
         $message = self::getMailContent($process, $config, $initiator, $status, $templateProvider);
@@ -286,10 +286,10 @@ class Messaging
     protected static function generateIcsContent(
         Process $process,
         Config $config,
-        $status = 'appointment',
-        $now = false,
-        $templateProvider = false,
-        $message = '' // Pass $message from getMailIcs, or query if not set
+        string $status = 'appointment',
+        mixed $now = false,
+        mixed $templateProvider = false,
+        string $message = '' // Pass $message from getMailIcs, or query if not set
     ) {
         // If $message is not provided, retrieve it from the getMailContent query
         if (empty($message)) {
@@ -339,7 +339,7 @@ class Messaging
         return self::getTextWithFoldedLines($icsString);
     }
 
-    public static function getPlainText($content, $lineBreak = "\n"): string
+    public static function getPlainText(mixed $content, string $lineBreak = "\n"): string
     {
         $converter = new \League\HTMLToMarkdown\HtmlConverter();
         $converter->getConfig()->setOption('remove_nodes', 'script');

--- a/zmsentities/src/Zmsentities/Helper/Messaging.php
+++ b/zmsentities/src/Zmsentities/Helper/Messaging.php
@@ -42,7 +42,7 @@ class Messaging
         $noAttachmentDomains = $config->toProperty()->notifications->noAttachmentDomains->get();
         $noAttachmentDomains = explode(',', (string)$noAttachmentDomains);
         foreach ($noAttachmentDomains as $matching) {
-            if (trim($matching) && strpos($client->email, '@' . trim($matching))) {
+            if (trim($matching) !== '' && strpos($client->email, '@' . trim($matching)) !== false) {
                 return false;
             }
         }

--- a/zmsentities/src/Zmsentities/Helper/Property.php
+++ b/zmsentities/src/Zmsentities/Helper/Property.php
@@ -71,7 +71,7 @@ class Property implements \ArrayAccess
         throw new \BO\Zmsentities\Exception\PropertyOffsetReadOnly(__CLASS__ . "[$offset] is readonly");
     }
 
-    public function __get($property)
+    public function __get(mixed $property)
     {
         if (
             (is_array($this->access) && array_key_exists($property, $this->access)) ||
@@ -94,7 +94,7 @@ class Property implements \ArrayAccess
         return $string;
     }
 
-    public static function __keyExists($key, $data)
+    public static function __keyExists(mixed $key, mixed $data)
     {
         if (is_array($data)) {
             return array_key_exists($key, $data);

--- a/zmsentities/src/Zmsentities/Helper/Sorter.php
+++ b/zmsentities/src/Zmsentities/Helper/Sorter.php
@@ -25,7 +25,7 @@ class Sorter
         return $string;
     }
 
-    public static function toSortedCsv($csvString): string
+    public static function toSortedCsv(mixed $csvString): string
     {
         $csvElements = explode(',', $csvString ?? '');
         sort($csvElements);

--- a/zmsentities/src/Zmsentities/Helper/TemplateFinder.php
+++ b/zmsentities/src/Zmsentities/Helper/TemplateFinder.php
@@ -12,6 +12,7 @@ class TemplateFinder
      */
     public static function getTemplatePath(): string
     {
-        return realpath(__DIR__) . '/../../../templates';
+        $templatePath = realpath(__DIR__);
+        return ($templatePath !== false ? $templatePath : __DIR__) . '/../../../templates';
     }
 }

--- a/zmsentities/src/Zmsentities/Ics.php
+++ b/zmsentities/src/Zmsentities/Ics.php
@@ -8,7 +8,7 @@ class Ics extends Schema\Entity
 
     public static $schema = "ics.json";
 
-    public function getContent()
+    public function getContent(): mixed
     {
         return $this->content;
     }

--- a/zmsentities/src/Zmsentities/Log.php
+++ b/zmsentities/src/Zmsentities/Log.php
@@ -91,7 +91,7 @@ class Log extends Schema\Entity
         return $display;
     }
 
-    private static function formatAppointmentAtDisplay($appointmentAt): ?string
+    private static function formatAppointmentAtDisplay(mixed $appointmentAt): ?string
     {
         if (empty($appointmentAt)) {
             return null;

--- a/zmsentities/src/Zmsentities/Mail.php
+++ b/zmsentities/src/Zmsentities/Mail.php
@@ -44,7 +44,7 @@ class Mail extends Schema\Entity
         return $this->toProperty()->process->authKey->get();
     }
 
-    public function addMultiPart($multiPart): static
+    public function addMultiPart(mixed $multiPart): static
     {
         $this->multipart = $multiPart;
         return $this;
@@ -113,7 +113,7 @@ class Mail extends Schema\Entity
         return $client;
     }
 
-    public function toCustomMessageEntity(Process $process, $collection): static
+    public function toCustomMessageEntity(Process $process, mixed $collection): static
     {
         $entity = clone $this;
         $message = '';
@@ -163,7 +163,7 @@ class Mail extends Schema\Entity
      * @return Mail
      * @throws Exception\TemplateNotFound
      */
-    public function toResolvedEntity($processList, Config $config, $status, $initiator = null)
+    public function toResolvedEntity(mixed $processList, Config $config, mixed $status, mixed $initiator = null)
     {
         $collection = (new ProcessList())->testProcessListLength(
             $processList,
@@ -239,7 +239,7 @@ class Mail extends Schema\Entity
         return $entity;
     }
 
-    public function withDepartment($department): static
+    public function withDepartment(mixed $department): static
     {
         $this->department = $department;
         return $this;
@@ -256,7 +256,7 @@ class Mail extends Schema\Entity
         return $this['client']['email'];
     }
 
-    public function setTemplateProvider($templateProvider): static
+    public function setTemplateProvider(mixed $templateProvider): static
     {
         $this->templateProvider = $templateProvider;
         return $this;

--- a/zmsentities/src/Zmsentities/Mail.php
+++ b/zmsentities/src/Zmsentities/Mail.php
@@ -191,8 +191,9 @@ class Mail extends Schema\Entity
             'base64' => false
         ));
 
+        $firstAppointment = $mainProcess ? $mainProcess->getAppointments()->getFirst() : null;
         if (
-            $mainProcess && $mainProcess->getAppointments()->getFirst()->hasTime() &&
+            $firstAppointment && $firstAppointment->hasTime() &&
             Messaging::isIcsRequired($config, $mainProcess, $status)
         ) {
             $entity->multipart[] = new Mimepart(array(

--- a/zmsentities/src/Zmsentities/Mail.php
+++ b/zmsentities/src/Zmsentities/Mail.php
@@ -34,12 +34,12 @@ class Mail extends Schema\Entity
         ];
     }
 
-    public function getProcessId()
+    public function getProcessId(): mixed
     {
         return $this->toProperty()->process->id->get();
     }
 
-    public function getProcessAuthKey()
+    public function getProcessAuthKey(): mixed
     {
         return $this->toProperty()->process->authKey->get();
     }
@@ -60,7 +60,7 @@ class Mail extends Schema\Entity
         return (null != $this->getIcsPart());
     }
 
-    public function getHtmlPart()
+    public function getHtmlPart(): mixed
     {
         $multiPart = $this->toProperty()->multipart->get();
         foreach ($multiPart as $part) {
@@ -72,7 +72,7 @@ class Mail extends Schema\Entity
         return null;
     }
 
-    public function getPlainPart()
+    public function getPlainPart(): mixed
     {
         foreach ($this->multipart as $part) {
             $mimepart = new Mimepart($part);
@@ -83,7 +83,7 @@ class Mail extends Schema\Entity
         return null;
     }
 
-    public function getIcsPart()
+    public function getIcsPart(): mixed
     {
         foreach ($this->multipart as $part) {
             $mimepart = new Mimepart($part);
@@ -103,7 +103,7 @@ class Mail extends Schema\Entity
         return $this->getFirstClient();
     }
 
-    public function getFirstClient()
+    public function getFirstClient(): \BO\Zmsentities\Client|null
     {
         $client = null;
         if ($this->toProperty()->process->isAvailable()) {
@@ -245,7 +245,7 @@ class Mail extends Schema\Entity
         return $this;
     }
 
-    public function getRecipient()
+    public function getRecipient(): mixed
     {
         if (! isset($this['client'])) {
             $this['client'] = $this->getFirstClient();

--- a/zmsentities/src/Zmsentities/Mail.php
+++ b/zmsentities/src/Zmsentities/Mail.php
@@ -193,7 +193,7 @@ class Mail extends Schema\Entity
 
         $firstAppointment = $mainProcess ? $mainProcess->getAppointments()->getFirst() : null;
         if (
-            $firstAppointment && $firstAppointment->hasTime() &&
+            $mainProcess && $firstAppointment && $firstAppointment->hasTime() &&
             Messaging::isIcsRequired($config, $mainProcess, $status)
         ) {
             $entity->multipart[] = new Mimepart(array(

--- a/zmsentities/src/Zmsentities/Mail.php
+++ b/zmsentities/src/Zmsentities/Mail.php
@@ -17,7 +17,7 @@ class Mail extends Schema\Entity
 
     public static $schema = "mail.json";
 
-    protected $templateProvider = false;
+    protected mixed $templateProvider = false;
 
     /**
      * @return (Client|Collection\MimepartList|Department|Process)[]

--- a/zmsentities/src/Zmsentities/Mailtemplate.php
+++ b/zmsentities/src/Zmsentities/Mailtemplate.php
@@ -27,7 +27,7 @@ class Mailtemplate extends Schema\Entity
         return ($this->hasType($type) && isset($this[$type][$key])) ? true : false;
     }
 
-    public function getPreference(mixed $type, mixed $key)
+    public function getPreference(mixed $type, mixed $key): mixed
     {
         return $this->toProperty()->$type->$key->get();
     }

--- a/zmsentities/src/Zmsentities/Mailtemplate.php
+++ b/zmsentities/src/Zmsentities/Mailtemplate.php
@@ -17,22 +17,22 @@ class Mailtemplate extends Schema\Entity
         ];
     }
 
-    public function hasType($type): bool
+    public function hasType(mixed $type): bool
     {
         return (isset($this[$type])) ? true : false;
     }
 
-    public function hasPreference($type, $key): bool
+    public function hasPreference(mixed $type, mixed $key): bool
     {
         return ($this->hasType($type) && isset($this[$type][$key])) ? true : false;
     }
 
-    public function getPreference($type, $key)
+    public function getPreference(mixed $type, mixed $key)
     {
         return $this->toProperty()->$type->$key->get();
     }
 
-    public function setPreference($type, $key, $value): static
+    public function setPreference(mixed $type, mixed $key, mixed $value): static
     {
         $preference = $this->toProperty()->$type->$key->get();
         if (null !== $preference) {

--- a/zmsentities/src/Zmsentities/Mimepart.php
+++ b/zmsentities/src/Zmsentities/Mimepart.php
@@ -41,7 +41,7 @@ class Mimepart extends Schema\Entity
         return ($this->mime == 'text/calendar') ? true : false;
     }
 
-    public function getContent()
+    public function getContent(): mixed
     {
         return ($this->isBase64Encoded()) ? \base64_decode($this->content) : $this->content;
     }

--- a/zmsentities/src/Zmsentities/Month.php
+++ b/zmsentities/src/Zmsentities/Month.php
@@ -53,7 +53,7 @@ class Month extends Schema\Entity
         \DateTimeInterface $currentDate,
         \BO\Zmsentities\Collection\DayList $dayList
     ): self {
-        $startDow = date('w', mktime(0, 0, 0, $currentDate->format('m'), 1, $currentDate->format('Y')));
+        $startDow = date('w', mktime(0, 0, 0, (int) $currentDate->format('m'), 1, (int) $currentDate->format('Y')));
         $monthDayList = $dayList->withAssociatedDays($currentDate);
         $month = (new self(
             array(

--- a/zmsentities/src/Zmsentities/Month.php
+++ b/zmsentities/src/Zmsentities/Month.php
@@ -6,7 +6,7 @@ class Month extends Schema\Entity
 {
     public const string PRIMARY = 'month';
 
-    public $calendarDayList;
+    public mixed $calendarDayList = null;
 
     public static $schema = "month.json";
 

--- a/zmsentities/src/Zmsentities/Month.php
+++ b/zmsentities/src/Zmsentities/Month.php
@@ -30,10 +30,12 @@ class Month extends Schema\Entity
 
     public function getDayList(): Collection\DayList
     {
-        if (!$this->days instanceof Collection\DayList) {
-            $this->days = new Collection\DayList($this->days);
+        $days = $this->days;
+        if (!$days instanceof Collection\DayList) {
+            $days = new Collection\DayList($days);
+            $this->days = $days;
         }
-        return $this->days;
+        return $days;
     }
 
     public function setDays(Collection\DayList $dayList): static

--- a/zmsentities/src/Zmsentities/Month.php
+++ b/zmsentities/src/Zmsentities/Month.php
@@ -22,7 +22,7 @@ class Month extends Schema\Entity
         ];
     }
 
-    public function getFirstDay()
+    public function getFirstDay(): \BO\Zmsentities\Helper\DateTime
     {
         $dateTime = Helper\DateTime::create($this['year'] . '-' . $this['month'] . '-1');
         return $dateTime->modify('00:00:00');

--- a/zmsentities/src/Zmsentities/Organisation.php
+++ b/zmsentities/src/Zmsentities/Organisation.php
@@ -21,7 +21,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
         ];
     }
 
-    public function hasDepartment(mixed $departmentId)
+    public function hasDepartment(mixed $departmentId): bool
     {
         return $this->getDepartmentList()->hasEntity($departmentId);
     }
@@ -37,7 +37,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
         return $this->departments;
     }
 
-    public function getPreference(mixed $index)
+    public function getPreference(mixed $index): mixed
     {
         return $this->toProperty()->preferences->$index->get();
     }
@@ -46,7 +46,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
      * @return bool
      */
     #[\Override]
-    public function hasAccess(Useraccount $useraccount)
+    public function hasAccess(Useraccount $useraccount): bool
     {
         return $useraccount->isSuperUser()
             || 0 < $this->getDepartmentList()->withAccess($useraccount)->count();

--- a/zmsentities/src/Zmsentities/Organisation.php
+++ b/zmsentities/src/Zmsentities/Organisation.php
@@ -21,7 +21,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
         ];
     }
 
-    public function hasDepartment($departmentId)
+    public function hasDepartment(mixed $departmentId)
     {
         return $this->getDepartmentList()->hasEntity($departmentId);
     }
@@ -37,7 +37,7 @@ class Organisation extends Schema\Entity implements Useraccount\AccessInterface
         return $this->departments;
     }
 
-    public function getPreference($index)
+    public function getPreference(mixed $index)
     {
         return $this->toProperty()->preferences->$index->get();
     }

--- a/zmsentities/src/Zmsentities/Owner.php
+++ b/zmsentities/src/Zmsentities/Owner.php
@@ -21,7 +21,7 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
             ];
     }
 
-    public function hasOrganisation($organisationId)
+    public function hasOrganisation(mixed $organisationId)
     {
         return $this->getOrganisationList()->hasEntity($organisationId);
     }

--- a/zmsentities/src/Zmsentities/Owner.php
+++ b/zmsentities/src/Zmsentities/Owner.php
@@ -21,7 +21,7 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
             ];
     }
 
-    public function hasOrganisation(mixed $organisationId)
+    public function hasOrganisation(mixed $organisationId): bool
     {
         return $this->getOrganisationList()->hasEntity($organisationId);
     }
@@ -42,7 +42,7 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
      * @return bool
      */
     #[\Override]
-    public function hasAccess(Useraccount $useraccount)
+    public function hasAccess(Useraccount $useraccount): bool
     {
         return $useraccount->isSuperUser()
             || 0 < $this->getOrganisationList()->withAccess($useraccount)->count();

--- a/zmsentities/src/Zmsentities/Owner.php
+++ b/zmsentities/src/Zmsentities/Owner.php
@@ -28,13 +28,15 @@ class Owner extends Schema\Entity implements Useraccount\AccessInterface
 
     public function getOrganisationList(): Collection\OrganisationList
     {
-        if (!$this->organisations instanceof Collection\OrganisationList) {
-            $this->organisations = new Collection\OrganisationList($this->organisations);
-            foreach ($this->organisations as $key => $organisation) {
-                $this->organisations[$key] = new Organisation($organisation);
+        $organisations = $this->organisations;
+        if (!$organisations instanceof Collection\OrganisationList) {
+            $organisations = new Collection\OrganisationList($organisations);
+            foreach ($organisations as $key => $organisation) {
+                $organisations[$key] = new Organisation($organisation);
             }
+            $this->organisations = $organisations;
         }
-        return $this->organisations;
+        return $organisations;
     }
 
 

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -268,15 +268,17 @@ class Process extends Schema\Entity
      */
     public function getAppointments()
     {
-        if (!$this['appointments'] instanceof Collection\AppointmentList) {
-            $this['appointments'] = new Collection\AppointmentList($this['appointments']);
-            foreach ($this['appointments'] as $index => $appointment) {
+        $appointments = $this['appointments'];
+        if (!$appointments instanceof Collection\AppointmentList) {
+            $appointments = new Collection\AppointmentList($appointments);
+            foreach ($appointments as $index => $appointment) {
                 if (!$appointment instanceof Appointment) {
-                    $this['appointments'][$index] = new Appointment($appointment);
+                    $appointments[$index] = new Appointment($appointment);
                 }
             }
+            $this['appointments'] = $appointments;
         }
-        return $this['appointments'];
+        return $appointments;
     }
 
     /**
@@ -285,15 +287,17 @@ class Process extends Schema\Entity
      */
     public function getClients()
     {
-        if (!$this['clients'] instanceof Collection\ClientList) {
-            $this['clients'] = new Collection\ClientList($this['clients']);
-            foreach ($this['clients'] as $index => $client) {
+        $clients = $this['clients'];
+        if (!$clients instanceof Collection\ClientList) {
+            $clients = new Collection\ClientList($clients);
+            foreach ($clients as $index => $client) {
                 if (!$client instanceof Client) {
-                    $this['clients'][$index] = new Client($client);
+                    $clients[$index] = new Client($client);
                 }
             }
+            $this['clients'] = $clients;
         }
-        return $this['clients'];
+        return $clients;
     }
 
     public function hasAppointment(mixed $date, mixed $scopeId): bool

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -102,17 +102,17 @@ class Process extends Schema\Entity
         return $this->requests;
     }
 
-    public function getRequestIds()
+    public function getRequestIds(): mixed
     {
         return $this->getRequests()->getIds();
     }
 
-    public function getDisplayNumber()
+    public function getDisplayNumber(): mixed
     {
         return $this->displayNumber;
     }
 
-    public function getRequestCSV()
+    public function getRequestCSV(): string
     {
         return $this->getRequests()->getIdsCsv();
     }
@@ -241,12 +241,12 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function getStatus()
+    public function getStatus(): mixed
     {
         return $this->status;
     }
 
-    public function getReminderTimestamp()
+    public function getReminderTimestamp(): mixed
     {
         $timestamp = $this->toProperty()->reminderTimestamp->get();
         return ($timestamp) ? $timestamp : 0;
@@ -295,7 +295,7 @@ class Process extends Schema\Entity
         return $this['clients'];
     }
 
-    public function hasAppointment(mixed $date, mixed $scopeId)
+    public function hasAppointment(mixed $date, mixed $scopeId): bool
     {
         return $this->getAppointments()->hasDateScope($date, $scopeId);
     }
@@ -330,7 +330,7 @@ class Process extends Schema\Entity
         return (isset($this['queue']) && isset($this['queue']['number']) && $this['queue']['number']);
     }
 
-    public function getQueueNumber()
+    public function getQueueNumber(): mixed
     {
         return $this['queue']['number'];
     }
@@ -348,7 +348,7 @@ class Process extends Schema\Entity
      * which are used for processing like to pick up documents
      *
      */
-    public function getScopeId()
+    public function getScopeId(): mixed
     {
         //as current scope - see zmsbackend Query/Process EntityMapping
         return $this->toProperty()->scope->id->get();
@@ -368,7 +368,7 @@ class Process extends Schema\Entity
         return $this->getProperty('scope');
     }
 
-    public function getAmendment()
+    public function getAmendment(): mixed
     {
         return $this->toProperty()->amendment->get();
     }
@@ -378,7 +378,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->showUpTime->get();
     }*/
 
-    public function getShowUpTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null)
+    public function getShowUpTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null): \BO\Zmsentities\Helper\DateTime
     {
         $showUpTime = $this->toProperty()->showUpTime->get();
         $showDateTime = Helper\DateTime::create($default, $timezone);
@@ -389,17 +389,17 @@ class Process extends Schema\Entity
         return $showDateTime;
     }
 
-    public function getWaitingTime()
+    public function getWaitingTime(): mixed
     {
         return $this->toProperty()->queue->waitingTime->get();
     }
 
-    public function getProcessingTime()
+    public function getProcessingTime(): mixed
     {
         return $this->toProperty()->processingTime->get();
     }
 
-    public function getFinishTime()
+    public function getFinishTime(): mixed
     {
         return $this->toProperty()->finishTime->get();
     }
@@ -412,7 +412,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function getCustomTextfield()
+    public function getCustomTextfield(): mixed
     {
         return $this->toProperty()->customTextfield->get();
     }
@@ -426,7 +426,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function getCustomTextfield2()
+    public function getCustomTextfield2(): mixed
     {
         return $this->toProperty()->customTextfield2->get();
     }
@@ -447,7 +447,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function getAuthKey()
+    public function getAuthKey(): mixed
     {
         return $this->toProperty()->authKey->get();
     }
@@ -468,12 +468,12 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function getCallTimeString()
+    public function getCallTimeString(): mixed
     {
         return $this->getCallTime()->format('H:i:s');
     }
 
-    public function getCallTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null)
+    public function getCallTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null): \BO\Zmsentities\Helper\DateTime
     {
         $callTime = $this->toProperty()->queue->callTime->get();
         $callDateTime = Helper\DateTime::create($default, $timezone);
@@ -611,7 +611,7 @@ class Process extends Schema\Entity
         return $calendar;
     }
 
-    public function toQueue(\DateTimeInterface $dateTime)
+    public function toQueue(\DateTimeInterface $dateTime): mixed
     {
         $queue = new Queue($this->queue);
         $queue->withAppointment = ($this->getFirstAppointment()->hasTime()) ? true : false;
@@ -644,7 +644,7 @@ class Process extends Schema\Entity
      * @param \DateTimeInterface|string $default
      *
      */
-    public function getArrivalTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null)
+    public function getArrivalTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null): \BO\Zmsentities\Helper\DateTime
     {
         $queueArrivalTime = $this->toProperty()->queue->arrivalTime->get();
 
@@ -674,22 +674,22 @@ class Process extends Schema\Entity
     /**
      * Calculate real waiting time, only available after called
      */
-    public function getWaitedSeconds(string|\DateTimeInterface $defaultTime = 'now')
+    public function getWaitedSeconds(string|\DateTimeInterface $defaultTime = 'now'): mixed
     {
         return $this->getCallTime($defaultTime)->getTimestamp() - $this->getArrivalTime($defaultTime)->getTimestamp();
     }
 
-    public function getWaitedMinutes(string|\DateTimeInterface $defaultTime = 'now')
+    public function getWaitedMinutes(string|\DateTimeInterface $defaultTime = 'now'): mixed
     {
         return $this->getWaitedSeconds($defaultTime) / 60;
     }
 
-    public function getWaySeconds(string|\DateTimeInterface $defaultTime = 'now')
+    public function getWaySeconds(string|\DateTimeInterface $defaultTime = 'now'): mixed
     {
         return $this->getShowUpTime($defaultTime)->getTimestamp() - $this->getCallTime($defaultTime)->getTimestamp();
     }
 
-    public function getWayMinutes(string|\DateTimeInterface $defaultTime = 'now')
+    public function getWayMinutes(string|\DateTimeInterface $defaultTime = 'now'): mixed
     {
         return $this->getWaySeconds($defaultTime) / 60;
     }
@@ -762,7 +762,7 @@ class Process extends Schema\Entity
         return $string;
     }
 
-    public function getExternalUserId()
+    public function getExternalUserId(): mixed
     {
         return $this->toProperty()->externalUserId->get();
     }
@@ -773,7 +773,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function getParkedBy()
+    public function getParkedBy(): mixed
     {
         return $this->toProperty()->parkedBy->get();
     }

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -365,7 +365,7 @@ class Process extends Schema\Entity
             return true;
         }
         $client = $this->getFirstClient();
-        return $client && isset($client->familyName) && $client->familyName === 'dereferenced';
+        return isset($client->familyName) && $client->familyName === 'dereferenced';
     }
 
     public function getCurrentScope(): Scope

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -151,7 +151,7 @@ class Process extends Schema\Entity
     {
         $this->requests = new Collection\RequestList();
         if ($requestCSV) {
-            foreach (explode(',', $requestCSV) as $id) {
+            foreach (explode(',', (string) $requestCSV) as $id) {
                 $this->requests->addEntity(new Request(array(
                             'source' => $source,
                             'id' => $id
@@ -210,7 +210,7 @@ class Process extends Schema\Entity
         $dateTime = Helper\DateTime::create($dateTime);
         if (isset($requestData['selectedtime'])) {
             $time = explode('-', $requestData['selectedtime']);
-            $dateTime = $dateTime->setTime($time[0], $time[1]);
+            $dateTime = $dateTime->setTime((int) $time[0], (int) $time[1]);
         }
 
         $appointment = (new Appointment())
@@ -720,7 +720,7 @@ class Process extends Schema\Entity
                 'Anmerkung' => null,
                 'IPTimeStamp' => $this->createTimestamp,
                 'LastChange' => $lastChange,
-            ), 1);
+            ), true);
     }
 
     public function toDerefencedCustomTextfield(): string|null
@@ -732,7 +732,7 @@ class Process extends Schema\Entity
                 'CustomTextfield' => null,
                 'IPTimeStamp' => $this->createTimestamp,
                 'LastChange' => $lastChange,
-            ), 1);
+            ), true);
     }
 
     public function toDerefencedCustomTextfield2(): string|null
@@ -744,7 +744,7 @@ class Process extends Schema\Entity
                 'CustomTextfield2' => null,
                 'IPTimeStamp' => $this->createTimestamp,
                 'LastChange' => $lastChange,
-            ), 1);
+            ), true);
     }
 
     public function __toString()

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -117,13 +117,13 @@ class Process extends Schema\Entity
         return $this->getRequests()->getIdsCsv();
     }
 
-    public function addScope($scopeId): static
+    public function addScope(mixed $scopeId): static
     {
         $this->scope = new Scope(array('id' => $scopeId));
         return $this;
     }
 
-    public function addQueue($number, \DateTimeInterface $dateTime): static
+    public function addQueue(mixed $number, \DateTimeInterface $dateTime): static
     {
         $this->queue = new Queue(array(
             'number' => $number,
@@ -133,7 +133,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addRequests($source, $requestCSV): static
+    public function addRequests(mixed $source, mixed $requestCSV): static
     {
         $requestList = $this->getRequests();
         foreach (explode(',', $requestCSV) as $id) {
@@ -147,7 +147,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function updateRequests($source, int|string $requestCSV = ''): static
+    public function updateRequests(mixed $source, int|string $requestCSV = ''): static
     {
         $this->requests = new Collection\RequestList();
         if ($requestCSV) {
@@ -186,7 +186,7 @@ class Process extends Schema\Entity
         return (bool) ((int) $this->toProperty()->scope->preferences->client->adminMailOnMailSent->get());
     }
 
-    public function withUpdatedData($requestData, \DateTimeInterface $dateTime, $scope = null, $notice = ''): static
+    public function withUpdatedData(mixed $requestData, \DateTimeInterface $dateTime, mixed $scope = null, string $notice = ''): static
     {
         $this->scope = ($scope) ? $scope : $this->scope;
         $this->addAppointmentFromRequest($requestData, $dateTime);
@@ -201,7 +201,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addAppointmentFromRequest($requestData, \DateTimeInterface $dateTime): static
+    public function addAppointmentFromRequest(mixed $requestData, \DateTimeInterface $dateTime): static
     {
         $this->appointments = null;
         if (isset($requestData['selecteddate'])) {
@@ -222,7 +222,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addClientFromForm($requestData): static
+    public function addClientFromForm(mixed $requestData): static
     {
         $client = new Client();
         foreach ($requestData as $key => $value) {
@@ -252,7 +252,7 @@ class Process extends Schema\Entity
         return ($timestamp) ? $timestamp : 0;
     }
 
-    public function addReminderTimestamp($input, \DateTimeInterface $dateTime): static
+    public function addReminderTimestamp(mixed $input, \DateTimeInterface $dateTime): static
     {
         $this->reminderTimestamp = (
             Property::__keyExists('headsUpTime', $input) &&
@@ -295,7 +295,7 @@ class Process extends Schema\Entity
         return $this['clients'];
     }
 
-    public function hasAppointment($date, $scopeId)
+    public function hasAppointment(mixed $date, mixed $scopeId)
     {
         return $this->getAppointments()->hasDateScope($date, $scopeId);
     }
@@ -318,7 +318,7 @@ class Process extends Schema\Entity
         return (isset($this['id']) && isset($this['authKey']) && $this['id'] && $this['authKey']);
     }
 
-    public function withReassignedCredentials($process): static
+    public function withReassignedCredentials(mixed $process): static
     {
         $this->id = $process->getId();
         $this->authKey = $process->getAuthKey();
@@ -378,7 +378,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->showUpTime->get();
     }*/
 
-    public function getShowUpTime($default = 'now', $timezone = null)
+    public function getShowUpTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null)
     {
         $showUpTime = $this->toProperty()->showUpTime->get();
         $showDateTime = Helper\DateTime::create($default, $timezone);
@@ -404,7 +404,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->finishTime->get();
     }
 
-    public function addAmendment($input, $notice = ''): static
+    public function addAmendment(mixed $input, string $notice = ''): static
     {
         $this->amendment = $notice;
         $this->amendment .= (isset($input['amendment']) && $input['amendment']) ? $input['amendment'] : '';
@@ -417,7 +417,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->customTextfield->get();
     }
 
-    public function addCustomTextfield($input): static
+    public function addCustomTextfield(mixed $input): static
     {
         $this->customTextfield = (
             isset($input['customTextfield']) && $input['customTextfield']
@@ -431,7 +431,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->customTextfield2->get();
     }
 
-    public function addCustomTextfield2($input): static
+    public function addCustomTextfield2(mixed $input): static
     {
         $this->customTextfield2 = (
             isset($input['customTextfield2']) && $input['customTextfield2']
@@ -440,7 +440,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function addPriority($input): static
+    public function addPriority(mixed $input): static
     {
         $this->priority = isset($input['priority']) && $input['priority'] ? $input['priority'] : null;
 
@@ -462,7 +462,7 @@ class Process extends Schema\Entity
         $this->authKey = bin2hex(random_bytes(32));
     }
 
-    public function setCallTime($dateTime = null): static
+    public function setCallTime(mixed $dateTime = null): static
     {
         $this->queue['callTime'] = ($dateTime) ? $dateTime->getTimestamp() : 0;
         return $this;
@@ -473,7 +473,7 @@ class Process extends Schema\Entity
         return $this->getCallTime()->format('H:i:s');
     }
 
-    public function getCallTime($default = 'now', $timezone = null)
+    public function getCallTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null)
     {
         $callTime = $this->toProperty()->queue->callTime->get();
         $callDateTime = Helper\DateTime::create($default, $timezone);
@@ -517,7 +517,7 @@ class Process extends Schema\Entity
         return $this;
     }
 
-    public function setClientsCount($count): static
+    public function setClientsCount(mixed $count): static
     {
         $clientList = $this->getClients();
         while ($clientList->count() < $count) {
@@ -644,7 +644,7 @@ class Process extends Schema\Entity
      * @param \DateTimeInterface|string $default
      *
      */
-    public function getArrivalTime(string|\DateTimeInterface $default = 'now', $timezone = null)
+    public function getArrivalTime(string|\DateTimeInterface $default = 'now', mixed $timezone = null)
     {
         $queueArrivalTime = $this->toProperty()->queue->arrivalTime->get();
 
@@ -674,22 +674,22 @@ class Process extends Schema\Entity
     /**
      * Calculate real waiting time, only available after called
      */
-    public function getWaitedSeconds($defaultTime = 'now')
+    public function getWaitedSeconds(string|\DateTimeInterface $defaultTime = 'now')
     {
         return $this->getCallTime($defaultTime)->getTimestamp() - $this->getArrivalTime($defaultTime)->getTimestamp();
     }
 
-    public function getWaitedMinutes($defaultTime = 'now')
+    public function getWaitedMinutes(string|\DateTimeInterface $defaultTime = 'now')
     {
         return $this->getWaitedSeconds($defaultTime) / 60;
     }
 
-    public function getWaySeconds($defaultTime = 'now')
+    public function getWaySeconds(string|\DateTimeInterface $defaultTime = 'now')
     {
         return $this->getShowUpTime($defaultTime)->getTimestamp() - $this->getCallTime($defaultTime)->getTimestamp();
     }
 
-    public function getWayMinutes($defaultTime = 'now')
+    public function getWayMinutes(string|\DateTimeInterface $defaultTime = 'now')
     {
         return $this->getWaySeconds($defaultTime) / 60;
     }
@@ -767,7 +767,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->externalUserId->get();
     }
 
-    public function setExternalUserId($externalUserId): static
+    public function setExternalUserId(mixed $externalUserId): static
     {
         $this->externalUserId = $externalUserId;
         return $this;
@@ -778,7 +778,7 @@ class Process extends Schema\Entity
         return $this->toProperty()->parkedBy->get();
     }
 
-    public function setParkedBy($name): void
+    public function setParkedBy(mixed $name): void
     {
         $this->parkedBy = $name;
     }

--- a/zmsentities/src/Zmsentities/Process.php
+++ b/zmsentities/src/Zmsentities/Process.php
@@ -77,7 +77,7 @@ class Process extends Schema\Entity
         $appointment = new Appointment();
         $appointment->addScope($scope->id);
         $appointment->addSlotCount(0);
-        $appointment->addDate($dateTime->modify('00:00:00')->getTimestamp());
+        $appointment->addDate(Helper\DateTime::create($dateTime)->modify('00:00:00')->getTimestamp());
         $process = new static();
         $process->scope = $scope;
         $process->setStatus('queued');
@@ -207,9 +207,10 @@ class Process extends Schema\Entity
         if (isset($requestData['selecteddate'])) {
             $dateTime = new \DateTime($requestData['selecteddate']);
         }
+        $dateTime = Helper\DateTime::create($dateTime);
         if (isset($requestData['selectedtime'])) {
             $time = explode('-', $requestData['selectedtime']);
-            $dateTime->setTime($time[0], $time[1]);
+            $dateTime = $dateTime->setTime($time[0], $time[1]);
         }
 
         $appointment = (new Appointment())

--- a/zmsentities/src/Zmsentities/Provider.php
+++ b/zmsentities/src/Zmsentities/Provider.php
@@ -24,7 +24,7 @@ class Provider extends Schema\Entity
     }
 
     #[\Override]
-    public function addData($mergeData): static
+    public function addData(mixed $mergeData): static
     {
         $refString = '$ref';
         if (

--- a/zmsentities/src/Zmsentities/Provider.php
+++ b/zmsentities/src/Zmsentities/Provider.php
@@ -43,7 +43,8 @@ class Provider extends Schema\Entity
         if (isset($mergeData['parent_id'])) {
             $this['parent_id'] = $mergeData['parent_id'];
         }
-        return parent::addData($mergeData);
+        parent::addData($mergeData);
+        return $this;
     }
 
     public function hasRequest(string $requestId): bool

--- a/zmsentities/src/Zmsentities/Provider.php
+++ b/zmsentities/src/Zmsentities/Provider.php
@@ -46,7 +46,7 @@ class Provider extends Schema\Entity
         return parent::addData($mergeData);
     }
 
-    public function hasRequest(string $requestId)
+    public function hasRequest(string $requestId): bool
     {
         return $this->getRequestList()->hasRequests($requestId);
     }
@@ -67,17 +67,17 @@ class Provider extends Schema\Entity
         return $requestList;
     }
 
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->toProperty()->source->get();
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return $this->toProperty()->name->get();
     }
 
-    public function getDisplayName()
+    public function getDisplayName(): mixed
     {
         return $this->toProperty()->display_name->get();
     }
@@ -88,17 +88,17 @@ class Provider extends Schema\Entity
         return new Contact($contact);
     }
 
-    public function getLink()
+    public function getLink(): mixed
     {
         return $this->toProperty()->link->get();
     }
 
-    public function getAdditionalData()
+    public function getAdditionalData(): mixed
     {
         return $this->toProperty()->data->get();
     }
 
-    public function getSlotTimeInMinutes()
+    public function getSlotTimeInMinutes(): mixed
     {
         $data = $this->getAdditionalData();
         if (! is_array($data)) {
@@ -107,7 +107,7 @@ class Provider extends Schema\Entity
         return $data['slotTimeInMinutes'] ?? null;
     }
 
-    public function getParentId()
+    public function getParentId(): mixed
     {
         return $this->toProperty()->parent_id->get();
     }

--- a/zmsentities/src/Zmsentities/Queue.php
+++ b/zmsentities/src/Zmsentities/Queue.php
@@ -8,7 +8,7 @@ class Queue extends Schema\Entity implements Helper\NoSanitize
 
     public static $schema = "queue.json";
 
-    protected $process;
+    protected ?Process $process = null;
 
     /**
      * @return (int|null)[]

--- a/zmsentities/src/Zmsentities/Queue.php
+++ b/zmsentities/src/Zmsentities/Queue.php
@@ -47,7 +47,7 @@ class Queue extends Schema\Entity implements Helper\NoSanitize
     }
 
     #[\Override]
-    public function withReference($additionalData = [])
+    public function withReference($additionalData = []): self|array
     {
         return clone $this;
     }

--- a/zmsentities/src/Zmsentities/Request.php
+++ b/zmsentities/src/Zmsentities/Request.php
@@ -30,7 +30,9 @@ class Request extends Schema\Entity
     {
         $additionalData['id'] = $this->getId();
         $additionalData['name'] = $this->getName();
-        return parent::withReference($additionalData);
+        /** @var self|array $referenced */
+        $referenced = parent::withReference($additionalData);
+        return $referenced;
     }
 
     public function hasAppointmentFromProviderData(): bool

--- a/zmsentities/src/Zmsentities/Request.php
+++ b/zmsentities/src/Zmsentities/Request.php
@@ -26,7 +26,7 @@ class Request extends Schema\Entity
     }
 
     #[\Override]
-    public function withReference($additionalData = [])
+    public function withReference($additionalData = []): self|array
     {
         $additionalData['id'] = $this->getId();
         $additionalData['name'] = $this->getName();

--- a/zmsentities/src/Zmsentities/Request.php
+++ b/zmsentities/src/Zmsentities/Request.php
@@ -48,32 +48,32 @@ class Request extends Schema\Entity
         return false;
     }
 
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->toProperty()->source->get();
     }
 
-    public function getGroup()
+    public function getGroup(): mixed
     {
         return $this->toProperty()->group->get();
     }
 
-    public function getLink()
+    public function getLink(): mixed
     {
         return $this->toProperty()->link->get();
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return $this->toProperty()->name->get();
     }
 
-    public function getAdditionalData()
+    public function getAdditionalData(): mixed
     {
         return $this->toProperty()->data->get();
     }
 
-    public function getParentId()
+    public function getParentId(): mixed
     {
         return $this->toProperty()->parent_id->get();
     }
@@ -88,7 +88,7 @@ class Request extends Schema\Entity
         return (string) $this->getId();
     }
 
-    public function getVariantId()
+    public function getVariantId(): mixed
     {
         return $this->toProperty()->variant_id->get();
     }

--- a/zmsentities/src/Zmsentities/RequestRelation.php
+++ b/zmsentities/src/Zmsentities/RequestRelation.php
@@ -23,22 +23,22 @@ class RequestRelation extends Schema\Entity
         ];
     }
 
-    public function getRequest()
+    public function getRequest(): mixed
     {
         return $this->toProperty()->request->get();
     }
 
-    public function getProvider()
+    public function getProvider(): mixed
     {
         return $this->toProperty()->provider->get();
     }
 
-    public function getSlotCount()
+    public function getSlotCount(): mixed
     {
         return $this->toProperty()->slots->get();
     }
 
-    public function getMaxQuantity()
+    public function getMaxQuantity(): mixed
     {
         return $this->toProperty()->maxQuantity->get();
     }
@@ -48,7 +48,7 @@ class RequestRelation extends Schema\Entity
         return (bool) $this->toProperty()->public->get();
     }
 
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->toProperty()->source->get();
     }

--- a/zmsentities/src/Zmsentities/Requeststatistic.php
+++ b/zmsentities/src/Zmsentities/Requeststatistic.php
@@ -50,7 +50,8 @@ class Requeststatistic extends Schema\Entity implements Helper\NoSanitize
                 ->addData($mergeData['additionalDepartmentRequests']);
         }
 
-        return parent::addData($mergeData);
+        parent::addData($mergeData);
+        return $this;
     }
 
     #[\Override]

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -23,7 +23,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     public const string PRIMARY = 'id';
 
     /**
-     * @var String $schema Filename of JSON-Schema file
+     * @var string|null $schema Filename of JSON-Schema file
      */
     public static $schema = null;
 
@@ -33,7 +33,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     public static $schemaRefPrefix = '';
 
     /**
-     * @var \ArrayObject $jsonSchema JSON-Schema definition to validate data
+     * @var \ArrayObject|null $jsonSchema JSON-Schema definition to validate data
      */
     protected $jsonSchema = null;
 
@@ -49,7 +49,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     protected static $schemaCache = [];
 
     /**
-     * @var Int $resolveLevel indicator on data integrity
+     * @var int|null $resolveLevel indicator on data integrity
      */
     protected $resolveLevel = null;
 
@@ -178,7 +178,13 @@ class Entity extends \ArrayObject implements \JsonSerializable
     {
         $class = get_called_class();
         if (!array_key_exists($class, self::$schemaCache)) {
-            self::$schemaCache[$class] = Loader::asArray($class::$schema);
+            $schemaFile = $class::$schema;
+            if (!is_string($schemaFile)) {
+                throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile(
+                    'Missing JSON-Schema file for ' . $class
+                );
+            }
+            self::$schemaCache[$class] = Loader::asArray($schemaFile);
         }
         return self::$schemaCache[$class];
     }

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -58,6 +58,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
      */
     public function __construct(mixed $input = null, int $flags = \ArrayObject::ARRAY_AS_PROPS, string $iterator_class = "ArrayIterator")
     {
+        /** @var class-string<\ArrayIterator> $iterator_class */
         parent::__construct($this->getDefaults(), $flags, $iterator_class);
         if ($input) {
             $input = $this->getUnflattenedArray($input);

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -224,7 +224,8 @@ class Entity extends \ArrayObject implements \JsonSerializable
 
     public function __toString()
     {
-        return json_encode($this->jsonSerialize(), JSON_HEX_QUOT);
+        $encoded = json_encode($this->jsonSerialize(), JSON_HEX_QUOT);
+        return $encoded !== false ? $encoded : '';
     }
 
     /**

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -72,7 +72,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $this->getArrayCopy();
     }
 
-    public function getUnflattenedArray(mixed $input)
+    public function getUnflattenedArray(mixed $input): mixed
     {
         if (!$input instanceof UnflattedArray) {
             $input = new UnflattedArray($input);
@@ -162,7 +162,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return new $class();
     }
 
-    protected static function readJsonSchema()
+    protected static function readJsonSchema(): mixed
     {
         $class = get_called_class();
         if (!array_key_exists($class, self::$schemaCache)) {
@@ -259,7 +259,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return (false !== $this->getId()) ? true : false;
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         $idName = $this::PRIMARY;
         return ($this->offsetExists($idName) && $this[$idName]) ? $this[$idName] : false;
@@ -275,12 +275,12 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return new \BO\Zmsentities\Helper\Property($this);
     }
 
-    public function hasProperty(mixed $propertyName)
+    public function hasProperty(mixed $propertyName): mixed
     {
         return $this->toProperty()->{$propertyName}->isAvailable();
     }
 
-    public function getProperty(string $propertyName, string $default = '')
+    public function getProperty(string $propertyName, string $default = ''): mixed
     {
         return $this->toProperty()->{$propertyName}->get($default);
     }

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -10,6 +10,7 @@ use BO\Zmsentities\Helper\Property;
  * @SuppressWarnings(Complexity)
  *
  * @extends \ArrayObject<array-key, mixed>
+ * @psalm-no-seal-properties
  */
 class Entity extends \ArrayObject implements \JsonSerializable
 {
@@ -206,6 +207,20 @@ class Entity extends \ArrayObject implements \JsonSerializable
     public function __toString()
     {
         return json_encode($this->jsonSerialize(), JSON_HEX_QUOT);
+    }
+
+    /**
+     * Declared so Psalm treats ARRAY_AS_PROPS reads as magic. PHP uses ArrayObject
+     * property handlers at runtime, so these methods are not invoked.
+     */
+    public function __get(string $name): mixed
+    {
+        return $this->offsetGet($name);
+    }
+
+    public function __isset(string $name): bool
+    {
+        return $this->offsetExists($name);
     }
 
     public function __clone()

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -73,6 +73,15 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $this->getArrayCopy();
     }
 
+    /**
+     * @param array-key|null $key
+     */
+    #[\Override]
+    public function offsetSet(mixed $key, mixed $value): void
+    {
+        parent::offsetSet($key, $value);
+    }
+
     public function getUnflattenedArray(mixed $input): mixed
     {
         if (!$input instanceof UnflattedArray) {

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -366,7 +366,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     }
 
     /**
-     * @return Int
+     * @return int|null
      */
     public function getResolveLevel()
     {

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -54,7 +54,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Read the json schema and let array act like an object
      */
-    public function __construct($input = null, $flags = \ArrayObject::ARRAY_AS_PROPS, $iterator_class = "ArrayIterator")
+    public function __construct(mixed $input = null, int $flags = \ArrayObject::ARRAY_AS_PROPS, string $iterator_class = "ArrayIterator")
     {
         parent::__construct($this->getDefaults(), $flags, $iterator_class);
         if ($input) {
@@ -72,7 +72,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $this->getArrayCopy();
     }
 
-    public function getUnflattenedArray($input)
+    public function getUnflattenedArray(mixed $input)
     {
         if (!$input instanceof UnflattedArray) {
             $input = new UnflattedArray($input);
@@ -112,7 +112,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
      *
      * @return bool
      */
-    public function isValid($resolveLevel = 0): bool
+    public function isValid(int $resolveLevel = 0): bool
     {
         $validator = $this->getValidator('de_DE', $resolveLevel = 0);
         return $validator->isValid();
@@ -124,7 +124,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
      * @throws \BO\Zmsentities\Exception\SchemaValidation
      * @return bool
      */
-    public function testValid($locale = 'de_DE', $resolveLevel = 0): bool
+    public function testValid(string $locale = 'de_DE', int $resolveLevel = 0): bool
     {
         $validator = $this->getValidator($locale, $resolveLevel);
         if (!$validator->isValid()) {
@@ -179,7 +179,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $entity;
     }
 
-    public function setJsonCompressLevel($jsonCompressLevel): static
+    public function setJsonCompressLevel(mixed $jsonCompressLevel): static
     {
         $this->jsonCompressLevel = $jsonCompressLevel;
         return $this;
@@ -247,7 +247,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Performs addData on a cloned entity
      */
-    public function withData($mergeData): static
+    public function withData(mixed $mergeData): static
     {
         $entity = clone $this;
         $entity->addData($mergeData);
@@ -275,12 +275,12 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return new \BO\Zmsentities\Helper\Property($this);
     }
 
-    public function hasProperty($propertyName)
+    public function hasProperty(mixed $propertyName)
     {
         return $this->toProperty()->{$propertyName}->isAvailable();
     }
 
-    public function getProperty(string $propertyName, $default = '')
+    public function getProperty(string $propertyName, string $default = '')
     {
         return $this->toProperty()->{$propertyName}->get($default);
     }
@@ -288,7 +288,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     /**
      * Change property without changing original
      */
-    public function withProperty($propertyName, $newValue): static
+    public function withProperty(mixed $propertyName, mixed $newValue): static
     {
         $entity = clone $this;
         $entity[$propertyName] = $newValue;

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -223,6 +223,16 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $this->offsetExists($name);
     }
 
+    public function __set(string $name, mixed $value): void
+    {
+        $this->offsetSet($name, $value);
+    }
+
+    public function __unset(string $name): void
+    {
+        $this->offsetUnset($name);
+    }
+
     public function __clone()
     {
         foreach ($this as $key => $property) {

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -11,6 +11,7 @@ use BO\Zmsentities\Helper\Property;
  *
  * @extends \ArrayObject<array-key, mixed>
  * @psalm-no-seal-properties
+ * @psalm-consistent-constructor
  */
 class Entity extends \ArrayObject implements \JsonSerializable
 {

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -80,6 +80,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     #[\Override]
     public function offsetSet(mixed $key, mixed $value): void
     {
+        /** @psalm-suppress PossiblyNullArgument */
         parent::offsetSet($key, $value);
     }
 
@@ -185,7 +186,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     public function getEntityName(): string
     {
         $entity = get_class($this);
-        $entity = preg_replace('#.*[\\\]#', '', $entity);
+        $entity = preg_replace('#.*[\\\]#', '', $entity) ?? '';
         $entity = strtolower($entity);
         return $entity;
     }

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -374,7 +374,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
     }
 
     /**
-     * @param Int $resolveLevel
+     * @param int|null $resolveLevel
      * @return self
      */
     public function setResolveLevel($resolveLevel)

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -269,11 +269,11 @@ class Entity extends \ArrayObject implements \JsonSerializable
         foreach ($mergeData as $key => $item) {
             if (isset($this[$key])) {
                 if ($this[$key] instanceof Entity) {
-                    $this[$key]->setResolveLevel($this->getResolveLevel() - 1);
+                    $this[$key]->setResolveLevel(($this->getResolveLevel() ?? 0) - 1);
                     $this[$key]->addData($item);
                 } elseif ($this[$key] instanceof \BO\Zmsentities\Collection\Base) {
                     $this[$key]->exchangeArray([]);
-                    $this[$key]->setResolveLevel($this->getResolveLevel() - 1);
+                    $this[$key]->setResolveLevel(($this->getResolveLevel() ?? 0) - 1);
                     $this[$key]->addData($item);
                 } elseif (is_array($this[$key])) {
                     $this[$key] = array_replace_recursive($this[$key], $item);

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -379,9 +379,9 @@ class Entity extends \ArrayObject implements \JsonSerializable
      * Set a very strict resolveLevel to reduce data
      *
      * @param Int $resolveLevel
-     * @return self
+     * @return self|array
      */
-    public function withResolveLevel($resolveLevel)
+    public function withResolveLevel($resolveLevel): self|array
     {
         if ($resolveLevel >= 0) {
             $entity = clone $this;
@@ -403,9 +403,9 @@ class Entity extends \ArrayObject implements \JsonSerializable
      * Replace data with a jsonSchema Reference
      *
      * @param Array $additionalData
-     * @return self
+     * @return self|array
      */
-    public function withReference($additionalData = [])
+    public function withReference($additionalData = []): self|array
     {
         if (isset($this[$this::PRIMARY])) {
             $additionalData['$ref'] =

--- a/zmsentities/src/Zmsentities/Schema/Entity.php
+++ b/zmsentities/src/Zmsentities/Schema/Entity.php
@@ -324,7 +324,7 @@ class Entity extends \ArrayObject implements \JsonSerializable
         return $this->toProperty()->{$propertyName}->isAvailable();
     }
 
-    public function getProperty(string $propertyName, string $default = ''): mixed
+    public function getProperty(string $propertyName, mixed $default = ''): mixed
     {
         return $this->toProperty()->{$propertyName}->get($default);
     }

--- a/zmsentities/src/Zmsentities/Schema/Factory.php
+++ b/zmsentities/src/Zmsentities/Schema/Factory.php
@@ -50,8 +50,10 @@ class Factory
             throw new \BO\Zmsentities\Exception\SchemaMissingKey('Missing $schema-key on given data.');
         }
         $schema = $this->data['$schema'];
-        $entityName = preg_replace('#^.*/([^/]+)\.json#', '$1', $schema);
-        $entityName = ucfirst($entityName ?? '');
+        $entityName = is_string($schema)
+            ? (preg_replace('#^.*/([^/]+)\.json#', '$1', $schema) ?? '')
+            : '';
+        $entityName = ucfirst($entityName);
 
         // jsonSerialize() lowercases the class short name (AvailabilityHistory →
         // availabilityhistory.json). ucfirst then yields Availabilityhistory, which

--- a/zmsentities/src/Zmsentities/Schema/Factory.php
+++ b/zmsentities/src/Zmsentities/Schema/Factory.php
@@ -32,8 +32,11 @@ class Factory
     public function getEntity()
     {
         $entityName = $this->getEntityName();
+        /** @var class-string<Entity> $class */
         $class = "\\BO\\Zmsentities\\$entityName";
-        return new $class(new UnflattedArray($this->data));
+        /** @var Entity $entity */
+        $entity = new $class(new UnflattedArray($this->data));
+        return $entity;
     }
 
     /**

--- a/zmsentities/src/Zmsentities/Schema/Factory.php
+++ b/zmsentities/src/Zmsentities/Schema/Factory.php
@@ -14,12 +14,12 @@ class Factory
      */
     protected $data = null;
 
-    public function __construct($data)
+    public function __construct(mixed $data)
     {
         $this->data = $data;
     }
 
-    public static function create($data): self
+    public static function create(mixed $data): self
     {
         return new self($data);
     }

--- a/zmsentities/src/Zmsentities/Schema/Factory.php
+++ b/zmsentities/src/Zmsentities/Schema/Factory.php
@@ -10,7 +10,7 @@ use BO\Zmsentities\Helper\Property;
 class Factory
 {
     /**
-     * @var Array $data unserialized entity
+     * @var mixed $data unserialized entity
      */
     protected $data = null;
 

--- a/zmsentities/src/Zmsentities/Schema/Loader.php
+++ b/zmsentities/src/Zmsentities/Schema/Loader.php
@@ -36,9 +36,9 @@ class Loader
     /**
      * @return false|string
      */
-    public static function asJson(string $schemaFilename): string|false
+    public static function asJson(string|false $schemaFilename): string|false
     {
-        if (!$schemaFilename) {
+        if ($schemaFilename === false || $schemaFilename === '') {
             throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile("Missing JSON-Schema file");
         }
         $schemaPath = preg_match('#^/#', $schemaFilename) ? false : self::getSchemaPath();

--- a/zmsentities/src/Zmsentities/Schema/Loader.php
+++ b/zmsentities/src/Zmsentities/Schema/Loader.php
@@ -9,6 +9,9 @@ class Loader
     public static function asArray(string $schemaFilename): Schema
     {
         $jsonString = self::asJson($schemaFilename);
+        if (!is_string($jsonString)) {
+            throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile("Missing JSON-Schema file $schemaFilename");
+        }
         $array = json_decode($jsonString, true);
         $object = json_decode($jsonString);
         if (null === $array && $jsonString) {

--- a/zmsentities/src/Zmsentities/Schema/Loader.php
+++ b/zmsentities/src/Zmsentities/Schema/Loader.php
@@ -41,7 +41,8 @@ class Loader
         if (!$schemaFilename) {
             throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile("Missing JSON-Schema file");
         }
-        $directory = preg_match('#^/#', $schemaFilename) ? '' : (self::getSchemaPath() ?: '');
+        $schemaPath = preg_match('#^/#', $schemaFilename) ? false : self::getSchemaPath();
+        $directory = $schemaPath !== false ? $schemaPath : '';
         $filename = $directory . DIRECTORY_SEPARATOR . $schemaFilename;
         return file_get_contents($filename);
     }

--- a/zmsentities/src/Zmsentities/Schema/Loader.php
+++ b/zmsentities/src/Zmsentities/Schema/Loader.php
@@ -41,7 +41,7 @@ class Loader
         if (!$schemaFilename) {
             throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile("Missing JSON-Schema file");
         }
-        $directory = preg_match('#^/#', $schemaFilename) ? '' : self::getSchemaPath();
+        $directory = preg_match('#^/#', $schemaFilename) ? '' : (self::getSchemaPath() ?: '');
         $filename = $directory . DIRECTORY_SEPARATOR . $schemaFilename;
         return file_get_contents($filename);
     }

--- a/zmsentities/src/Zmsentities/Schema/Loader.php
+++ b/zmsentities/src/Zmsentities/Schema/Loader.php
@@ -33,7 +33,7 @@ class Loader
     /**
      * @return false|string
      */
-    public static function asJson($schemaFilename): string|false
+    public static function asJson(string $schemaFilename): string|false
     {
         if (!$schemaFilename) {
             throw new \BO\Zmsentities\Exception\SchemaMissingJsonFile("Missing JSON-Schema file");

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -32,7 +32,7 @@ class Schema extends \ArrayObject
         if ($resolveLevel > 0) {
             $schema = clone $this;
             $schema = $this->resolveReferences($schema, $resolveLevel);
-            $schema->setJsonObject(json_decode(json_encode($schema->toSanitizedArray(true))));
+            $schema->setJsonObject(json_decode((string) json_encode($schema->toSanitizedArray(true))));
             return $schema;
         }
         return $this;
@@ -70,9 +70,9 @@ class Schema extends \ArrayObject
         if (null !== $this->asObject) {
             $data = $this->asObject;
         } elseif (! $keepEmpty) {
-            $data = json_decode(json_encode($this->toSanitizedArray($keepEmpty)));
+            $data = json_decode((string) json_encode($this->toSanitizedArray($keepEmpty)));
         } else {
-            $data = json_decode(json_encode($this->toSanitizedArray($keepEmpty)));
+            $data = json_decode((string) json_encode($this->toSanitizedArray($keepEmpty)));
         }
         return $data;
     }

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -105,7 +105,7 @@ class Schema extends \ArrayObject
      * Sanitize value for valid export as JSON
      *
      */
-    protected function toSanitizedValue(mixed $value, bool $keepEmpty = false, array $defaults = []): mixed
+    protected function toSanitizedValue(mixed $value, bool $keepEmpty = false, mixed $defaults = []): mixed
     {
         if ($value instanceof \BO\Zmsentities\Helper\NoSanitize) {
             return $value;
@@ -127,7 +127,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function toSanitizedList(array $value, mixed $keepEmpty, array $defaults = []): mixed
+    protected function toSanitizedList(array $value, mixed $keepEmpty, mixed $defaults = []): mixed
     {
         foreach ($value as $key => $item) {
             if ($this->jsonCompressLevel > 0 && isset($defaults[$key])) {

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -21,13 +21,13 @@ class Schema extends \ArrayObject
     /**
      * Read the json schema and let array act like an object
      */
-    public function __construct($input = [], $flags = \ArrayObject::ARRAY_AS_PROPS, $iterator_class = "ArrayIterator")
+    public function __construct(object|array $input = [], int $flags = \ArrayObject::ARRAY_AS_PROPS, string $iterator_class = "ArrayIterator")
     {
         $this->input = $input;
         parent::__construct($input, $flags, $iterator_class);
     }
 
-    public function withResolvedReferences($resolveLevel)
+    public function withResolvedReferences(mixed $resolveLevel)
     {
         if ($resolveLevel > 0) {
             $schema = clone $this;
@@ -38,7 +38,12 @@ class Schema extends \ArrayObject
         return $this;
     }
 
-    protected function resolveKey($key, $value, $resolveLevel)
+    /**
+     * @param (int|string) $key
+     *
+     * @psalm-param array-key $key
+     */
+    protected function resolveKey($key, mixed $value, mixed $resolveLevel)
     {
         if (is_array($value)) {
             $value = $this->resolveReferences($value, $resolveLevel);
@@ -48,7 +53,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function resolveReferences(array|self $hash, $resolveLevel)
+    protected function resolveReferences(array|self $hash, mixed $resolveLevel)
     {
         foreach ($hash as $key => $value) {
             $hash[$key] = $this->resolveKey($key, $value, $resolveLevel);
@@ -60,7 +65,7 @@ class Schema extends \ArrayObject
         return $hash;
     }
 
-    public function toJsonObject($keepEmpty = false)
+    public function toJsonObject(bool $keepEmpty = false)
     {
         if (null !== $this->asObject) {
             $data = $this->asObject;
@@ -78,7 +83,7 @@ class Schema extends \ArrayObject
         return $this;
     }
 
-    public function setDefaults($defaults): void
+    public function setDefaults(array $defaults): void
     {
         $this->defaults = $defaults;
     }
@@ -89,7 +94,7 @@ class Schema extends \ArrayObject
         return $this;
     }
 
-    public function toSanitizedArray($keepEmpty = false)
+    public function toSanitizedArray(bool $keepEmpty = false)
     {
         $data = $this->getArrayCopy();
         $data = $this->toSanitizedValue($data, $keepEmpty, $this->defaults);
@@ -100,7 +105,7 @@ class Schema extends \ArrayObject
      * Sanitize value for valid export as JSON
      *
      */
-    protected function toSanitizedValue(mixed $value, $keepEmpty = false, $defaults = [])
+    protected function toSanitizedValue(mixed $value, bool $keepEmpty = false, array $defaults = [])
     {
         if ($value instanceof \BO\Zmsentities\Helper\NoSanitize) {
             return $value;
@@ -122,7 +127,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function toSanitizedList(array $value, $keepEmpty, $defaults = [])
+    protected function toSanitizedList(array $value, mixed $keepEmpty, array $defaults = [])
     {
         foreach ($value as $key => $item) {
             if ($this->jsonCompressLevel > 0 && isset($defaults[$key])) {
@@ -140,7 +145,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected static function isItemEmpty($item): bool
+    protected static function isItemEmpty(mixed $item): bool
     {
         return (
             null === $item

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -24,6 +24,7 @@ class Schema extends \ArrayObject
     public function __construct(object|array $input = [], int $flags = \ArrayObject::ARRAY_AS_PROPS, string $iterator_class = "ArrayIterator")
     {
         $this->input = $input;
+        /** @var class-string<\ArrayIterator> $iterator_class */
         parent::__construct($input, $flags, $iterator_class);
     }
 

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -27,7 +27,7 @@ class Schema extends \ArrayObject
         parent::__construct($input, $flags, $iterator_class);
     }
 
-    public function withResolvedReferences(mixed $resolveLevel)
+    public function withResolvedReferences(mixed $resolveLevel): mixed
     {
         if ($resolveLevel > 0) {
             $schema = clone $this;
@@ -43,7 +43,7 @@ class Schema extends \ArrayObject
      *
      * @psalm-param array-key $key
      */
-    protected function resolveKey($key, mixed $value, mixed $resolveLevel)
+    protected function resolveKey($key, mixed $value, mixed $resolveLevel): mixed
     {
         if (is_array($value)) {
             $value = $this->resolveReferences($value, $resolveLevel);
@@ -53,7 +53,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function resolveReferences(array|self $hash, mixed $resolveLevel)
+    protected function resolveReferences(array|self $hash, mixed $resolveLevel): mixed
     {
         foreach ($hash as $key => $value) {
             $hash[$key] = $this->resolveKey($key, $value, $resolveLevel);
@@ -65,7 +65,7 @@ class Schema extends \ArrayObject
         return $hash;
     }
 
-    public function toJsonObject(bool $keepEmpty = false)
+    public function toJsonObject(bool $keepEmpty = false): mixed
     {
         if (null !== $this->asObject) {
             $data = $this->asObject;
@@ -94,7 +94,7 @@ class Schema extends \ArrayObject
         return $this;
     }
 
-    public function toSanitizedArray(bool $keepEmpty = false)
+    public function toSanitizedArray(bool $keepEmpty = false): mixed
     {
         $data = $this->getArrayCopy();
         $data = $this->toSanitizedValue($data, $keepEmpty, $this->defaults);
@@ -105,7 +105,7 @@ class Schema extends \ArrayObject
      * Sanitize value for valid export as JSON
      *
      */
-    protected function toSanitizedValue(mixed $value, bool $keepEmpty = false, array $defaults = [])
+    protected function toSanitizedValue(mixed $value, bool $keepEmpty = false, array $defaults = []): mixed
     {
         if ($value instanceof \BO\Zmsentities\Helper\NoSanitize) {
             return $value;
@@ -127,7 +127,7 @@ class Schema extends \ArrayObject
         return $value;
     }
 
-    protected function toSanitizedList(array $value, mixed $keepEmpty, array $defaults = [])
+    protected function toSanitizedList(array $value, mixed $keepEmpty, array $defaults = []): mixed
     {
         foreach ($value as $key => $item) {
             if ($this->jsonCompressLevel > 0 && isset($defaults[$key])) {
@@ -182,12 +182,12 @@ class Schema extends \ArrayObject
     }
     */
 
-    public function withoutRefs()
+    public function withoutRefs(): mixed
     {
         return $this->getWithoutRefs(clone $this);
     }
 
-    protected function getWithoutRefs(array|self $data)
+    protected function getWithoutRefs(array|self $data): mixed
     {
         foreach ($data as $key => $value) {
             if (is_array($value)) {

--- a/zmsentities/src/Zmsentities/Schema/Schema.php
+++ b/zmsentities/src/Zmsentities/Schema/Schema.php
@@ -7,11 +7,11 @@ namespace BO\Zmsentities\Schema;
  */
 class Schema extends \ArrayObject
 {
-    protected $input = null;
+    protected object|array|null $input = null;
 
-    protected $asObject = null;
+    protected ?\stdClass $asObject = null;
 
-    protected $defaults = [];
+    protected array $defaults = [];
 
     /**
      * @var Int $jsonCompressLevel

--- a/zmsentities/src/Zmsentities/Schema/UnflattedArray.php
+++ b/zmsentities/src/Zmsentities/Schema/UnflattedArray.php
@@ -6,7 +6,7 @@ class UnflattedArray
 {
     protected $value = null;
 
-    public function __construct($value)
+    public function __construct(mixed $value)
     {
         $this->value = $value;
     }

--- a/zmsentities/src/Zmsentities/Schema/UnflattedArray.php
+++ b/zmsentities/src/Zmsentities/Schema/UnflattedArray.php
@@ -11,7 +11,7 @@ class UnflattedArray
         $this->value = $value;
     }
 
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -37,8 +37,7 @@ class Validator
 
         // Load schemas only once for each process
         if (!self::$schemasLoaded) {
-            $this->loadSchemas();
-            self::$schemasLoaded = true;
+            self::$schemasLoaded = $this->loadSchemas();
         }
 
         $schemaJson = json_decode((string) json_encode($schemaObject->toJsonObject()));
@@ -46,24 +45,28 @@ class Validator
         $this->validationResult = $this->validator->validate($data, $schemaJson);
     }
 
-    private function loadSchemas(): void
+    private function loadSchemas(): bool
     {
         $schemaDir = realpath(dirname(__FILE__) . '/../../../schema');
         $schemaPath = ($schemaDir !== false ? $schemaDir : '') . '/';
         $resolver = $this->validator->resolver();
         if ($resolver === null) {
-            return;
+            return false;
         }
         $resolver->registerPrefix('schema://', $schemaPath);
         $schemaFiles = glob($schemaPath . '*.json');
+        if ($schemaFiles === false) {
+            return false;
+        }
 
         // TODO: Implement persistent caching for schema file reads to reduce redundant disk I/O and improve application performance. Not just for each process.
 
-        foreach ($schemaFiles !== false ? $schemaFiles : [] as $schemaFile) {
+        foreach ($schemaFiles as $schemaFile) {
             $schemaContent = file_get_contents($schemaFile);
             $schemaName = 'schema://' . basename($schemaFile);
             $resolver->registerRaw($schemaContent, $schemaName);
         }
+        return true;
     }
 
     public function isValid(): mixed

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -46,7 +46,8 @@ class Validator
 
     private function loadSchemas(): void
     {
-        $schemaPath = realpath(dirname(__FILE__) . '/../../../schema') . '/';
+        $schemaDir = realpath(dirname(__FILE__) . '/../../../schema');
+        $schemaPath = ($schemaDir !== false ? $schemaDir : '') . '/';
         $this->validator->resolver()->registerPrefix('schema://', $schemaPath);
         $schemaFiles = glob($schemaPath . '*.json');
 

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -27,9 +27,11 @@ class Validator
         if (self::$validatorInstance === null) {
             self::$validatorInstance = new OpisValidator();
             $formats = self::$validatorInstance->parser()->getFormatResolver();
-            $formats->registerCallable("array", "sameValues", function (array $data): bool {
-                return count($data) === 2 && $data[0] === $data[1];
-            });
+            if ($formats !== null) {
+                $formats->registerCallable("array", "sameValues", function (array $data): bool {
+                    return count($data) === 2 && $data[0] === $data[1];
+                });
+            }
         }
         $this->validator = self::$validatorInstance;
 
@@ -48,7 +50,11 @@ class Validator
     {
         $schemaDir = realpath(dirname(__FILE__) . '/../../../schema');
         $schemaPath = ($schemaDir !== false ? $schemaDir : '') . '/';
-        $this->validator->resolver()->registerPrefix('schema://', $schemaPath);
+        $resolver = $this->validator->resolver();
+        if ($resolver === null) {
+            return;
+        }
+        $resolver->registerPrefix('schema://', $schemaPath);
         $schemaFiles = glob($schemaPath . '*.json');
 
         // TODO: Implement persistent caching for schema file reads to reduce redundant disk I/O and improve application performance. Not just for each process.
@@ -56,7 +62,7 @@ class Validator
         foreach ($schemaFiles as $schemaFile) {
             $schemaContent = file_get_contents($schemaFile);
             $schemaName = 'schema://' . basename($schemaFile);
-            $this->validator->resolver()->registerRaw($schemaContent, $schemaName);
+            $resolver->registerRaw($schemaContent, $schemaName);
         }
     }
 

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -59,12 +59,12 @@ class Validator
         }
     }
 
-    public function isValid()
+    public function isValid(): mixed
     {
         return $this->validationResult->isValid();
     }
 
-    public function getErrors()
+    public function getErrors(): mixed
     {
         if ($this->validationResult->isValid()) {
             return [];
@@ -102,7 +102,7 @@ class Validator
         return $errors;
     }
 
-    public function getCustomMessage(OpisValidationError $error)
+    public function getCustomMessage(OpisValidationError $error): mixed
     {
         $schemaData = $error->schema()->info()->data();
         if (is_object($schemaData)) {
@@ -133,7 +133,7 @@ class Validator
         return $pointer;
     }
 
-    public function getTranslatedPointer(OpisValidationError $error)
+    public function getTranslatedPointer(OpisValidationError $error): mixed
     {
         $schemaData = $error->schema()->info()->data();
         if (is_object($schemaData)) {

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -17,7 +17,7 @@ class Validator
     private static $schemasLoaded = false;
     private static $validatorInstance = null;
 
-    public function __construct($data, Schema $schemaObject, $locale)
+    public function __construct(mixed $data, Schema $schemaObject, mixed $locale)
     {
         $this->schemaData = $data;
         $this->schemaObject = $schemaObject;

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -39,8 +39,8 @@ class Validator
             self::$schemasLoaded = true;
         }
 
-        $schemaJson = json_decode(json_encode($schemaObject->toJsonObject()));
-        $data = json_decode(json_encode($data));
+        $schemaJson = json_decode((string) json_encode($schemaObject->toJsonObject()));
+        $data = json_decode((string) json_encode($data));
         $this->validationResult = $this->validator->validate($data, $schemaJson);
     }
 

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -59,7 +59,7 @@ class Validator
 
         // TODO: Implement persistent caching for schema file reads to reduce redundant disk I/O and improve application performance. Not just for each process.
 
-        foreach ($schemaFiles as $schemaFile) {
+        foreach ($schemaFiles !== false ? $schemaFiles : [] as $schemaFile) {
             $schemaContent = file_get_contents($schemaFile);
             $schemaName = 'schema://' . basename($schemaFile);
             $resolver->registerRaw($schemaContent, $schemaName);

--- a/zmsentities/src/Zmsentities/Schema/Validator.php
+++ b/zmsentities/src/Zmsentities/Schema/Validator.php
@@ -8,14 +8,14 @@ use Opis\JsonSchema\Errors\ValidationError as OpisValidationError;
 
 class Validator
 {
-    protected $schemaObject;
-    protected $schemaData;
-    protected $locale;
-    protected $validator;
-    protected $validationResult;
+    protected Schema $schemaObject;
+    protected mixed $schemaData;
+    protected mixed $locale;
+    protected OpisValidator $validator;
+    protected ValidationResult $validationResult;
 
-    private static $schemasLoaded = false;
-    private static $validatorInstance = null;
+    private static bool $schemasLoaded = false;
+    private static ?OpisValidator $validatorInstance = null;
 
     public function __construct(mixed $data, Schema $schemaObject, mixed $locale)
     {

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -31,77 +31,77 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         ];
     }
 
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->toProperty()->source->get();
     }
 
-    public function getShortName()
+    public function getShortName(): mixed
     {
         return $this->toProperty()->shortName->get();
     }
 
-    public function getEmailFrom()
+    public function getEmailFrom(): mixed
     {
         return $this->getPreference('client', 'emailFrom', null);
     }
 
-    public function getEmailRequired()
+    public function getEmailRequired(): mixed
     {
         return $this->getPreference('client', 'emailRequired', null);
     }
 
-    public function getTelephoneActivated()
+    public function getTelephoneActivated(): mixed
     {
         return $this->getPreference('client', 'telephoneActivated', null);
     }
 
-    public function getTelephoneRequired()
+    public function getTelephoneRequired(): mixed
     {
         return $this->getPreference('client', 'telephoneRequired', null);
     }
 
-    public function getCustomTextfieldActivated()
+    public function getCustomTextfieldActivated(): mixed
     {
         return $this->getPreference('client', 'customTextfieldActivated', null);
     }
 
-    public function getCustomTextfieldRequired()
+    public function getCustomTextfieldRequired(): mixed
     {
         return $this->getPreference('client', 'customTextfieldRequired', null);
     }
 
-    public function getCustomTextfieldLabel()
+    public function getCustomTextfieldLabel(): mixed
     {
         return $this->getPreference('client', 'customTextfieldLabel', '');
     }
 
-    public function getCustomTextfield2Activated()
+    public function getCustomTextfield2Activated(): mixed
     {
         return $this->getPreference('client', 'customTextfield2Activated', null);
     }
 
-    public function getCustomTextfield2Required()
+    public function getCustomTextfield2Required(): mixed
     {
         return $this->getPreference('client', 'customTextfield2Required', null);
     }
 
-    public function getCustomTextfield2Label()
+    public function getCustomTextfield2Label(): mixed
     {
         return $this->getPreference('client', 'customTextfield2Label', '');
     }
 
-    public function getCaptchaActivatedRequired()
+    public function getCaptchaActivatedRequired(): mixed
     {
         return $this->getPreference('client', 'captchaActivatedRequired', null);
     }
 
-    public function getInfoForAppointment()
+    public function getInfoForAppointment(): mixed
     {
         return $this->getPreference('appointment', 'infoForAppointment', null);
     }
 
-    public function getInfoForAllAppointments()
+    public function getInfoForAllAppointments(): mixed
     {
         return $this->getPreference('appointment', 'infoForAllAppointments', null);
     }
@@ -123,7 +123,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->provider;
     }
 
-    public function getProviderId()
+    public function getProviderId(): mixed
     {
         return $this->getProvider()->id;
     }
@@ -156,7 +156,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this->closure;
     }
 
-    public function getRequestList()
+    public function getRequestList(): \BO\Zmsentities\Collection\RequestList
     {
         return $this->getProvider()->getRequestList();
     }
@@ -165,76 +165,76 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
      * @param false|null|string $isBool
      *
      */
-    public function getPreference(string $preferenceKey, string $index, string|false|null $isBool = false, mixed $default = null)
+    public function getPreference(string $preferenceKey, string $index, string|false|null $isBool = false, mixed $default = null): mixed
     {
         $preference = $this->toProperty()->preferences->$preferenceKey->$index->get($default);
         return ($isBool) ? ($preference ? 1 : 0) : $preference;
     }
 
-    public function getStatus(string $statusKey, string $index)
+    public function getStatus(string $statusKey, string $index): mixed
     {
         return $this->toProperty()->status->$statusKey->$index->get();
     }
 
-    public function getContactEmail()
+    public function getContactEmail(): mixed
     {
         return $this->toProperty()->contact->email->get();
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return $this->toProperty()->contact->name->get();
     }
 
-    public function getScopeInfo()
+    public function getScopeInfo(): mixed
     {
         return $this->toProperty()->preferences->ticketprinter->buttonName->get();
     }
 
-    public function getScopeHint()
+    public function getScopeHint(): mixed
     {
         return $this->toProperty()->hint->get();
     }
 
-    public function getDisplayNumberPrefix()
+    public function getDisplayNumberPrefix(): mixed
     {
         return $this->toProperty()->preferences->queue->displayNumberPrefix->get();
     }
 
-    public function getAlternateRedirectUrl()
+    public function getAlternateRedirectUrl(): mixed
     {
         $alternateUrl = $this->toProperty()->preferences->client->alternateAppointmentUrl->get();
 
         return ($alternateUrl) ? $alternateUrl : null;
     }
 
-    public function getAppointmentsPerMail()
+    public function getAppointmentsPerMail(): mixed
     {
         $appointmentsPerMail = $this->toProperty()->preferences->client->appointmentsPerMail->get();
 
         return ($appointmentsPerMail) ? $appointmentsPerMail : null;
     }
 
-    public function getSlotsPerAppointment()
+    public function getSlotsPerAppointment(): mixed
     {
         $slotsPerAppointment = $this->toProperty()->preferences->client->slotsPerAppointment->get();
 
         return ($slotsPerAppointment) ? $slotsPerAppointment : null;
     }
 
-    public function getWhitelistedMails()
+    public function getWhitelistedMails(): mixed
     {
         $emails = $this->toProperty()->preferences->client->whitelistedMails->get();
 
         return ($emails) ? $emails : '';
     }
 
-    public function getReservationDuration()
+    public function getReservationDuration(): mixed
     {
         return $this->toProperty()->preferences->appointment->reservationDuration->get();
     }
 
-    public function getWaitingTimeFromQueueList(Collection\QueueList $queueList, \DateTimeInterface $dateTime)
+    public function getWaitingTimeFromQueueList(Collection\QueueList $queueList, \DateTimeInterface $dateTime): mixed
     {
         return $queueList->getEstimatedWaitingTime(
             $this->getPreference('queue', 'processingTimeAverage'),
@@ -243,7 +243,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         );
     }
 
-    public function getCalculatedWorkstationCount()
+    public function getCalculatedWorkstationCount(): mixed
     {
         $workstationCount = null;
         if ($this->getStatus('queue', 'workstationCount') > 0) {
@@ -332,7 +332,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
      * @return bool
      */
     #[\Override]
-    public function hasAccess(Useraccount $useraccount)
+    public function hasAccess(Useraccount $useraccount): bool
     {
         return $useraccount->isSuperUser() ||  $useraccount->hasScope($this->id);
     }

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -174,7 +174,9 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
     public function getPreference(string $preferenceKey, string $index, string|false|null $isBool = false, mixed $default = null): mixed
     {
         $preference = $this->toProperty()->preferences->$preferenceKey->$index->get($default);
-        return ($isBool) ? ($preference ? 1 : 0) : $preference;
+        return ($isBool !== false && $isBool !== null && $isBool !== '' && $isBool !== '0')
+            ? ($preference ? 1 : 0)
+            : $preference;
     }
 
     public function getStatus(string $statusKey, string $index): mixed

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -112,15 +112,17 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         if (!isset($this->provider)) {
             throw new Exception\ScopeMissingProvider("Provider is missing", 500);
         }
-        if (!$this->provider instanceof Provider) {
-            $this->provider = new Provider($this->toProperty()->provider->get());
+        $provider = $this->provider;
+        if (!$provider instanceof Provider) {
+            $provider = new Provider($this->toProperty()->provider->get());
+            $this->provider = $provider;
         }
-        if (!isset($this->provider['id']) || !$this->provider->id) {
+        if (!isset($provider['id']) || !$provider->id) {
             $exception = new Exception\ScopeMissingProvider("No reference to a provider found for scope $this->id");
             $exception->data['scope'] = $this->getArrayCopy();
             throw $exception;
         }
-        return $this->provider;
+        return $provider;
     }
 
     public function getProviderId(): mixed
@@ -130,30 +132,34 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
 
     public function getDayoffList(): DayoffList
     {
-        if (!isset($this->dayoff) || !$this->dayoff instanceof Collection\DayoffList) {
-            $this->dayoff = (!isset($this->dayoff) || !is_array($this->dayoff)) ? [] : $this->dayoff;
-            $this->dayoff = new Collection\DayoffList($this->dayoff);
-            foreach ($this->dayoff as $key => $dayoff) {
-                if (!$dayoff instanceof Dayoff) {
-                    $this->dayoff[$key] = new Dayoff($dayoff);
+        $dayoff = $this->dayoff ?? [];
+        if (!$dayoff instanceof Collection\DayoffList) {
+            $dayoff = is_array($dayoff) ? $dayoff : [];
+            $dayoff = new Collection\DayoffList($dayoff);
+            foreach ($dayoff as $key => $entry) {
+                if (!$entry instanceof Dayoff) {
+                    $dayoff[$key] = new Dayoff($entry);
                 }
             }
+            $this->dayoff = $dayoff;
         }
-        return $this->dayoff;
+        return $dayoff;
     }
 
     public function getClosureList(): ClosureList
     {
-        if (!isset($this->closure) || !$this->closure instanceof Collection\ClosureList) {
-            $this->closure = (!isset($this->closure) || !is_array($this->closure)) ? [] : $this->closure;
-            $this->closure = new Collection\ClosureList($this->closure);
-            foreach ($this->closure as $key => $closure) {
-                if (!$closure instanceof Closure) {
-                    $this->closure[$key] = new Closure($closure);
+        $closure = $this->closure ?? [];
+        if (!$closure instanceof Collection\ClosureList) {
+            $closure = is_array($closure) ? $closure : [];
+            $closure = new Collection\ClosureList($closure);
+            foreach ($closure as $key => $entry) {
+                if (!$entry instanceof Closure) {
+                    $closure[$key] = new Closure($entry);
                 }
             }
+            $this->closure = $closure;
         }
-        return $this->closure;
+        return $closure;
     }
 
     public function getRequestList(): \BO\Zmsentities\Collection\RequestList

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -165,7 +165,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
      * @param false|null|string $isBool
      *
      */
-    public function getPreference(string $preferenceKey, string $index, string|false|null $isBool = false, $default = null)
+    public function getPreference(string $preferenceKey, string $index, string|false|null $isBool = false, mixed $default = null)
     {
         $preference = $this->toProperty()->preferences->$preferenceKey->$index->get($default);
         return ($isBool) ? ($preference ? 1 : 0) : $preference;
@@ -376,7 +376,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         return $this;
     }
 
-    public function setStatusAvailability($key, $value): static
+    public function setStatusAvailability(mixed $key, mixed $value): static
     {
         $this->status['availability'][$key] = $value;
         return $this;

--- a/zmsentities/src/Zmsentities/Scope.php
+++ b/zmsentities/src/Zmsentities/Scope.php
@@ -256,7 +256,7 @@ class Scope extends Schema\Entity implements Useraccount\AccessInterface
         $workstationCount = null;
         if ($this->getStatus('queue', 'workstationCount') > 0) {
             $workstationCount = $this->getStatus('queue', 'workstationCount');
-        } elseif (! $workstationCount && $this->getStatus('queue', 'ghostWorkstationCount') > 0) {
+        } elseif ($this->getStatus('queue', 'ghostWorkstationCount') > 0) {
             $workstationCount = $this->getStatus('queue', 'ghostWorkstationCount');
         }
         return $workstationCount;

--- a/zmsentities/src/Zmsentities/Session.php
+++ b/zmsentities/src/Zmsentities/Session.php
@@ -267,7 +267,7 @@ class Session extends Schema\Entity
      *
      * @return boolean
      */
-    public function hasDifferentEntry($newEntryData)
+    public function hasDifferentEntry(mixed $newEntryData)
     {
         return (
             ($this->getProviders() || $this->getScope()) &&

--- a/zmsentities/src/Zmsentities/Session.php
+++ b/zmsentities/src/Zmsentities/Session.php
@@ -64,47 +64,47 @@ class Session extends Schema\Entity
         ];
     }
 
-    public function getContent()
+    public function getContent(): mixed
     {
         return $this->toProperty()->content->get();
     }
 
-    public function getBasket()
+    public function getBasket(): mixed
     {
         return $this->toProperty()->content->basket->get();
     }
 
-    public function getHuman()
+    public function getHuman(): mixed
     {
         return $this->toProperty()->content->human->get();
     }
 
-    public function getRequests()
+    public function getRequests(): string
     {
         return Helper\Sorter::toSortedCsv($this->toProperty()->content->basket->requests->get());
     }
 
-    public function getProviders()
+    public function getProviders(): string
     {
         return Helper\Sorter::toSortedCsv($this->toProperty()->content->basket->providers->get());
     }
 
-    public function getProcess()
+    public function getProcess(): mixed
     {
         return $this->toProperty()->content->basket->process->get();
     }
 
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->toProperty()->content->source->get();
     }
 
-    public function getScope()
+    public function getScope(): mixed
     {
         return $this->toProperty()->content->basket->scope->get();
     }
 
-    public function getAuthKey()
+    public function getAuthKey(): mixed
     {
         return $this->toProperty()->content->basket->authKey->get();
     }
@@ -120,7 +120,7 @@ class Session extends Schema\Entity
         return (null !== $steps) ? end($steps) : $steps;
     }
 
-    public function getStatus()
+    public function getStatus(): mixed
     {
         return $this->toProperty()->content->status->get();
     }

--- a/zmsentities/src/Zmsentities/Session.php
+++ b/zmsentities/src/Zmsentities/Session.php
@@ -127,7 +127,10 @@ class Session extends Schema\Entity
 
     public function removeLastStep(): static
     {
-        unset($this->content['human']['step'][$this->getLastStep()]);
+        $lastStep = $this->getLastStep();
+        if ($lastStep !== null && $lastStep !== false) {
+            unset($this->content['human']['step'][$lastStep]);
+        }
         return $this;
     }
 

--- a/zmsentities/src/Zmsentities/Slot.php
+++ b/zmsentities/src/Zmsentities/Slot.php
@@ -61,7 +61,7 @@ class Slot extends Schema\Entity
         return ($this->toProperty()->time->get()) ? true : false;
     }
 
-    public function getTimeString()
+    public function getTimeString(): mixed
     {
         if (null === $this->toProperty()->time->get()) {
             return '0:00';

--- a/zmsentities/src/Zmsentities/Source.php
+++ b/zmsentities/src/Zmsentities/Source.php
@@ -86,7 +86,7 @@ class Source extends Schema\Entity
         return $requestList;
     }
 
-    public function hasProvider($providerIdCsv): bool
+    public function hasProvider(mixed $providerIdCsv): bool
     {
         $providerIds = explode(',', $providerIdCsv);
         foreach ($providerIds as $providerId) {
@@ -111,7 +111,7 @@ class Source extends Schema\Entity
         return $requestRelationList;
     }
 
-    public function hasRequest($requestIdCsv): bool
+    public function hasRequest(mixed $requestIdCsv): bool
     {
         $requestIds = explode(',', $requestIdCsv);
         foreach ($requestIds as $requestId) {

--- a/zmsentities/src/Zmsentities/Source.php
+++ b/zmsentities/src/Zmsentities/Source.php
@@ -29,17 +29,17 @@ class Source extends Schema\Entity
         ];
     }
 
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->toProperty()->source->get();
     }
 
-    public function getLabel()
+    public function getLabel(): mixed
     {
         return $this->toProperty()->label->get();
     }
 
-    public function getContact()
+    public function getContact(): mixed
     {
         return $this->toProperty()->contact->get();
     }

--- a/zmsentities/src/Zmsentities/Ticketprinter.php
+++ b/zmsentities/src/Zmsentities/Ticketprinter.php
@@ -38,7 +38,7 @@ class Ticketprinter extends Schema\Entity
         return $this;
     }
 
-    public function isEnabled()
+    public function isEnabled(): mixed
     {
         return $this->enabled;
     }
@@ -97,7 +97,7 @@ class Ticketprinter extends Schema\Entity
         );
     }
 
-    protected function getButtonData(string $string, array $button)
+    protected function getButtonData(string $string, array $button): mixed
     {
         $value = $this->getButtonValue($string, $this->getButtonType($string));
         if ('link' == $button['type']) {
@@ -116,7 +116,7 @@ class Ticketprinter extends Schema\Entity
         return $button;
     }
 
-    protected function getButtonValue(string $string, string $type)
+    protected function getButtonValue(string $string, string $type): mixed
     {
         $value = (in_array($type, ['l', 'r'])) ?
             Validator::value(substr($string, 1))->isString() :
@@ -129,7 +129,7 @@ class Ticketprinter extends Schema\Entity
         return substr($string, 0, 1);
     }
 
-    protected function getExternalLinkData(mixed $value, mixed $button)
+    protected function getExternalLinkData(mixed $value, mixed $button): mixed
     {
         if (preg_match("/\[([^\]]*)\]/", $value, $matches)) {
             $data = explode('|', $matches[1]);

--- a/zmsentities/src/Zmsentities/Ticketprinter.php
+++ b/zmsentities/src/Zmsentities/Ticketprinter.php
@@ -11,7 +11,7 @@ class Ticketprinter extends Schema\Entity
 
     public static $schema = "ticketprinter.json";
 
-    protected $allowedButtonTypes = [
+    protected array $allowedButtonTypes = [
         's' => 'scope',
         /*'c' => 'cluster',*/
         'l' => 'link',

--- a/zmsentities/src/Zmsentities/Ticketprinter.php
+++ b/zmsentities/src/Zmsentities/Ticketprinter.php
@@ -31,7 +31,7 @@ class Ticketprinter extends Schema\Entity
         ];
     }
 
-    public function getHashWith($organisiationId): static
+    public function getHashWith(mixed $organisiationId): static
     {
         $this->hash = $organisiationId . "abcdefghijklmnopqrstuvwxyz";
         //$this->hash = $organisiationId . bin2hex(openssl_random_pseudo_bytes(16));
@@ -97,7 +97,7 @@ class Ticketprinter extends Schema\Entity
         );
     }
 
-    protected function getButtonData(string $string, $button)
+    protected function getButtonData(string $string, array $button)
     {
         $value = $this->getButtonValue($string, $this->getButtonType($string));
         if ('link' == $button['type']) {
@@ -116,7 +116,7 @@ class Ticketprinter extends Schema\Entity
         return $button;
     }
 
-    protected function getButtonValue($string, $type)
+    protected function getButtonValue(string $string, string $type)
     {
         $value = (in_array($type, ['l', 'r'])) ?
             Validator::value(substr($string, 1))->isString() :
@@ -124,12 +124,12 @@ class Ticketprinter extends Schema\Entity
         return $value->getValue();
     }
 
-    protected function getButtonType($string): string
+    protected function getButtonType(string $string): string
     {
         return substr($string, 0, 1);
     }
 
-    protected function getExternalLinkData($value, $button)
+    protected function getExternalLinkData(mixed $value, mixed $button)
     {
         if (preg_match("/\[([^\]]*)\]/", $value, $matches)) {
             $data = explode('|', $matches[1]);

--- a/zmsentities/src/Zmsentities/Ticketprinter.php
+++ b/zmsentities/src/Zmsentities/Ticketprinter.php
@@ -104,7 +104,13 @@ class Ticketprinter extends Schema\Entity
             $button = $this->getExternalLinkData($value, $button);
         } else {
             $button['url'] = '/' . $button['type'] . '/' . $value . '/';
-            $button[$button['type']]['id'] = $value;
+            $buttonType = $button['type'];
+            $nested = [];
+            if (isset($button[$buttonType]) && is_array($button[$buttonType])) {
+                $nested = $button[$buttonType];
+            }
+            $nested['id'] = $value;
+            $button[$buttonType] = $nested;
         }
 
         if ('request' == $button['type']) {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -111,7 +111,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function getDepartment(mixed $departmentId)
+    public function getDepartment(mixed $departmentId): \BO\Zmsentities\Department
     {
         foreach ($this->getDepartmentList() as $department) {
             if ($department['id'] == $departmentId) {
@@ -121,12 +121,12 @@ class Useraccount extends Schema\Entity
         return new Department(['name' => 'Not existing']);
     }
 
-    public function hasDepartment(mixed $departmentId)
+    public function hasDepartment(mixed $departmentId): mixed
     {
         return $this->getDepartment($departmentId)->hasId();
     }
 
-    public function hasScope(mixed $scopeId)
+    public function hasScope(mixed $scopeId): mixed
     {
         return $this->getDepartmentList()->getUniqueScopeList()->hasEntity($scopeId);
     }
@@ -306,7 +306,7 @@ class Useraccount extends Schema\Entity
         return new Department();
     }
 
-    public function testDepartmentById(mixed $departmentId)
+    public function testDepartmentById(mixed $departmentId): \BO\Zmsentities\Department
     {
         $department = $this->getDepartmentById($departmentId);
         if (!$department->hasId()) {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -111,7 +111,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function getDepartment($departmentId)
+    public function getDepartment(mixed $departmentId)
     {
         foreach ($this->getDepartmentList() as $department) {
             if ($department['id'] == $departmentId) {
@@ -121,12 +121,12 @@ class Useraccount extends Schema\Entity
         return new Department(['name' => 'Not existing']);
     }
 
-    public function hasDepartment($departmentId)
+    public function hasDepartment(mixed $departmentId)
     {
         return $this->getDepartment($departmentId)->hasId();
     }
 
-    public function hasScope($scopeId)
+    public function hasScope(mixed $scopeId)
     {
         return $this->getDepartmentList()->getUniqueScopeList()->hasEntity($scopeId);
     }
@@ -286,7 +286,7 @@ class Useraccount extends Schema\Entity
         return $this->toProperty()->permissions?->superuser?->get() ?? false;
     }
 
-    public function getDepartmentById($departmentId): Department
+    public function getDepartmentById(mixed $departmentId): Department
     {
         foreach ($this->getDepartmentList() as $department) {
             if ($departmentId == $department['id']) {
@@ -306,7 +306,7 @@ class Useraccount extends Schema\Entity
         return new Department();
     }
 
-    public function testDepartmentById($departmentId)
+    public function testDepartmentById(mixed $departmentId)
     {
         $department = $this->getDepartmentById($departmentId);
         if (!$department->hasId()) {
@@ -317,7 +317,7 @@ class Useraccount extends Schema\Entity
         return $department;
     }
 
-    public function setPassword($input): static
+    public function setPassword(mixed $input): static
     {
         if (isset($input['password']) && '' != $input['password']) {
             $this->password = $input['password'];
@@ -352,7 +352,7 @@ class Useraccount extends Schema\Entity
      * @return static
      */
     #[\Override]
-    public function withCleanedUpFormData($keepPassword = false)
+    public function withCleanedUpFormData(bool $keepPassword = false)
     {
         unset($this['save']);
         if (isset($this['password']) && '' == $this['password'] && false === $keepPassword) {
@@ -377,7 +377,7 @@ class Useraccount extends Schema\Entity
      *
      * @return array $useraccount
     */
-    public function setVerifiedHash($password)
+    public function setVerifiedHash(mixed $password)
     {
         // Do you have old, turbo-legacy, non-crypt hashes?
         if (strpos($this->password, '$') !== 0) {
@@ -394,7 +394,7 @@ class Useraccount extends Schema\Entity
         return $this;
     }
 
-    public function withVerifiedHash($password): static
+    public function withVerifiedHash(mixed $password): static
     {
         $useraccount = clone $this;
         if ($useraccount->isPasswordNeedingRehash()) {
@@ -435,7 +435,7 @@ class Useraccount extends Schema\Entity
      *
      * @return string $entity
     */
-    public function createFromOpenidData($data)
+    public function createFromOpenidData(mixed $data)
     {
         $entity = new self();
         $entity->id = $data['username'];

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -69,7 +69,8 @@ class Useraccount extends Schema\Entity
         if ($hasDepartments && !($this['departments'] ?? null) instanceof Collection\DepartmentList) {
             $this->departments = new Collection\DepartmentList();
         }
-        return parent::addData($mergeData);
+        parent::addData($mergeData);
+        return $this;
     }
 
     /**

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -63,7 +63,7 @@ class Useraccount extends Schema\Entity
         $hasDepartments = false;
         if (is_array($mergeData) || $mergeData instanceof \ArrayAccess) {
             $hasDepartments = isset($mergeData['departments']);
-        } elseif (is_object($mergeData)) {
+        } else {
             $hasDepartments = isset($mergeData->departments);
         }
         if ($hasDepartments && !($this['departments'] ?? null) instanceof Collection\DepartmentList) {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -445,7 +445,7 @@ class Useraccount extends Schema\Entity
     /**
      * create useraccount from open id input data with random password
      *
-     * @return string $entity
+     * @return self
     */
     public function createFromOpenidData(mixed $data)
     {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -91,13 +91,15 @@ class Useraccount extends Schema\Entity
         if (!isset($this['departments'])) {
             return new Collection\DepartmentList();
         }
-        if (!$this->departments instanceof Collection\DepartmentList) {
-            $this->departments = new Collection\DepartmentList($this->departments);
-            foreach ($this->departments as $key => $department) {
-                $this->departments[$key] = new Department($department);
+        $departments = $this->departments;
+        if (!$departments instanceof Collection\DepartmentList) {
+            $departments = new Collection\DepartmentList($departments);
+            foreach ($departments as $key => $department) {
+                $departments[$key] = new Department($department);
             }
+            $this->departments = $departments;
         }
-        return $this->departments;
+        return $departments;
     }
 
     public function addDepartment(Department|array $department): static
@@ -375,9 +377,9 @@ class Useraccount extends Schema\Entity
     /**
      * verify hashed password and create new if needs rehash
      *
-     * @return array $useraccount
+     * @return static $useraccount
     */
-    public function setVerifiedHash(mixed $password)
+    public function setVerifiedHash(mixed $password): static
     {
         // Do you have old, turbo-legacy, non-crypt hashes?
         if (strpos($this->password, '$') !== 0) {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -461,7 +461,7 @@ class Useraccount extends Schema\Entity
     /**
      * get oidc provider from $entity id if it exists
      *
-     * @return string $entity
+     * @return string|null $entity
     */
     public function getOidcProviderFromName()
     {

--- a/zmsentities/src/Zmsentities/Useraccount.php
+++ b/zmsentities/src/Zmsentities/Useraccount.php
@@ -164,7 +164,8 @@ class Useraccount extends Schema\Entity
                 continue;
             }
 
-            if (! ($permissions?->$required?->get() ?? false)) {
+            $granted = $permissions?->$required?->get() ?? false;
+            if ($granted === false || $granted === null || $granted === 0 || $granted === '0' || $granted === '') {
                 return false;
             }
         }
@@ -191,7 +192,8 @@ class Useraccount extends Schema\Entity
                 continue;
             }
 
-            if ($permissions?->$required?->get() ?? false) {
+            $granted = $permissions?->$required?->get() ?? false;
+            if ($granted !== false && $granted !== null && $granted !== 0 && $granted !== '0' && $granted !== '') {
                 return true;
             }
         }
@@ -210,7 +212,14 @@ class Useraccount extends Schema\Entity
 
         $permissions = $this['permissions'] ?? [];
         $requiredPermission = $permissions[$permission] ?? false;
-        if (!is_array($permissions) || !$requiredPermission || '0' === $requiredPermission) {
+        if (
+            !is_array($permissions)
+            || $requiredPermission === false
+            || $requiredPermission === null
+            || $requiredPermission === 0
+            || $requiredPermission === '0'
+            || $requiredPermission === ''
+        ) {
             return false;
         }
 

--- a/zmsentities/src/Zmsentities/Useraccount/AccessInterface.php
+++ b/zmsentities/src/Zmsentities/Useraccount/AccessInterface.php
@@ -4,5 +4,5 @@ namespace BO\Zmsentities\Useraccount;
 
 interface AccessInterface
 {
-    public function hasAccess(\BO\Zmsentities\Useraccount $useraccount);
+    public function hasAccess(\BO\Zmsentities\Useraccount $useraccount): bool;
 }

--- a/zmsentities/src/Zmsentities/Useraccount/AccessInterface.php
+++ b/zmsentities/src/Zmsentities/Useraccount/AccessInterface.php
@@ -5,4 +5,8 @@ namespace BO\Zmsentities\Useraccount;
 interface AccessInterface
 {
     public function hasAccess(\BO\Zmsentities\Useraccount $useraccount): bool;
+
+    public function getEntityName(): string;
+
+    public function getId(): mixed;
 }

--- a/zmsentities/src/Zmsentities/Useraccount/EntityAccess.php
+++ b/zmsentities/src/Zmsentities/Useraccount/EntityAccess.php
@@ -12,7 +12,7 @@ class EntityAccess implements RightsInterface
     }
 
     #[\Override]
-    public function validateUseraccount(\BO\Zmsentities\Useraccount $useraccount)
+    public function validateUseraccount(\BO\Zmsentities\Useraccount $useraccount): bool
     {
         return $this->entity->hasAccess($useraccount);
     }

--- a/zmsentities/src/Zmsentities/Useraccount/RightsInterface.php
+++ b/zmsentities/src/Zmsentities/Useraccount/RightsInterface.php
@@ -4,5 +4,5 @@ namespace BO\Zmsentities\Useraccount;
 
 interface RightsInterface
 {
-    public function validateUseraccount(\BO\Zmsentities\Useraccount $useraccount);
+    public function validateUseraccount(\BO\Zmsentities\Useraccount $useraccount): bool;
 }

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -49,7 +49,7 @@ class ProcessValidator
         if ($length) {
             $valid->isGreaterThan(100000, "Eine Vorgangsnummer besteht aus mindestens 6 Ziffern");
             $valid->isLowerEqualThan(99999999999, "Eine Vorgangsnummer besteht aus maximal 11 Ziffern");
-        } elseif (!$length && $isRequiredCallback && $isRequiredCallback()) {
+        } elseif (!$length && $isRequiredCallback !== null && $isRequiredCallback()) {
             $valid->isRequired("Eine Vorgangsnummer wird benötigt.");
         }
         $this->getCollection()->validatedAction($valid, $setter);
@@ -61,14 +61,14 @@ class ProcessValidator
         $trimmed = trim((string) $unvalid->getUnvalidated());
         $valid = (new Unvalidated($trimmed, $unvalid->getName()))->isString();
         $length = strlen($trimmed);
-        if ($length || ($isRequiredCallback && $isRequiredCallback())) {
+        if ($length || ($isRequiredCallback !== null && $isRequiredCallback())) {
             if ($length) {
                 $valid
                 ->isMatchOf(
                     '/^(?:[a-f0-9]{4}|[a-f0-9]{64})$/i',
                     "Der Absagecode ist nicht korrekt"
                 );
-            } elseif ($isRequiredCallback && $isRequiredCallback()) {
+            } elseif ($isRequiredCallback !== null && $isRequiredCallback()) {
                 $valid->isRequired("Ein Absagecode wird benötigt");
             }
             $this->getCollection()->validatedAction($valid, $setter);
@@ -87,7 +87,7 @@ class ProcessValidator
                 6,
                 "Für den Standort muss eine gültige E-Mail Adresse eingetragen werden"
             );
-        } elseif (!$length && $isRequiredCallback && $isRequiredCallback()) {
+        } elseif (!$length && $isRequiredCallback !== null && $isRequiredCallback()) {
             $valid->isBiggerThan(
                 6,
                 "Für den Email-Versand muss eine gültige E-Mail Adresse angegeben werden"

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -151,7 +151,7 @@ class ProcessValidator
         try {
             $phoneNumberUtil = \libphonenumber\PhoneNumberUtil::getInstance();
             $phoneNumberObject = $phoneNumberUtil->parse($valid->getValue(), 'DE');
-            $telephone = '+' . $phoneNumberObject->getCountryCode() . $phoneNumberObject->getNationalNumber();
+            $telephone = '+' . (string) $phoneNumberObject->getCountryCode() . (string) $phoneNumberObject->getNationalNumber();
         } catch (\Exception $exception) {
             $telephone = $valid->getValue();
         }

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -68,7 +68,7 @@ class ProcessValidator
                     '/^(?:[a-f0-9]{4}|[a-f0-9]{64})$/i',
                     "Der Absagecode ist nicht korrekt"
                 );
-            } elseif ($isRequiredCallback !== null && $isRequiredCallback()) {
+            } else {
                 $valid->isRequired("Ein Absagecode wird benötigt");
             }
             $this->getCollection()->validatedAction($valid, $setter);

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -137,7 +137,7 @@ class ProcessValidator
                 ' Zeichen'
             );
         }
-        $this->getCollection()->validatedAction($valid, function ($raw) use ($setter) {
+        $this->getCollection()->validatedAction($valid, function (mixed $raw) use ($setter) {
             $setter(ProcessPlainText::normalize($raw));
         });
         return $this;

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -74,6 +74,7 @@ class ProcessValidator
             $this->getCollection()->validatedAction($valid, $setter);
             return $this;
         }
+        return $this;
     }
 
     public function validateMail(Unvalidated $unvalid, callable $setter, callable $isRequiredCallback = null): self

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -49,7 +49,7 @@ class ProcessValidator
         if ($length) {
             $valid->isGreaterThan(100000, "Eine Vorgangsnummer besteht aus mindestens 6 Ziffern");
             $valid->isLowerEqualThan(99999999999, "Eine Vorgangsnummer besteht aus maximal 11 Ziffern");
-        } elseif (!$length && $isRequiredCallback !== null && $isRequiredCallback()) {
+        } elseif ($isRequiredCallback !== null && $isRequiredCallback()) {
             $valid->isRequired("Eine Vorgangsnummer wird benötigt.");
         }
         $this->getCollection()->validatedAction($valid, $setter);

--- a/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
+++ b/zmsentities/src/Zmsentities/Validator/ProcessValidator.php
@@ -13,9 +13,9 @@ use BO\Zmsentities\Process;
  */
 class ProcessValidator
 {
-    protected $process;
+    protected Process $process;
 
-    protected $collection = [];
+    protected Collection $collection;
 
     public function __construct(Process $process)
     {

--- a/zmsentities/src/Zmsentities/Workstation.php
+++ b/zmsentities/src/Zmsentities/Workstation.php
@@ -173,7 +173,7 @@ class Workstation extends Schema\Entity
             $exception = new Exception\WorkstationProcessMatchScopeFailed();
             $scopeContactName = null;
             $currentScope = $process->getCurrentScope();
-            if ($currentScope && isset($currentScope['contact']['name'])) {
+            if ($currentScope instanceof Scope && isset($currentScope['contact']['name'])) {
                 $scopeContactName = $currentScope['contact']['name'];
             }
 

--- a/zmsentities/src/Zmsentities/Workstation.php
+++ b/zmsentities/src/Zmsentities/Workstation.php
@@ -36,7 +36,7 @@ class Workstation extends Schema\Entity
         ];
     }
 
-    public function getQueuePreference(mixed $key, bool $isBoolean = false)
+    public function getQueuePreference(mixed $key, bool $isBoolean = false): mixed
     {
         $result = null;
         if (isset($this['queue']) && Property::__keyExists($key, $this['queue'])) {
@@ -57,7 +57,7 @@ class Workstation extends Schema\Entity
         return $this->useraccount;
     }
 
-    public function getDepartmentById(mixed $departmentId)
+    public function getDepartmentById(mixed $departmentId): \BO\Zmsentities\Department
     {
         return $this->getUseraccount()->getDepartmentById($departmentId);
     }
@@ -81,17 +81,17 @@ class Workstation extends Schema\Entity
         }
     }
 
-    public function getProviderOfGivenScope()
+    public function getProviderOfGivenScope(): mixed
     {
         return $this->toProperty()->scope->provider->id->get();
     }
 
-    public function hasSuperUseraccount()
+    public function hasSuperUseraccount(): bool
     {
         return $this->getUseraccount()->isSuperUser();
     }
 
-    public function hasAuditAccount()
+    public function hasAuditAccount(): bool
     {
         return $this->getUseraccount()->hasPermissions(['logs']);
     }
@@ -111,7 +111,7 @@ class Workstation extends Schema\Entity
         return (! trim($this->name)) ? 'counter' : 'workstation';
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return ($this->name) ? $this->name : "Tresen";
     }

--- a/zmsentities/src/Zmsentities/Workstation.php
+++ b/zmsentities/src/Zmsentities/Workstation.php
@@ -36,7 +36,7 @@ class Workstation extends Schema\Entity
         ];
     }
 
-    public function getQueuePreference($key, $isBoolean = false)
+    public function getQueuePreference(mixed $key, bool $isBoolean = false)
     {
         $result = null;
         if (isset($this['queue']) && Property::__keyExists($key, $this['queue'])) {
@@ -57,7 +57,7 @@ class Workstation extends Schema\Entity
         return $this->useraccount;
     }
 
-    public function getDepartmentById($departmentId)
+    public function getDepartmentById(mixed $departmentId)
     {
         return $this->getUseraccount()->getDepartmentById($departmentId);
     }
@@ -136,7 +136,7 @@ class Workstation extends Schema\Entity
         return $process;
     }
 
-    public function getScopeList($cluster = null): Collection\ScopeList
+    public function getScopeList(mixed $cluster = null): Collection\ScopeList
     {
         $scopeList = new Collection\ScopeList();
         $scopeList->addEntity(new Scope($this->getScope()));
@@ -164,7 +164,7 @@ class Workstation extends Schema\Entity
     /**
      * @return void
      */
-    public function validateProcessScopeAccess($scopeList, $process = null)
+    public function validateProcessScopeAccess(mixed $scopeList, mixed $process = null)
     {
         if (null === $process) {
             $process = $this->process;
@@ -236,7 +236,7 @@ class Workstation extends Schema\Entity
         return $this->queue['clusterEnabled'] ? true : false;
     }
 
-    public function hasAccessToUseraccount($useraccount): bool
+    public function hasAccessToUseraccount(mixed $useraccount): bool
     {
         $departmentList = $this->getDepartmentList();
         $accessedList = $departmentList->withAccess($useraccount);

--- a/zmsentities/src/Zmsentities/Workstation.php
+++ b/zmsentities/src/Zmsentities/Workstation.php
@@ -154,7 +154,7 @@ class Workstation extends Schema\Entity
             $scopeList->addList($department->getScopeList());
         }
         foreach ($this->getScopeList() as $scope) {
-            if (! $scopeList->hasEntity($scope->id) && $scope instanceof Scope) {
+            if (! $scopeList->hasEntity($scope->id)) {
                 $scopeList->addEntity($scope);
             }
         }

--- a/zmsentities/tests/Zmsentities/AppointmentTest.php
+++ b/zmsentities/tests/Zmsentities/AppointmentTest.php
@@ -27,6 +27,7 @@ class AppointmentTest extends EntityCommonTests
         $this->assertTrue('12:00 Uhr' == $entity->toTime(), 'German time does not match.');
         $this->assertTrue('12:00 o\'clock' == $entity->toTime('en'), 'English time does not match.');
         $entity->setDateByString('2016-05-27 11:50');
+        $this->assertSame('1464342600', $entity->date);
         $this->assertTrue('Freitag 27. Mai 2016' == $entity->toDate(), 'German date does not match.');
         $this->assertTrue('Friday May 27, 2016' == $entity->toDate('en'), 'English date does not match.');
         $this->assertTrue('11:50 Uhr' == $entity->toTime(), 'German time does not match.');

--- a/zmsentities/tests/Zmsentities/AppointmentTest.php
+++ b/zmsentities/tests/Zmsentities/AppointmentTest.php
@@ -87,6 +87,15 @@ class AppointmentTest extends EntityCommonTests
         $this->assertFalse($collection->hasAppointment($entity2));
     }
 
+    public function testGetByDateNormalizesArray()
+    {
+        $entity = (new $this->entityclass())->getExample();
+        $collection = new $this->collectionclass([$entity->getArrayCopy()]);
+        $item = $collection->getByDate($entity['date']);
+        $this->assertInstanceOf($this->entityclass, $item);
+        $this->assertTrue($collection->hasDateScope($entity['date'], $entity->toProperty()->scope->id->get()));
+    }
+
     public function testHasTime()
     {
         $entity = (new $this->entityclass())->getExample();

--- a/zmsentities/tests/Zmsentities/CalldisplayTest.php
+++ b/zmsentities/tests/Zmsentities/CalldisplayTest.php
@@ -47,6 +47,24 @@ class CalldisplayTest extends EntityCommonTests
         $this->assertEquals(1, $entity->getClusterList()->count());
     }
 
+    public function testEmptyCsvListsAreIgnored()
+    {
+        $entity = (new $this->entityclass())->getExample();
+        $resolvedEntity = $entity->withResolvedCollections(array(
+            'scopelist' => '',
+            'clusterlist' => '',
+        ));
+        $this->assertFalse($resolvedEntity->hasScopeList());
+        $this->assertFalse($resolvedEntity->hasClusterList());
+
+        $resolvedEntity = $entity->withResolvedCollections(array(
+            'scopelist' => '141,,142',
+            'clusterlist' => ',110,',
+        ));
+        $this->assertEquals(2, $resolvedEntity->getScopeList()->count());
+        $this->assertEquals(1, $resolvedEntity->getClusterList()->count());
+    }
+
     public function testGetImageName()
     {
         $entity = (new $this->entityclass())->getExample();

--- a/zmsentities/tests/Zmsentities/ClusterTest.php
+++ b/zmsentities/tests/Zmsentities/ClusterTest.php
@@ -56,6 +56,15 @@ class ClusterTest extends EntityCommonTests
         $this->assertEquals('A-Test Name', $collection->getFirst()->scopes->getFirst()->provider['name']);
     }
 
+    public function testWithUniqueClustersSkipsNullEntries()
+    {
+        $entity = $this->getExample();
+        $collection = new $this->collectionclass([null, $entity, $entity]);
+        $uniqueCollection = $collection->withUniqueClusters();
+        $this->assertEquals(1, $uniqueCollection->count());
+        $this->assertEquals($entity->id, $uniqueCollection->getFirst()->id);
+    }
+
     public function testCollectionAddEntityFailed()
     {
         $this->expectException('\Exception');

--- a/zmsentities/tests/Zmsentities/ContactTest.php
+++ b/zmsentities/tests/Zmsentities/ContactTest.php
@@ -12,5 +12,6 @@ class ContactTest extends EntityCommonTests
         $this->assertTrue($entity->hasProperty('city'));
         $this->assertEquals('Schönefeld', $entity->getProperty('city'));
         $this->assertEquals('no value', $entity->getProperty('test', 'no value'));
+        $this->assertSame(0, $entity->getProperty('missingNumeric', 0));
     }
 }

--- a/zmsentities/tests/Zmsentities/DayoffTest.php
+++ b/zmsentities/tests/Zmsentities/DayoffTest.php
@@ -33,6 +33,12 @@ class DayoffTest extends EntityCommonTests
             'Dayoff list should not have entity with date 2015-11-20'
         );
 
+        $existing = $collection->getFirst();
+        $this->assertTrue(
+            $collection->hasEntityByDate($existing->getDateTime()),
+            'Dayoff list should accept DateTimeInterface dates'
+        );
+
         $collection->sortByName();
         $this->assertTrue('Christi Himmelfahrt' == $collection->getIterator()->current()->name, 'Dayoff list sort by name failed');
         $collection->sortByCustomKey('date');

--- a/zmsentities/tests/Zmsentities/ExchangeTest.php
+++ b/zmsentities/tests/Zmsentities/ExchangeTest.php
@@ -214,6 +214,24 @@ class ExchangeTest extends EntityCommonTests
         $this->assertEquals(1, count($entity->data));
     }
 
+    public function testAddDataSetWithGenerator()
+    {
+        $now = new \DateTimeImmutable('2016-04-01 11:55:00');
+        $entity = (new $this->entityclass());
+        $entity->setPeriod($now, $now);
+        $entity->addDictionaryEntry('id', 'number');
+        $entity->addDictionaryEntry('date', 'date');
+        $entity->addDictionaryEntry('name', 'string', 'Naming');
+        $values = (function () {
+            yield 1;
+            yield '2016-04-01';
+            yield 'Test';
+        })();
+        $entity->addDataSet($values);
+        $this->assertEquals([1, '2016-04-01', 'Test'], $entity->data[0]);
+        $this->assertEquals('totals', $entity->withCalculatedTotals(['id'])->getCalculatedTotals()[2]);
+    }
+
     public function testDataFormat()
     {
         $this->expectException('\Exception');

--- a/zmsentities/tests/Zmsentities/ExchangeTest.php
+++ b/zmsentities/tests/Zmsentities/ExchangeTest.php
@@ -232,6 +232,24 @@ class ExchangeTest extends EntityCommonTests
         $this->assertEquals('totals', $entity->withCalculatedTotals(['id'])->getCalculatedTotals()[2]);
     }
 
+    public function testAddDataSetWithGeneratorReindexesKeys()
+    {
+        $now = new \DateTimeImmutable('2016-04-01 11:55:00');
+        $entity = (new $this->entityclass());
+        $entity->setPeriod($now, $now);
+        $entity->addDictionaryEntry('id', 'number');
+        $entity->addDictionaryEntry('date', 'date');
+        $entity->addDictionaryEntry('name', 'string', 'Naming');
+        $values = (function () {
+            yield 5 => 1;
+            yield 5 => '2016-04-01';
+            yield 9 => 'Test';
+        })();
+        $entity->addDataSet($values);
+        $this->assertSame([0, 1, 2], array_keys($entity->data[0]));
+        $this->assertEquals([1, '2016-04-01', 'Test'], $entity->data[0]);
+    }
+
     public function testDataFormat()
     {
         $this->expectException('\Exception');

--- a/zmsentities/tests/Zmsentities/ProviderTest.php
+++ b/zmsentities/tests/Zmsentities/ProviderTest.php
@@ -71,6 +71,9 @@ class ProviderTest extends EntityCommonTests
         $this->assertEquals(2, $collection->count());
         $uniqueCollection = $collection->withUniqueProvider();
         $this->assertEquals(1, $uniqueCollection->count());
+
+        $collectionWithNull = new $this->collectionclass([null, $entity, $entity]);
+        $this->assertEquals(1, $collectionWithNull->withUniqueProvider()->count());
     }
 
     public function testSource()

--- a/zmsentities/tests/Zmsentities/QueueListTest.php
+++ b/zmsentities/tests/Zmsentities/QueueListTest.php
@@ -71,6 +71,14 @@ class QueueListTest extends EntityCommonTests
         $collection->withEstimatedWaitingTime(0, 1, $now);
     }
 
+    public function testWithEstimatedWaitingTimeAllowsNullWorkstationCount(): void
+    {
+        $now = new \DateTimeImmutable(self::DEFAULT_TIME);
+        $collection = new $this->collectionclass();
+        $withWaitingTime = $collection->withEstimatedWaitingTime(10, null, $now);
+        $this->assertGreaterThan(0, $withWaitingTime->count());
+    }
+
     public function testGetNextProcess()
     {
         $now = new \DateTimeImmutable(self::DEFAULT_TIME);

--- a/zmsentities/tests/Zmsentities/SchemaTest.php
+++ b/zmsentities/tests/Zmsentities/SchemaTest.php
@@ -52,6 +52,15 @@ class SchemaTest extends Base
         $this->assertTrue($jsonSerialize == $entity->jsonSerialize(), "Schema Helper jsonSerialize does not match");
     }
 
+    public function testJsonSerializeWithCompressLevelAndScalarDefaults()
+    {
+        $entity = new \BO\Zmsentities\Workstation();
+        $entity->setJsonCompressLevel(1);
+        $encoded = json_encode($entity);
+        $this->assertNotFalse($encoded);
+        $this->assertStringContainsString('$schema', $encoded);
+    }
+
     public function testResolveLevel()
     {
         $entity = new \BO\Zmsentities\Process([


### PR DESCRIPTION
## Summary
- Add missing param/return types and ArrayObject magic methods in zmsentities, one Psalm issue type per commit.
- Keep runtime types wide where callers pass scalars, timestamps, or objects (Schema sanitizer nested defaults, Messaging template provider).
- Further Psalm types will land on this branch as follow-up commits.

## Test plan
- [ ] zmsentities PHPUnit (`php vendor/bin/phpunit --no-coverage`)
- [ ] Workstation queue table loads without `Schema::toSanitizedValue` TypeError
- [ ] Psalm `zmsentities` notes drop as each issue-type commit lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved consistency and reliability across appointment, calendar, availability, queue, messaging, and schema workflows.
  * Enhanced date and time handling, including timezone-aware processing and broader date input support.
  * Expanded support for collections, access checks, and data conversion.

* **Bug Fixes**
  * Improved handling of missing, empty, null, or unexpected values in scheduling, messaging, templates, and schema processing.
  * Prevented invalid entries from affecting scope, cluster, provider, and appointment results.
  * Added safer fallbacks for queue estimates and template resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->