### PR TITLE
fix(ZMS): clear zmsmessaging Psalm notes by issue type

### DIFF
--- a/zmsmessaging/bootstrap.php
+++ b/zmsmessaging/bootstrap.php
@@ -14,9 +14,11 @@ if (file_exists(APP_PATH . '/vendor/autoload.php')) {
     define('VENDOR_PATH', APP_PATH . '/../..');
 }
 }
+/** @psalm-suppress UnresolvableInclude */
 require_once(VENDOR_PATH . '/autoload.php');
 
 // initialize the static \App singleton
+/** @psalm-suppress UnresolvableInclude */
 require(APP_PATH . '/config.php');
 
 \BO\Slim\Bootstrap::ensureLogger();

--- a/zmsmessaging/config.example.php
+++ b/zmsmessaging/config.example.php
@@ -1,15 +1,33 @@
 <?php
 // @codingStandardsIgnoreFile
 
-define('ZMS_API_URL', getenv('ZMS_API_URL') ? getenv('ZMS_API_URL') : 'https://localhost/terminvereinbarung/api/2');
+define(
+    'ZMS_API_URL',
+    (($value = getenv('ZMS_API_URL')) !== false && $value !== '')
+        ? $value
+        : 'https://localhost/terminvereinbarung/api/2'
+);
 
-define('ZMS_API_PASSWORD_MESSAGING', getenv('ZMS_API_PASSWORD_MESSAGING')
-    ? getenv('ZMS_API_PASSWORD_MESSAGING')
-    : 'examplepassword');
+define(
+    'ZMS_API_PASSWORD_MESSAGING',
+    (($value = getenv('ZMS_API_PASSWORD_MESSAGING')) !== false && $value !== '')
+        ? $value
+        : 'examplepassword'
+);
 
-define('ZMS_API_PROXY', getenv('ZMS_API_PROXY') ? getenv('ZMS_API_PROXY') : NULL);
+define(
+    'ZMS_API_PROXY',
+    (($value = getenv('ZMS_API_PROXY')) !== false && $value !== '')
+        ? $value
+        : null
+);
 
-define('ZMS_IDENTIFIER', getenv('ZMS_IDENTIFIER') ? getenv('ZMS_IDENTIFIER') : 'zms');
+define(
+    'ZMS_IDENTIFIER',
+    (($value = getenv('ZMS_IDENTIFIER')) !== false && $value !== '')
+        ? $value
+        : 'zms'
+);
 define('ZMS_MODULE_NAME', 'zmsmessaging');
 
 define('ZMS_MESSAGING_SMTP_ENABLED', getenv('ZMS_MESSAGING_SMTP_ENABLED') !== false);

--- a/zmsmessaging/config.example.php
+++ b/zmsmessaging/config.example.php
@@ -40,12 +40,12 @@ class App extends \BO\Zmsmessaging\Application
      */
     const string MODULE_NAME = ZMS_MODULE_NAME;
 
-    public static $httpUser = '_system_messenger';
+    public static string $httpUser = '_system_messenger';
 
-    public static $httpPassword = ZMS_API_PASSWORD_MESSAGING;
+    public static string $httpPassword = ZMS_API_PASSWORD_MESSAGING;
 
     // http curl options
