### PR TITLE
fix(ZMSKVR-1573): align XLSX processing-time rounding with UI

### DIFF
--- a/zmsstatistic/src/Zmsstatistic/Helper/ReportHelper.php
+++ b/zmsstatistic/src/Zmsstatistic/Helper/ReportHelper.php
@@ -110,18 +110,21 @@ class ReportHelper
         return $entity;
     }
 
+    /**
+     * Format minutes as mm:ss, rounding the full duration to the nearest second.
+     * Same rule as the Twig formatMinutesToTime macro.
+     */
     public static function formatTimeValue(mixed $value): mixed
     {
         if (!is_numeric($value)) {
             return $value;
         }
-        $minutes = floor((float) $value);
-        $seconds = round(($value - $minutes) * 60);
-        if ($seconds >= 60) {
-            $minutes += 1;
-            $seconds = 0;
+        $totalSeconds = (int) round((float) $value * 60);
+        if ($totalSeconds <= 0) {
+            return '00:00';
         }
-        return sprintf('%02d:%02d', $minutes, $seconds);
+
+        return sprintf('%02d:%02d', intdiv($totalSeconds, 60), $totalSeconds % 60);
     }
 
     /**

--- a/zmsstatistic/tests/Zmsstatistic/HelperSnippetsTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/HelperSnippetsTest.php
@@ -2,26 +2,41 @@
 
 namespace BO\Zmsstatistic\Tests;
 
+use BO\Zmsstatistic\Helper\ReportHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class HelperSnippetsTest extends \PHPUnit\Framework\TestCase
 {
     public function testFormatMinutesToTimeRoundsToNearestSecond(): void
     {
-        $loader = new \Twig\Loader\FilesystemLoader(dirname(__DIR__, 2) . '/templates');
-        $twig = new \Twig\Environment($loader);
-        $twig->addExtension(
-            new \Symfony\Bridge\Twig\Extension\TranslationExtension(
-                new \Symfony\Component\Translation\Translator('de')
-            )
-        );
-        $template = $twig->createTemplate(
-            "{% import 'element/helper/snippets.twig' as timeutils %}"
-            . '{{ timeutils.formatMinutesToTime(1.11) }}'
-        );
-
-        $this->assertSame('1:07', trim($template->render()));
+        $this->assertSame('1:07', $this->renderFormatMinutesToTime(1.11));
     }
 
     public function testFormatMinutesToTimeRoundsUnroundedOverallAverageOnce(): void
+    {
+        // (1:02 + 2:12 + 0:32) / 3 = 75.33s → 1:15, not 1:16 from rounding minutes first
+        $this->assertSame('1:15', $this->renderFormatMinutesToTime((62 + 132 + 32) / 3 / 60));
+    }
+
+    #[DataProvider('sharedRoundingValues')]
+    public function testUiAndXlsxRoundTheSameSecond(float $minutes, string $ui, string $xlsx): void
+    {
+        $this->assertSame($ui, $this->renderFormatMinutesToTime($minutes));
+        $this->assertSame($xlsx, ReportHelper::formatTimeValue($minutes));
+    }
+
+    public static function sharedRoundingValues(): array
+    {
+        return [
+            'nearest second' => [1.11, '1:07', '01:07'],
+            // 3.425 min = 205.5s; leftover-seconds rounding used to yield 3:25 in XLSX
+            'half-second float trap' => [3.425, '3:26', '03:26'],
+            'unrounded overall average' => [(62 + 132 + 32) / 3 / 60, '1:15', '01:15'],
+            'zero' => [0.0, '0:00', '00:00'],
+        ];
+    }
+
+    private function renderFormatMinutesToTime(float $minutes): string
     {
         $loader = new \Twig\Loader\FilesystemLoader(dirname(__DIR__, 2) . '/templates');
         $twig = new \Twig\Environment($loader);
@@ -35,7 +50,6 @@ class HelperSnippetsTest extends \PHPUnit\Framework\TestCase
             . '{{ timeutils.formatMinutesToTime(minutes) }}'
         );
 
-        // (1:02 + 2:12 + 0:32) / 3 = 75.33s → 1:15, not 1:16 from rounding minutes first
-        $this->assertSame('1:15', trim($template->render(['minutes' => (62 + 132 + 32) / 3 / 60])));
+        return trim($template->render(['minutes' => $minutes]));
     }
 }

--- a/zmsstatistic/tests/Zmsstatistic/ReportHelperFormatTimeValueTest.php
+++ b/zmsstatistic/tests/Zmsstatistic/ReportHelperFormatTimeValueTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BO\Zmsstatistic\Tests;
+
+use BO\Zmsstatistic\Helper\ReportHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ReportHelperFormatTimeValueTest extends \PHPUnit\Framework\TestCase
+{
+    #[DataProvider('timeValueProvider')]
+    public function testFormatTimeValue(mixed $value, mixed $expected): void
+    {
+        $this->assertSame($expected, ReportHelper::formatTimeValue($value));
+    }
+
+    public static function timeValueProvider(): array
+    {
+        return [
+            'non-numeric passthrough' => ['-', '-'],
+            'zero' => [0, '00:00'],
+            'nearest second' => [1.11, '01:07'],
+            'half-second float trap' => [3.425, '03:26'],
+            'unrounded overall average' => [(62 + 132 + 32) / 3 / 60, '01:15'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- XLSX Bearbeitungsdauer sometimes differed from the UI by 1 second because `formatTimeValue` floored whole minutes, then rounded leftover seconds.
- Twig already rounded the full duration to the nearest second; Excel now uses that same rule.
- Adds regression tests for the float `.5` case (`3.425` min → `3:26`) so UI and XLSX stay in sync.

## Test plan
- [ ] Open Dienstleistungsstatistik for a range that previously mismatched (e.g. Wohnsitzanmeldung).
- [ ] Confirm Ø Bearbeitungsdauer in the table matches the XLSX download for every service, including the overall footer.
- [ ] Download XLSX and spot-check values that sit near a half-second boundary.
- [ ] `podman exec zms-web bash -lc 'export XDEBUG_MODE=off; cd /var/www/html/zmsstatistic && ./vendor/bin/phpunit --no-coverage'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Time values now round consistently to the nearest second across UI and spreadsheet reports.
  - Non-positive values display as `00:00`.
  - Non-numeric inputs remain unchanged.

- **Tests**
  - Added coverage for rounding, zero values, fractional-second edge cases, averages, and non-numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->