### PR TITLE
fix(GH): bump react/http to 1.11.1 for Trivy CVE-2026-84997

### DIFF
--- a/zmsmessaging/composer.lock
+++ b/zmsmessaging/composer.lock
@@ -3168,16 +3168,16 @@
         },
         {
             "name": "react/http",
-            "version": "v1.11.0",
+            "version": "v1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/http.git",
-                "reference": "8db02de41dcca82037367f67a2d4be365b1c4db9"
+                "reference": "e5b8eb2654dec6cbbc692a39f05ea4ecd40c8cc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http/zipball/8db02de41dcca82037367f67a2d4be365b1c4db9",
-                "reference": "8db02de41dcca82037367f67a2d4be365b1c4db9",
+                "url": "https://api.github.com/repos/reactphp/http/zipball/e5b8eb2654dec6cbbc692a39f05ea4ecd40c8cc1",
+                "reference": "e5b8eb2654dec6cbbc692a39f05ea4ecd40c8cc1",
                 "shasum": ""
             },
             "require": {
@@ -3194,7 +3194,7 @@
                 "clue/http-proxy-react": "^1.8",
                 "clue/reactphp-ssh-proxy": "^1.4",
                 "clue/socks-react": "^1.4",
-                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
                 "react/async": "^4.2 || ^3 || ^2",
                 "react/promise-stream": "^1.4",
                 "react/promise-timer": "^1.11"
@@ -3247,7 +3247,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/http/issues",
-                "source": "https://github.com/reactphp/http/tree/v1.11.0"
+                "source": "https://github.com/reactphp/http/tree/v1.11.1"
             },
             "funding": [
                 {
@@ -3255,7 +3255,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-11-20T15:24:08+00:00"
+            "time": "2026-09-09T07:08:28+00:00"
         },
         {
             "name": "react/promise",


### PR DESCRIPTION
## Summary
- Bump `react/http` in `zmsmessaging` from v1.11.0 to v1.11.1 so the PR/push Trivy check on `next` stops failing on [CVE-2026-84997](https://github.com/reactphp/http/security/advisories/GHSA-x424-64qh-5j54) (malformed HTTP chunked body).
- Constraint was already `^1.10`; this is a lockfile-only security pin ([reactphp/http v1.11.1](https://github.com/reactphp/http/releases/tag/v1.11.1)).

## Test plan
- [ ] PR Trivy check is green
- [ ] After merge, a `next` push Trivy run no longer reports `react/http` CVE-2026-84997