-    public static $http_curl_config = array(
+    public static array $http_curl_config = array(
         CURLOPT_SSL_VERIFYPEER => false, // Internal certificates are self-signed
         CURLOPT_TIMEOUT => 10,
         CURLOPT_PROXY => ZMS_API_PROXY,
@@ -56,15 +56,15 @@ class App extends \BO\Zmsmessaging\Application
      * -----------------------------------------------------------------------
      * SMTP settings
      */
-    public static $smtp_enabled = ZMS_MESSAGING_SMTP_ENABLED;
-    public static $smtp_host = ZMS_MESSAGING_SMTP_HOST;
-    public static $smtp_port = ZMS_MESSAGING_SMTP_PORT;
-    public static $smtp_auth_enabled = ZMS_MESSAGING_SMTP_AUTH_ENABLED;
-    public static $smtp_auth_method = ZMS_MESSAGING_SMTP_AUTH_METHOD;
-    public static $smtp_username = ZMS_MESSAGING_SMTP_USERNAME;
-    public static $smtp_password = ZMS_MESSAGING_SMTP_PASSWORD;
-    public static $smtp_skip_tls_verify = ZMS_MESSAGING_SMTP_SKIP_TLS_VERIFY;
-    public static $smtp_debug = ZMS_MESSAGING_SMTP_DEBUG;
+    public static bool $smtp_enabled = ZMS_MESSAGING_SMTP_ENABLED;
+    public static mixed $smtp_host = ZMS_MESSAGING_SMTP_HOST;
+    public static mixed $smtp_port = ZMS_MESSAGING_SMTP_PORT;
+    public static bool $smtp_auth_enabled = ZMS_MESSAGING_SMTP_AUTH_ENABLED;
+    public static mixed $smtp_auth_method = ZMS_MESSAGING_SMTP_AUTH_METHOD;
+    public static mixed $smtp_username = ZMS_MESSAGING_SMTP_USERNAME;
+    public static mixed $smtp_password = ZMS_MESSAGING_SMTP_PASSWORD;
+    public static bool $smtp_skip_tls_verify = ZMS_MESSAGING_SMTP_SKIP_TLS_VERIFY;
+    public static mixed $smtp_debug = ZMS_MESSAGING_SMTP_DEBUG;
 }
 
 // uncomment for testing

--- a/zmsmessaging/src/Zmsmessaging/Application.php
+++ b/zmsmessaging/src/Zmsmessaging/Application.php
@@ -8,6 +8,8 @@
 
 namespace BO\Zmsmessaging;
 
+use BO\Zmsclient\Http;
+
 /**
  * @SuppressWarnings("TooManyFields")
  */
@@ -33,19 +35,19 @@ class Application extends \BO\Slim\Application
      * ZMS Messaging access
      */
 
-    public static $messaging = null;
+    public static mixed $messaging = null;
 
     /*
      * -----------------------------------------------------------------------
      * ZMS API access
      */
-    public static $http = null;
+    public static ?Http $http = null;
 
-    public static $httpUser = 'test';
+    public static string $httpUser = 'test';
 
-    public static $httpPassword = 'test';
+    public static string $httpPassword = 'test';
 
-    public static $http_curl_config = array();
+    public static array $http_curl_config = array();
 
     /**
      * config preferences
@@ -61,29 +63,29 @@ class Application extends \BO\Slim\Application
      * -----------------------------------------------------------------------
      * Mail settings
      */
-    public static $mails_per_minute = 300;
+    public static mixed $mails_per_minute = 300;
 
     /*
      * -----------------------------------------------------------------------
      * SMTP settings
      */
-    public static $smtp_enabled = false;
+    public static bool $smtp_enabled = false;
 
-    public static $smtp_host = null;
+    public static mixed $smtp_host = null;
 
-    public static $smtp_port = null;
+    public static mixed $smtp_port = null;
 
-    public static $smtp_auth_enabled = true;
+    public static bool $smtp_auth_enabled = true;
 
-    public static $smtp_auth_method = null;
+    public static mixed $smtp_auth_method = null;
 
-    public static $smtp_username = null;
+    public static mixed $smtp_username = null;
 
-    public static $smtp_password = null;
+    public static mixed $smtp_password = null;
 
-    public static $smtp_skip_tls_verify = false;
+    public static bool $smtp_skip_tls_verify = false;
 
-    public static $verify_dns_enabled = false;
+    public static bool $verify_dns_enabled = false;
 
-    public static $smtp_debug = false;
+    public static mixed $smtp_debug = false;
 }

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -12,6 +12,7 @@ use BO\Zmsentities\Mail;
 use BO\Zmsentities\Mimepart;
 use BO\Zmsentities\Schema\Entity;
 use BO\Mellon\Validator;
+use BO\Zmsclient\Http;
 
 class BaseController
 {
@@ -44,18 +45,36 @@ class BaseController
         return $time;
     }
 
+    protected function getNow(): \DateTimeInterface
+    {
+        $now = \App::$now;
+        if ($now instanceof \DateTimeInterface) {
+            return $now;
+        }
+        throw new \RuntimeException('Current time is not initialized');
+    }
+
+    protected function getHttp(): Http
+    {
+        $http = \App::$http;
+        if ($http instanceof Http) {
+            return $http;
+        }
+        throw new \RuntimeException('HTTP client is not initialized');
+    }
+
     protected function sendMailer(Entity $entity, mixed $mailer = null, mixed $action = false): mixed
     {
         // @codeCoverageIgnoreStart
         $hasSendSuccess = ($action) ? $mailer->Send() : $action;
         if (false !== $action && null !== $mailer && ! $hasSendSuccess) {
-            $this->log("Exception: SendingFailed  - " . \App::$now->format('c'));
+            $this->log("Exception: SendingFailed  - " . $this->getNow()->format('c'));
             throw new Exception\SendingFailed();
         }
         // @codeCoverageIgnoreEnd
         $log = new Mimepart(['mime' => 'text/plain']);
         $log['content'] = ($entity instanceof Mail) ? $entity['subject'] : $entity['message'];
-        \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log);
+        $this->getHttp()->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log);
         return $mailer;
     }
 
@@ -64,11 +83,11 @@ class BaseController
      */
     protected function removeEntityOlderThanOneHour(Mail $entity)
     {
-        if (3600 < \App::$now->getTimestamp() - $entity['createTimestamp']) {
+        if (3600 < $this->getNow()->getTimestamp() - $entity['createTimestamp']) {
             $this->deleteEntityFromQueue($entity);
             $log = new Mimepart(['mime' => 'text/plain']);
             $log['content'] = 'Zmsmessaging Failure: Queue entry older than 1 hour has been removed';
-            \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
+            $this->getHttp()->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
             \App::$log->warning($log['content']);
             return false;
         }
@@ -80,7 +99,7 @@ class BaseController
             return false;
         }
         try {
-            $entity = \App::$http
+            $entity = $this->getHttp()
                 ->readDeleteResult('/mails/' . $entity['id'] . '/')
                 ->getEntity();
         } catch (\BO\Zmsclient\Exception $exception) {

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -54,8 +54,8 @@ class BaseController
         }
         // @codeCoverageIgnoreEnd
         $log = new Mimepart(['mime' => 'text/plain']);
-        $log->content = ($entity instanceof Mail) ? $entity->subject : $entity->message;
-        \App::$http->readPostResult('/log/process/' . $entity->process['id'] . '/', $log);
+        $log->content = ($entity instanceof Mail) ? $entity['subject'] : $entity['message'];
+        \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log);
         return $mailer;
     }
 
@@ -64,11 +64,11 @@ class BaseController
      */
     protected function removeEntityOlderThanOneHour(Mail $entity)
     {
-        if (3600 < \App::$now->getTimestamp() - $entity->createTimestamp) {
+        if (3600 < \App::$now->getTimestamp() - $entity['createTimestamp']) {
             $this->deleteEntityFromQueue($entity);
             $log = new Mimepart(['mime' => 'text/plain']);
             $log->content = 'Zmsmessaging Failure: Queue entry older than 1 hour has been removed';
-            \App::$http->readPostResult('/log/process/' . $entity->process['id'] . '/', $log, ['error' => 1]);
+            \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
             \App::$log->warning($log->content);
             return false;
         }
@@ -81,7 +81,7 @@ class BaseController
         }
         try {
             $entity = \App::$http
-                ->readDeleteResult('/mails/' . $entity->id . '/')
+                ->readDeleteResult('/mails/' . $entity['id'] . '/')
                 ->getEntity();
         } catch (\BO\Zmsclient\Exception $exception) {
             throw $exception;

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -54,7 +54,7 @@ class BaseController
         }
         // @codeCoverageIgnoreEnd
         $log = new Mimepart(['mime' => 'text/plain']);
-        $log->content = ($entity instanceof Mail) ? $entity['subject'] : $entity['message'];
+        $log['content'] = ($entity instanceof Mail) ? $entity['subject'] : $entity['message'];
         \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log);
         return $mailer;
     }
@@ -67,9 +67,9 @@ class BaseController
         if (3600 < \App::$now->getTimestamp() - $entity['createTimestamp']) {
             $this->deleteEntityFromQueue($entity);
             $log = new Mimepart(['mime' => 'text/plain']);
-            $log->content = 'Zmsmessaging Failure: Queue entry older than 1 hour has been removed';
+            $log['content'] = 'Zmsmessaging Failure: Queue entry older than 1 hour has been removed';
             \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
-            \App::$log->warning($log->content);
+            \App::$log->warning($log['content']);
             return false;
         }
     }

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -21,7 +21,7 @@ class BaseController
     protected $startTime;
     protected $maxRunTime = 50;
 
-    public function __construct($verbose = false, $maxRunTime = 50)
+    public function __construct(mixed $verbose = false, mixed $maxRunTime = 50)
     {
         $this->verbose = $verbose;
         $this->startTime = microtime(true);
@@ -44,7 +44,7 @@ class BaseController
         return $time;
     }
 
-    protected function sendMailer(Entity $entity, $mailer = null, $action = false)
+    protected function sendMailer(Entity $entity, mixed $mailer = null, mixed $action = false)
     {
         // @codeCoverageIgnoreStart
         $hasSendSuccess = ($action) ? $mailer->Send() : $action;
@@ -183,7 +183,7 @@ class BaseController
         }
     }
 
-    protected function convertCollectionToArray($collection): array
+    protected function convertCollectionToArray(mixed $collection): array
     {
         $this->log("Converting collection to array");
         $array = [];

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -161,10 +161,10 @@ class BaseController
                         $errorOutput = stream_get_contents($handle['pipes'][2]);  // stderr
                         fclose($handle['pipes'][1]);
                         fclose($handle['pipes'][2]);
-                        if (trim($output)) {
+                        if (is_string($output) && trim($output)) {
                             $this->log("\nProcess stdout: " . trim($output) . "\n");
                         }
-                        if (trim($errorOutput)) {
+                        if (is_string($errorOutput) && trim($errorOutput)) {
                             $this->log("\nProcess stderr: " . trim($errorOutput) . "\n");
                         }
 

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -177,10 +177,6 @@ class BaseController
 
     public function log(string $message): void
     {
-        if (is_array($message)) {
-            $message = print_r($message, true);
-        }
-
         $time = $this->getSpendTime();
         $memory = memory_get_usage() / (1024 * 1024);
         static::$logList[] = $message;

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -28,7 +28,7 @@ class BaseController
         $this->maxRunTime = $maxRunTime;
     }
 
-    public static function getLogList()
+    public static function getLogList(): array
     {
         return static::$logList;
     }
@@ -44,7 +44,7 @@ class BaseController
         return $time;
     }
 
-    protected function sendMailer(Entity $entity, mixed $mailer = null, mixed $action = false)
+    protected function sendMailer(Entity $entity, mixed $mailer = null, mixed $action = false): mixed
     {
         // @codeCoverageIgnoreStart
         $hasSendSuccess = ($action) ? $mailer->Send() : $action;

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -95,9 +95,6 @@ class BaseController
 
     public function deleteEntityFromQueue(Mail $entity): bool
     {
-        if (!($entity instanceof Mail)) {
-            return false;
-        }
         try {
             $entity = $this->getHttp()
                 ->readDeleteResult('/mails/' . $entity['id'] . '/')
@@ -132,16 +129,14 @@ class BaseController
         if (! $entity->hasContent()) {
             throw new \BO\Zmsmessaging\Exception\MailWithoutContent();
         }
-        if ($entity instanceof Mail) {
-            $isMail = Validator::value($entity->getRecipient())->isMail()->getValue();
-            if (!$isMail) {
+        $isMail = Validator::value($entity->getRecipient())->isMail()->getValue();
+        if (!$isMail) {
+            throw new \BO\Zmsmessaging\Exception\InvalidMailAddress();
+        }
+        if (\App::$verify_dns_enabled) {
+            $hasDns = Validator::value($entity->getRecipient())->isMail()->hasDNS()->getValue();
+            if (!$hasDns) {
                 throw new \BO\Zmsmessaging\Exception\InvalidMailAddress();
-            }
-            if (\App::$verify_dns_enabled) {
-                $hasDns = Validator::value($entity->getRecipient())->isMail()->hasDNS()->getValue();
-                if (!$hasDns) {
-                    throw new \BO\Zmsmessaging\Exception\InvalidMailAddress();
-                }
             }
         }
     }

--- a/zmsmessaging/src/Zmsmessaging/BaseController.php
+++ b/zmsmessaging/src/Zmsmessaging/BaseController.php
@@ -15,11 +15,11 @@ use BO\Mellon\Validator;
 
 class BaseController
 {
-    protected $verbose = false;
-    protected static $logList = [];
-    protected $workstation = null;
-    protected $startTime;
-    protected $maxRunTime = 50;
+    protected mixed $verbose = false;
+    protected static array $logList = [];
+    protected mixed $workstation = null;
+    protected float $startTime;
+    protected mixed $maxRunTime = 50;
 
     public function __construct(mixed $verbose = false, mixed $maxRunTime = 50)
     {

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -75,7 +75,7 @@ class Mail extends BaseController
                     }
                 }
             } else {
-                $batchSize = min(count($this->messagesQueue), max(1, ceil(count($this->messagesQueue) / 12)));
+                $batchSize = min(count($this->messagesQueue), max(1, (int) ceil(count($this->messagesQueue) / 12)));
                 $this->log("More than 50 items, processing in batches of $batchSize.");
                 $batches = array_chunk(iterator_to_array($this->messagesQueue), $batchSize);
                 $this->log("Messages divided into " . count($batches) . " batches.");

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -222,7 +222,7 @@ class Mail extends BaseController
         return $results;
     }
 
-    protected function getValidMailer(MailEntity $entity)
+    protected function getValidMailer(MailEntity $entity): PHPMailer|false
     {
         $message = '';
         $messageId = $entity['id'];
@@ -346,7 +346,7 @@ class Mail extends BaseController
         }
     }
 
-    private function deleteEntitiesFromQueue(array $itemIds)
+    private function deleteEntitiesFromQueue(array $itemIds): mixed
     {
         $endpoint = '/mails/';
         $params = [

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -18,7 +18,7 @@ class Mail extends BaseController
     protected $messagesQueue = null;
     protected $startTime;
 
-    public function __construct($verbose = false, $maxRunTime = 50)
+    public function __construct(mixed $verbose = false, mixed $maxRunTime = 50)
     {
         parent::__construct($verbose, $maxRunTime);
         $this->log("Read Mail QueueList start with limit " . \App::$mails_per_minute . " - " . \App::$now->format('c'));
@@ -38,7 +38,7 @@ class Mail extends BaseController
      * @return (mixed|string[])[]
      *
      */
-    public function initQueueTransmission($action = false): array
+    public function initQueueTransmission(mixed $action = false): array
     {
         $resultList = [];
         if ($this->messagesQueue && count($this->messagesQueue)) {
@@ -119,7 +119,7 @@ class Mail extends BaseController
      * @return ((array|mixed|null|string)[]|string)[]
      *
      */
-    public function sendQueueItems($action, array $itemIds): array
+    public function sendQueueItems(mixed $action, array $itemIds): array
     {
         $endpoint = '/mails/';
         $params = [

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -249,7 +249,7 @@ class Mail extends BaseController
             }
 
             $log = new Mimepart(['mime' => 'text/plain']);
-            $log->content = $message;
+            $log['content'] = $message;
             $this->log("Build Mailer Exception log message: " . $message);
             \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
             return false;

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -301,7 +301,7 @@ class Mail extends BaseController
 
         if (null !== $entity->getIcsPart()) {
             $mailer->AddStringAttachment(
-                $icsPart,
+                $icsPart ?? '',
                 "Termin.ics",
                 $encoding,
                 "text/calendar; charset=utf-8; method=REQUEST"

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -148,7 +148,7 @@ class Mail extends BaseController
             $processId = $entity['process']['id'] ?? null;
             $mailer = $this->getValidMailer($entity);
             if (!$mailer) {
-                $this->log("No valid mailer for mail ID: " . $entity->id);
+                $this->log("No valid mailer for mail ID: " . $entity['id']);
                 continue;
             }
 
@@ -156,10 +156,10 @@ class Mail extends BaseController
                 $result = $this->sendMailer($entity, $mailer, $action);
                 if ($result instanceof PHPMailer) {
                     $mailResult = [
-                        'id' => ($result->getLastMessageID()) ? $result->getLastMessageID() : $entity->id,
-                        'mailId' => $entity->id,
+                        'id' => ($result->getLastMessageID()) ? $result->getLastMessageID() : $entity['id'],
+                        'mailId' => $entity['id'],
                         'processId' => $processId,
-                        'createTimestamp' => $entity->createTimestamp,
+                        'createTimestamp' => $entity['createTimestamp'],
                         'recipients' => $result->getAllRecipientAddresses(),
                         'mime' => $result->getMailMIME(),
                         'attachments' => $result->getAttachments(),
@@ -167,30 +167,30 @@ class Mail extends BaseController
                     ];
                     $results[] = $mailResult;
                     $processedMails[] = [
-                        'mailId' => $entity->id,
+                        'mailId' => $entity['id'],
                         'processId' => $processId,
-                        'createTimestamp' => $entity->createTimestamp,
+                        'createTimestamp' => $entity['createTimestamp'],
                     ];
                     \App::$log->info('Mail processed from queue', [
-                        'mailId' => $entity->id,
+                        'mailId' => $entity['id'],
                         'processId' => $processId,
-                        'createTimestamp' => $entity->createTimestamp,
+                        'createTimestamp' => $entity['createTimestamp'],
                     ]);
-                    $successfullySentIds[] = $entity->id;
+                    $successfullySentIds[] = $entity['id'];
                 } else {
                     $errorInfo = $result->ErrorInfo ?? 'Unknown mailer error';
                     $results[] = [
                         'errorInfo' => $errorInfo,
-                        'mailId' => $entity->id,
+                        'mailId' => $entity['id'],
                         'processId' => $processId,
                     ];
                     $this->log('Mail send failed with error: ' . $errorInfo);
                 }
             } catch (\Exception $e) {
-                $this->log("Exception while sending mail ID " . $entity->id . ": " . $e->getMessage());
+                $this->log("Exception while sending mail ID " . $entity['id'] . ": " . $e->getMessage());
                 $results[] = [
                     'errorInfo' => $e->getMessage(),
-                    'mailId' => $entity->id,
+                    'mailId' => $entity['id'],
                     'processId' => $processId,
                 ];
             }
@@ -251,7 +251,7 @@ class Mail extends BaseController
             $log = new Mimepart(['mime' => 'text/plain']);
             $log->content = $message;
             $this->log("Build Mailer Exception log message: " . $message);
-            \App::$http->readPostResult('/log/process/' . $entity->process['id'] . '/', $log, ['error' => 1]);
+            \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
             return false;
         }
 
@@ -267,7 +267,7 @@ class Mail extends BaseController
     {
         $this->testEntity($entity);
         $encoding = 'base64';
-        foreach ($entity->multipart as $part) {
+        foreach ($entity['multipart'] as $part) {
             $mimepart = new Mimepart($part);
             if ($mimepart->isText()) {
                 $textPart = $mimepart->getContent();
@@ -290,7 +290,7 @@ class Mail extends BaseController
         $mailer->AltBody = (isset($textPart)) ? $textPart : '';
         $mailer->Body = (isset($htmlPart)) ? $htmlPart : '';
         $mailer->SetFrom($entity['department']['email'], $entity['department']['name']);
-        $mailer->AddAddress($entity->getRecipient(), $entity->client['familyName']);
+        $mailer->AddAddress($entity->getRecipient(), $entity['client']['familyName']);
 
         if (null !== $entity->getIcsPart()) {
             $mailer->AddStringAttachment(

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -90,8 +90,12 @@ class Mail extends BaseController
                     $ids = array_map(function ($message): mixed {
                         return $message['id'];
                     }, $batch);
-                    $encodedIds = base64_encode(json_encode($ids));
-                    $actionStr = is_array($action) ? json_encode($action) : ($action === false ? 'false' : ($action === true ? 'true' : (string)$action));
+                    $idsJson = json_encode($ids);
+                    $encodedIds = base64_encode($idsJson === false ? '[]' : $idsJson);
+                    $actionJson = is_array($action) ? json_encode($action) : false;
+                    $actionStr = is_array($action)
+                        ? ($actionJson === false ? '[]' : $actionJson)
+                        : ($action === false ? 'false' : ($action === true ? 'true' : (string)$action));
 
                     $idsStr = implode(', ', $ids);
                     $command = "php " . escapeshellarg(__DIR__ . '/MailProcessor.php') . " " . escapeshellarg($encodedIds) . " " . escapeshellarg($actionStr);

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -20,8 +20,8 @@ class Mail extends BaseController
     public function __construct(mixed $verbose = false, mixed $maxRunTime = 50)
     {
         parent::__construct($verbose, $maxRunTime);
-        $this->log("Read Mail QueueList start with limit " . \App::$mails_per_minute . " - " . \App::$now->format('c'));
-        $queueList = \App::$http->readGetResult('/mails/', [
+        $this->log("Read Mail QueueList start with limit " . \App::$mails_per_minute . " - " . $this->getNow()->format('c'));
+        $queueList = $this->getHttp()->readGetResult('/mails/', [
             'resolveReferences' => 0,
             'limit' => \App::$mails_per_minute,
             'onlyIds' => true
@@ -29,7 +29,7 @@ class Mail extends BaseController
         if (null !== $queueList) {
             $this->messagesQueue = $queueList->sortByCustomKey('createTimestamp');
         } else {
-            $this->log("QueueList is null - " . \App::$now->format('c'));
+            $this->log("QueueList is null - " . $this->getNow()->format('c'));
         }
     }
 
@@ -42,7 +42,7 @@ class Mail extends BaseController
         $resultList = [];
         if ($this->messagesQueue && count($this->messagesQueue)) {
             if ($this->maxRunTime < $this->getSpendTime()) {
-                $this->log("Max Runtime exceeded before processing started - " . \App::$now->format('c'));
+                $this->log("Max Runtime exceeded before processing started - " . $this->getNow()->format('c'));
                 return $resultList;
             }
             $this->log("Messages queue count - " . count($this->messagesQueue));
@@ -52,7 +52,7 @@ class Mail extends BaseController
                 $itemIds = [];
                 foreach ($this->messagesQueue as $item) {
                     if ($this->maxRunTime < $this->getSpendTime()) {
-                        $this->log("Max Runtime exceeded during message loop - " . \App::$now->format('c'));
+                        $this->log("Max Runtime exceeded during message loop - " . $this->getNow()->format('c'));
                         break;
                     }
                     $itemIds[] = $item['id'];
@@ -83,7 +83,7 @@ class Mail extends BaseController
                 $processHandles = [];
                 foreach ($batches as $batch) {
                     if ($this->maxRunTime < $this->getSpendTime()) {
-                        $this->log("Max Runtime exceeded during batch processing - " . \App::$now->format('c'));
+                        $this->log("Max Runtime exceeded during batch processing - " . $this->getNow()->format('c'));
                         break;
                     }
 
@@ -101,7 +101,7 @@ class Mail extends BaseController
                 if ($this->maxRunTime >= $this->getSpendTime()) {
                     $this->monitorProcesses($processHandles);
                 } else {
-                    $this->log("Max Runtime exceeded before process monitoring started - " . \App::$now->format('c'));
+                    $this->log("Max Runtime exceeded before process monitoring started - " . $this->getNow()->format('c'));
                 }
             }
         } else {
@@ -127,7 +127,7 @@ class Mail extends BaseController
         ];
 
         try {
-            $response = \App::$http->readGetResult($endpoint, $params);
+            $response = $this->getHttp()->readGetResult($endpoint, $params);
             $mailItems = $response->getCollection();
         } catch (\Exception $e) {
             $this->log("Error fetching mail data: " . $e->getMessage() . "\n\n");
@@ -239,11 +239,11 @@ class Mail extends BaseController
         }
         if ($message) {
             if (428 == $code || 422 == $code) {
-                $this->log("Build Mailer Failure " . $code . ": deleteEntityFromQueue() - " . \App::$now->format('c'));
+                $this->log("Build Mailer Failure " . $code . ": deleteEntityFromQueue() - " . $this->getNow()->format('c'));
                 $this->deleteEntityFromQueue($entity);
             } else {
                 $this->log(
-                    "Build Mailer Failure " . $code . ": removeEntityOlderThanOneHour() - " . \App::$now->format('c')
+                    "Build Mailer Failure " . $code . ": removeEntityOlderThanOneHour() - " . $this->getNow()->format('c')
                 );
                 $this->removeEntityOlderThanOneHour($entity);
             }
@@ -251,7 +251,7 @@ class Mail extends BaseController
             $log = new Mimepart(['mime' => 'text/plain']);
             $log['content'] = $message;
             $this->log("Build Mailer Exception log message: " . $message);
-            \App::$http->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
+            $this->getHttp()->readPostResult('/log/process/' . $entity['process']['id'] . '/', $log, ['error' => 1]);
             return false;
         }
 
@@ -353,7 +353,7 @@ class Mail extends BaseController
         ];
 
         try {
-            $response = \App::$http->readDeleteResult($endpoint, $params);
+            $response = $this->getHttp()->readDeleteResult($endpoint, $params);
             return $response;
         } catch (\Exception $e) {
             $this->log("Error deleting mail data: " . $e->getMessage() . "\n\n");

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -88,7 +88,7 @@ class Mail extends BaseController
                         break;
                     }
 
-                    $ids = array_map(function ($message) {
+                    $ids = array_map(function ($message): mixed {
                         return $message['id'];
                     }, $batch);
                     $encodedIds = base64_encode(json_encode($ids));

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -15,8 +15,7 @@ use PHPMailer\PHPMailer\Exception as PHPMailerException;
 
 class Mail extends BaseController
 {
-    protected $messagesQueue = null;
-    protected $startTime;
+    protected mixed $messagesQueue = null;
 
     public function __construct(mixed $verbose = false, mixed $maxRunTime = 50)
     {

--- a/zmsmessaging/src/Zmsmessaging/Mail.php
+++ b/zmsmessaging/src/Zmsmessaging/Mail.php
@@ -229,6 +229,8 @@ class Mail extends BaseController
     {
         $message = '';
         $messageId = $entity['id'];
+        $code = 0;
+        $mailer = false;
         try {
             $mailer = $this->readMailer($entity);
         // @codeCoverageIgnoreStart
@@ -271,6 +273,7 @@ class Mail extends BaseController
     {
         $this->testEntity($entity);
         $encoding = 'base64';
+        $icsPart = null;
         foreach ($entity['multipart'] as $part) {
             $mimepart = new Mimepart($part);
             if ($mimepart->isText()) {

--- a/zmsmessaging/src/Zmsmessaging/MailProcessor.php
+++ b/zmsmessaging/src/Zmsmessaging/MailProcessor.php
@@ -15,7 +15,7 @@ require __DIR__ . '/../../bootstrap.php';
 
 class MailProcessor extends Mail
 {
-    public function __construct($verbose = false, $maxRunTime = 50)
+    public function __construct(mixed $verbose = false, mixed $maxRunTime = 50)
     {
         parent::__construct($verbose, $maxRunTime);
     }

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -25,7 +25,7 @@ abstract class Base extends TestCase
      */
     use ProphecyTrait;
 
-    protected $apiCalls = array();
+    protected mixed $apiCalls = array();
 
     public function setUp(): void
     {

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -37,7 +37,7 @@ abstract class Base extends TestCase
     {
     }
 
-    protected function getApiMockup(): object
+    protected function getApiMockup(): Http
     {
         $mock = $this->prophesize(Http::class);
         foreach ($this->getApiCalls() as $options) {

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -95,6 +95,10 @@ abstract class Base extends TestCase
         return $this->apiCalls;
     }
 
+    abstract protected function getResponse(mixed $content = '', mixed $status = 200): mixed;
+
+    abstract protected function getRequest(mixed $method = "GET", mixed $uri = ''): mixed;
+
     public function setApiCalls(mixed $apiCalls): void
     {
         $this->apiCalls = $apiCalls;

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -67,7 +67,7 @@ abstract class Base extends TestCase
             } else {
                 $function = $mock->__call(
                     $function,
-                    $parameters
+                    $parameters ?? []
                 );
             }
             if (isset($options['exception'])) {

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -90,7 +90,7 @@ abstract class Base extends TestCase
     /**
      * Overwrite this function if api calls definition needs function calls
      */
-    protected function getApiCalls()
+    protected function getApiCalls(): mixed
     {
         return $this->apiCalls;
     }

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -95,7 +95,7 @@ abstract class Base extends TestCase
         return $this->apiCalls;
     }
 
-    public function setApiCalls($apiCalls): void
+    public function setApiCalls(mixed $apiCalls): void
     {
         $this->apiCalls = $apiCalls;
         \App::$http = $this->getApiMockup();

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -4,6 +4,7 @@ namespace BO\Zmsmessaging\PhpUnit;
 
 use BO\Zmsentities\Schema\Entity;
 use BO\Zmsentities\Collection\Base as BaseCollection;
+use BO\Zmsclient\Http;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Argument;
@@ -38,7 +39,7 @@ abstract class Base extends TestCase
 
     protected function getApiMockup(): object
     {
-        $mock = $this->prophesize('BO\Zmsclient\Http');
+        $mock = $this->prophesize(Http::class);
         foreach ($this->getApiCalls() as $options) {
             $parameters = isset($options['parameters']) ? $options['parameters'] : null;
             $function = $options['function'];

--- a/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
+++ b/zmsmessaging/src/Zmsmessaging/PhpUnit/Base.php
@@ -55,7 +55,7 @@ abstract class Base extends TestCase
                     $function,
                     [
                         $options['url'],
-                        Argument::that(function ($value) {
+                        Argument::that(function (mixed $value) {
                             return
                                 ($value instanceof Entity) ||
                                 ($value instanceof BaseCollection);

--- a/zmsmessaging/tests/Zmsmessaging/Base.php
+++ b/zmsmessaging/tests/Zmsmessaging/Base.php
@@ -6,7 +6,7 @@ abstract class Base extends \BO\Zmsmessaging\PhpUnit\Base
 {
     protected $namespace = '\\BO\\Zmsmessaging\\';
 
-    protected function getResponse($content = '', $status = 200)
+    protected function getResponse(mixed $content = '', mixed $status = 200): mixed
     {
         $response = new \BO\Zmsclient\Psr7\Response();
         $response->withStatus($status);
@@ -14,7 +14,7 @@ abstract class Base extends \BO\Zmsmessaging\PhpUnit\Base
         return $response;
     }
 
-    protected function getRequest($method = "GET", $uri = '')
+    protected function getRequest(mixed $method = "GET", mixed $uri = ''): mixed
     {
         $request = new \BO\Zmsclient\Psr7\Request($method, new \BO\Zmsclient\Psr7\Uri($uri));
         return $request;

--- a/zmsmessaging/tests/Zmsmessaging/DeleteFromQueueTest.php
+++ b/zmsmessaging/tests/Zmsmessaging/DeleteFromQueueTest.php
@@ -4,7 +4,7 @@ namespace BO\Zmsmessaging\Tests;
 
 class DeleteFromQueueTest extends Base
 {
-    protected function getApiCalls()
+    protected function getApiCalls(): mixed
     {
         return [
             [

--- a/zmsmessaging/tests/Zmsmessaging/DeleteMailsFailedTest.php
+++ b/zmsmessaging/tests/Zmsmessaging/DeleteMailsFailedTest.php
@@ -6,7 +6,7 @@ use \BO\Mellon\Validator;
 
 class DeleteMailsFailedTest extends Base
 {
-    protected function getApiCalls()
+    protected function getApiCalls(): mixed
     {
         return [
             [


### PR DESCRIPTION
## Summary
- Clear all zmsmessaging Psalm notes (`errorLevel` 7, `--show-info=true`) one issue type per commit.
- Keep runtime the same: wide `mixed` types where config/env values vary; Mail/Mimepart fields use array access instead of waiting on zmsentities `@property` docs.

## Test plan
- [ ] Psalm: `php vendor/bin/psalm --no-progress --no-cache --show-info=true` in `zmsmessaging` (0 notes)
- [ ] PHPUnit: `XDEBUG_MODE=off php vendor/bin/phpunit --no-coverage` in `zmsmessaging`
- [ ] Copy typed properties from `config.example.php` into local `config.php` before running tests